### PR TITLE
Optimize expression mapping

### DIFF
--- a/src/binder/aggregate.rs
+++ b/src/binder/aggregate.rs
@@ -22,7 +22,7 @@ impl<'a, T: Transaction> Binder<'a, T> {
     ) -> LogicalPlan {
         self.context.step(QueryBindStep::Agg);
 
-        AggregateOperator::build(children, agg_calls, groupby_exprs)
+        AggregateOperator::build(children, agg_calls, groupby_exprs, false)
     }
 
     pub fn extract_select_aggregate(
@@ -137,6 +137,7 @@ impl<'a, T: Transaction> Binder<'a, T> {
             }
             ScalarExpression::Constant(_) | ScalarExpression::ColumnRef { .. } => (),
             ScalarExpression::Empty => unreachable!(),
+            ScalarExpression::Reference { .. } => unreachable!(),
         }
 
         Ok(())
@@ -310,6 +311,7 @@ impl<'a, T: Transaction> Binder<'a, T> {
             }
             ScalarExpression::Constant(_) => Ok(()),
             ScalarExpression::Empty => unreachable!(),
+            ScalarExpression::Reference { .. } => unreachable!(),
         }
     }
 }

--- a/src/binder/distinct.rs
+++ b/src/binder/distinct.rs
@@ -12,6 +12,6 @@ impl<'a, T: Transaction> Binder<'a, T> {
     ) -> LogicalPlan {
         self.context.step(QueryBindStep::Distinct);
 
-        AggregateOperator::build(children, vec![], select_list)
+        AggregateOperator::build(children, vec![], select_list, true)
     }
 }

--- a/src/catalog/table.rs
+++ b/src/catalog/table.rs
@@ -120,6 +120,7 @@ impl TableCatalog {
         let index = IndexMeta {
             id: index_id,
             column_ids,
+            table_name: self.name.clone(),
             name,
             is_unique,
             is_primary,

--- a/src/db.rs
+++ b/src/db.rs
@@ -172,6 +172,11 @@ impl<S: Storage> Database<S> {
                     NormalizationRuleImpl::EliminateLimits,
                 ],
             )
+            .batch(
+                "Expression Remapper".to_string(),
+                HepBatchStrategy::once_topdown(),
+                vec![NormalizationRuleImpl::ExpressionRemapper],
+            )
             .implementations(vec![
                 // DQL
                 ImplementationRuleImpl::SimpleAggregate,

--- a/src/execution/volcano/dql/aggregate/hash_agg.rs
+++ b/src/execution/volcano/dql/aggregate/hash_agg.rs
@@ -26,6 +26,7 @@ impl From<(AggregateOperator, LogicalPlan)> for HashAggExecutor {
             AggregateOperator {
                 agg_calls,
                 groupby_exprs,
+                ..
             },
             input,
         ): (AggregateOperator, LogicalPlan),
@@ -197,6 +198,7 @@ mod test {
                 args: vec![ScalarExpression::ColumnRef(t1_columns[1].clone())],
                 ty: LogicalType::Integer,
             }],
+            is_distinct: false,
         };
 
         let input = LogicalPlan {

--- a/src/execution/volcano/dql/join/hash_join.rs
+++ b/src/execution/volcano/dql/join/hash_join.rs
@@ -23,7 +23,7 @@ pub struct HashJoin {
 
 impl From<(JoinOperator, LogicalPlan, LogicalPlan)> for HashJoin {
     fn from(
-        (JoinOperator { on, join_type }, left_input, right_input): (
+        (JoinOperator { on, join_type, .. }, left_input, right_input): (
             JoinOperator,
             LogicalPlan,
             LogicalPlan,
@@ -180,7 +180,7 @@ impl HashJoinStatus {
             &filter,
             join_tuples.is_empty() || matches!(ty, JoinType::Full | JoinType::Cross),
         ) {
-            let mut filter_tuples = Vec::with_capacity(join_tuples.len());
+            let mut filter_tuples = Vec::new();
 
             for mut tuple in join_tuples {
                 if let DataValue::Boolean(option) = expr.eval(&tuple)?.as_ref() {

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -80,7 +80,6 @@ pub enum ScalarExpression {
     Reference {
         expr: Box<ScalarExpression>,
         pos: usize,
-        ty: LogicalType,
     },
 }
 
@@ -105,9 +104,8 @@ impl ScalarExpression {
             .iter()
             .find_position(|expr| self.output_name() == expr.output_name())
         {
-            let ty = self.return_type();
             let expr = Box::new(mem::replace(self, ScalarExpression::Empty));
-            *self = ScalarExpression::Reference { expr, pos, ty };
+            *self = ScalarExpression::Reference { expr, pos };
             return;
         }
 
@@ -209,9 +207,10 @@ impl ScalarExpression {
                 LogicalType::Boolean
             }
             Self::SubString { .. } => LogicalType::Varchar(None),
-            Self::Alias { expr, .. } => expr.return_type(),
+            Self::Alias { expr, .. } | ScalarExpression::Reference { expr, .. } => {
+                expr.return_type()
+            }
             ScalarExpression::Empty => unreachable!(),
-            ScalarExpression::Reference { ty, .. } => *ty,
         }
     }
 

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
+use std::{fmt, mem};
 
 use sqlparser::ast::{BinaryOperator as SqlBinaryOperator, UnaryOperator as SqlUnaryOperator};
 
@@ -77,6 +77,11 @@ pub enum ScalarExpression {
     },
     // Temporary expression used for expression substitution
     Empty,
+    Reference {
+        expr: Box<ScalarExpression>,
+        pos: usize,
+        ty: LogicalType,
+    },
 }
 
 impl ScalarExpression {
@@ -85,6 +90,86 @@ impl ScalarExpression {
             expr.unpack_alias()
         } else {
             self
+        }
+    }
+    pub fn unpack_reference(&self) -> &ScalarExpression {
+        if let ScalarExpression::Reference { expr, .. } = self {
+            expr.unpack_reference()
+        } else {
+            self
+        }
+    }
+
+    pub fn try_reference(&mut self, output_exprs: &[ScalarExpression]) {
+        if let Some((pos, _)) = output_exprs
+            .iter()
+            .find_position(|expr| self.output_name() == expr.output_name())
+        {
+            let ty = self.return_type();
+            let expr = Box::new(mem::replace(self, ScalarExpression::Empty));
+            *self = ScalarExpression::Reference { expr, pos, ty };
+            return;
+        }
+
+        match self {
+            ScalarExpression::Alias { expr, .. } => {
+                expr.try_reference(output_exprs);
+            }
+            ScalarExpression::TypeCast { expr, .. } => {
+                expr.try_reference(output_exprs);
+            }
+            ScalarExpression::IsNull { expr, .. } => {
+                expr.try_reference(output_exprs);
+            }
+            ScalarExpression::Unary { expr, .. } => {
+                expr.try_reference(output_exprs);
+            }
+            ScalarExpression::Binary {
+                left_expr,
+                right_expr,
+                ..
+            } => {
+                left_expr.try_reference(output_exprs);
+                right_expr.try_reference(output_exprs);
+            }
+            ScalarExpression::AggCall { args, .. } => {
+                for arg in args {
+                    arg.try_reference(output_exprs);
+                }
+            }
+            ScalarExpression::In { expr, args, .. } => {
+                expr.try_reference(output_exprs);
+                for arg in args {
+                    arg.try_reference(output_exprs);
+                }
+            }
+            ScalarExpression::Between {
+                expr,
+                left_expr,
+                right_expr,
+                ..
+            } => {
+                expr.try_reference(output_exprs);
+                left_expr.try_reference(output_exprs);
+                right_expr.try_reference(output_exprs);
+            }
+            ScalarExpression::SubString {
+                expr,
+                for_expr,
+                from_expr,
+            } => {
+                expr.try_reference(output_exprs);
+                if let Some(expr) = for_expr {
+                    expr.try_reference(output_exprs);
+                }
+                if let Some(expr) = from_expr {
+                    expr.try_reference(output_exprs);
+                }
+            }
+            ScalarExpression::Empty => unreachable!(),
+            ScalarExpression::Constant(_)
+            | ScalarExpression::ColumnRef(_)
+            | ScalarExpression::Reference { .. } => (),
         }
     }
 
@@ -126,6 +211,7 @@ impl ScalarExpression {
             Self::SubString { .. } => LogicalType::Varchar(None),
             Self::Alias { expr, .. } => expr.return_type(),
             ScalarExpression::Empty => unreachable!(),
+            ScalarExpression::Reference { ty, .. } => *ty,
         }
     }
 
@@ -193,7 +279,8 @@ impl ScalarExpression {
                         columns_collect(from_expr, vec, only_column_ref);
                     }
                 }
-                ScalarExpression::Constant(_) | ScalarExpression::Empty => (),
+                ScalarExpression::Constant(_) => (),
+                ScalarExpression::Reference { .. } | ScalarExpression::Empty => unreachable!(),
             }
         }
         let mut exprs = Vec::new();
@@ -241,7 +328,7 @@ impl ScalarExpression {
                         Some(true)
                     )
             }
-            ScalarExpression::Empty => unreachable!(),
+            ScalarExpression::Reference { .. } | ScalarExpression::Empty => unreachable!(),
         }
     }
 
@@ -261,7 +348,7 @@ impl ScalarExpression {
                 }
             },
             ScalarExpression::TypeCast { expr, ty } => {
-                format!("CAST({} as {})", expr.output_name(), ty)
+                format!("cast ({} as {})", expr.output_name(), ty)
             }
             ScalarExpression::IsNull { expr, negated } => {
                 let suffix = if *negated { "is not null" } else { "is null" };
@@ -289,7 +376,7 @@ impl ScalarExpression {
                 let args_str = args.iter().map(|expr| expr.output_name()).join(", ");
                 let op = |allow_distinct, distinct| {
                     if allow_distinct && distinct {
-                        "DISTINCT "
+                        "distinct "
                     } else {
                         ""
                     }
@@ -344,6 +431,7 @@ impl ScalarExpression {
                     op("for", for_expr),
                 )
             }
+            ScalarExpression::Reference { expr, .. } => expr.output_name(),
             ScalarExpression::Empty => unreachable!(),
         }
     }

--- a/src/expression/simplify.rs
+++ b/src/expression/simplify.rs
@@ -411,7 +411,9 @@ struct ReplaceUnary {
 impl ScalarExpression {
     pub fn exist_column(&self, table_name: &str, col_id: &ColumnId) -> bool {
         match self {
-            ScalarExpression::ColumnRef(col) => Self::_is_belong(table_name, col) && col.id() == Some(*col_id),
+            ScalarExpression::ColumnRef(col) => {
+                Self::_is_belong(table_name, col) && col.id() == Some(*col_id)
+            }
             ScalarExpression::Alias { expr, .. } => expr.exist_column(table_name, col_id),
             ScalarExpression::TypeCast { expr, .. } => expr.exist_column(table_name, col_id),
             ScalarExpression::IsNull { expr, .. } => expr.exist_column(table_name, col_id),
@@ -458,7 +460,8 @@ impl ScalarExpression {
                         .map(|expr| expr.exist_column(table_name, col_id))
                         == Some(true)
             }
-            ScalarExpression::Constant(_) | ScalarExpression::Empty => false,
+            ScalarExpression::Constant(_) => false,
+            ScalarExpression::Reference { .. } | ScalarExpression::Empty => unreachable!(),
         }
     }
 
@@ -988,12 +991,12 @@ impl ScalarExpression {
                 | ScalarExpression::In { .. }
                 | ScalarExpression::Between { .. }
                 | ScalarExpression::SubString { .. } => expr.convert_binary(table_name, id),
-                ScalarExpression::Empty => unreachable!(),
+                ScalarExpression::Reference { .. } | ScalarExpression::Empty => unreachable!(),
             },
             ScalarExpression::Constant(_)
             | ScalarExpression::ColumnRef(_)
             | ScalarExpression::AggCall { .. } => Ok(None),
-            ScalarExpression::Empty => unreachable!(),
+            ScalarExpression::Reference { .. } | ScalarExpression::Empty => unreachable!(),
         }
     }
 

--- a/src/optimizer/heuristic/graph.rs
+++ b/src/optimizer/heuristic/graph.rs
@@ -182,6 +182,13 @@ impl HepGraph {
             .map(|edge| edge.target())
     }
 
+    pub fn youngest_child_at(&self, id: HepNodeId) -> Option<HepNodeId> {
+        self.graph
+            .edges(id)
+            .max_by_key(|edge| edge.weight())
+            .map(|edge| edge.target())
+    }
+
     pub fn into_plan(mut self, memo: Option<&Memo>) -> Option<LogicalPlan> {
         self.build_childrens(self.root_index, memo)
     }

--- a/src/optimizer/rule/normalization/expression_remapper.rs
+++ b/src/optimizer/rule/normalization/expression_remapper.rs
@@ -1,0 +1,119 @@
+use crate::errors::DatabaseError;
+use crate::expression::ScalarExpression;
+use crate::optimizer::core::pattern::{Pattern, PatternChildrenPredicate};
+use crate::optimizer::core::rule::{MatchPattern, NormalizationRule};
+use crate::optimizer::heuristic::graph::{HepGraph, HepNodeId};
+use crate::planner::operator::join::JoinCondition;
+use crate::planner::operator::Operator;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref EXPRESSION_REMAPPER_RULE: Pattern = {
+        Pattern {
+            predicate: |_| true,
+            children: PatternChildrenPredicate::None,
+        }
+    };
+}
+
+#[derive(Clone)]
+pub struct ExpressionRemapper;
+
+impl ExpressionRemapper {
+    fn _apply(
+        output_exprs: &mut Vec<ScalarExpression>,
+        node_id: HepNodeId,
+        graph: &mut HepGraph,
+    ) -> Result<(), DatabaseError> {
+        if let Some(child_id) = graph.eldest_child_at(node_id) {
+            Self::_apply(output_exprs, child_id, graph)?;
+        }
+        // for join
+        let mut left_len = 0;
+        if let Operator::Join(_) = graph.operator(node_id) {
+            let mut second_output_exprs = Vec::new();
+            if let Some(child_id) = graph.youngest_child_at(node_id) {
+                Self::_apply(&mut second_output_exprs, child_id, graph)?;
+            }
+            left_len = output_exprs.len();
+            output_exprs.append(&mut second_output_exprs);
+        }
+        let operator = graph.operator_mut(node_id);
+
+        match operator {
+            Operator::Join(op) => {
+                match &mut op.on {
+                    JoinCondition::On { on, filter } => {
+                        for (left_expr, right_expr) in on {
+                            left_expr.try_reference(&output_exprs[0..left_len]);
+                            right_expr.try_reference(&output_exprs[left_len..]);
+                        }
+                        if let Some(expr) = filter {
+                            expr.try_reference(output_exprs);
+                        }
+                    }
+                    JoinCondition::None => {}
+                }
+
+                return Ok(());
+            }
+            Operator::Aggregate(op) => {
+                for expr in op.agg_calls.iter_mut().chain(op.groupby_exprs.iter_mut()) {
+                    expr.try_reference(output_exprs);
+                }
+            }
+            Operator::Filter(op) => {
+                op.predicate.try_reference(output_exprs);
+            }
+            Operator::Project(op) => {
+                for expr in op.exprs.iter_mut() {
+                    expr.try_reference(output_exprs);
+                }
+            }
+            Operator::Sort(op) => {
+                for sort_field in op.sort_fields.iter_mut() {
+                    sort_field.expr.try_reference(output_exprs);
+                }
+            }
+            Operator::Dummy
+            | Operator::Scan(_)
+            | Operator::Limit(_)
+            | Operator::Values(_)
+            | Operator::Show
+            | Operator::Explain
+            | Operator::Describe(_)
+            | Operator::Insert(_)
+            | Operator::Update(_)
+            | Operator::Delete(_)
+            | Operator::Analyze(_)
+            | Operator::AddColumn(_)
+            | Operator::DropColumn(_)
+            | Operator::CreateTable(_)
+            | Operator::DropTable(_)
+            | Operator::Truncate(_)
+            | Operator::CopyFromFile(_)
+            | Operator::CopyToFile(_) => (),
+        }
+        if let Some(exprs) = operator.output_exprs() {
+            *output_exprs = exprs;
+        }
+
+        Ok(())
+    }
+}
+
+impl MatchPattern for ExpressionRemapper {
+    fn pattern(&self) -> &Pattern {
+        &EXPRESSION_REMAPPER_RULE
+    }
+}
+
+impl NormalizationRule for ExpressionRemapper {
+    fn apply(&self, node_id: HepNodeId, graph: &mut HepGraph) -> Result<(), DatabaseError> {
+        Self::_apply(&mut Vec::new(), node_id, graph)?;
+        // mark changed to skip this rule batch
+        graph.version += 1;
+
+        Ok(())
+    }
+}

--- a/src/optimizer/rule/normalization/mod.rs
+++ b/src/optimizer/rule/normalization/mod.rs
@@ -7,6 +7,7 @@ use crate::optimizer::rule::normalization::column_pruning::ColumnPruning;
 use crate::optimizer::rule::normalization::combine_operators::{
     CollapseGroupByAgg, CollapseProject, CombineFilter,
 };
+use crate::optimizer::rule::normalization::expression_remapper::ExpressionRemapper;
 use crate::optimizer::rule::normalization::pushdown_limit::{
     EliminateLimits, LimitProjectTranspose, PushLimitIntoScan, PushLimitThroughJoin,
 };
@@ -17,6 +18,7 @@ use crate::optimizer::rule::normalization::simplification::SimplifyFilter;
 
 mod column_pruning;
 mod combine_operators;
+mod expression_remapper;
 mod pushdown_limit;
 mod pushdown_predicates;
 mod simplification;
@@ -40,6 +42,8 @@ pub enum NormalizationRuleImpl {
     // Simplification
     SimplifyFilter,
     ConstantCalculation,
+    // ColumnRemapper
+    ExpressionRemapper,
 }
 
 impl MatchPattern for NormalizationRuleImpl {
@@ -57,6 +61,7 @@ impl MatchPattern for NormalizationRuleImpl {
             NormalizationRuleImpl::PushPredicateIntoScan => PushPredicateIntoScan.pattern(),
             NormalizationRuleImpl::SimplifyFilter => SimplifyFilter.pattern(),
             NormalizationRuleImpl::ConstantCalculation => ConstantCalculation.pattern(),
+            NormalizationRuleImpl::ExpressionRemapper => ExpressionRemapper.pattern(),
         }
     }
 }
@@ -86,6 +91,7 @@ impl NormalizationRule for NormalizationRuleImpl {
                 PushPredicateIntoScan.apply(node_id, graph)
             }
             NormalizationRuleImpl::ConstantCalculation => ConstantCalculation.apply(node_id, graph),
+            NormalizationRuleImpl::ExpressionRemapper => ExpressionRemapper.apply(node_id, graph),
         }
     }
 }

--- a/src/optimizer/rule/normalization/pushdown_predicates.rs
+++ b/src/optimizer/rule/normalization/pushdown_predicates.rs
@@ -215,7 +215,9 @@ impl NormalizationRule for PushPredicateIntoScan {
                 if let Operator::Scan(child_op) = graph.operator_mut(child_id) {
                     //FIXME: now only support unique
                     for IndexInfo { meta, binaries } in &mut child_op.index_infos {
-                        let mut option = op.predicate.convert_binary(&meta.column_ids[0])?;
+                        let mut option = op
+                            .predicate
+                            .convert_binary(meta.table_name.as_str(), &meta.column_ids[0])?;
 
                         if let Some(mut binary) = option.take() {
                             binary.scope_aggregation()?;

--- a/src/optimizer/rule/normalization/simplification.rs
+++ b/src/optimizer/rule/normalization/simplification.rs
@@ -157,7 +157,7 @@ mod test {
             unreachable!();
         }
         if let Operator::Filter(filter_op) = best_plan.childrens[0].clone().operator {
-            let column_binary = filter_op.predicate.convert_binary(&0).unwrap();
+            let column_binary = filter_op.predicate.convert_binary("t1", &0).unwrap();
             let final_binary = ConstantBinary::Scope {
                 min: Bound::Unbounded,
                 max: Bound::Excluded(Arc::new(DataValue::Int32(Some(-2)))),
@@ -207,10 +207,10 @@ mod test {
             if let Operator::Filter(filter_op) = best_plan.childrens[0].clone().operator {
                 println!(
                     "{expr}: {:#?}",
-                    filter_op.predicate.convert_binary(&0).unwrap()
+                    filter_op.predicate.convert_binary("t1", &0).unwrap()
                 );
 
-                Ok(filter_op.predicate.convert_binary(&0).unwrap())
+                Ok(filter_op.predicate.convert_binary("t1", &0).unwrap())
             } else {
                 Ok(None)
             }
@@ -341,7 +341,7 @@ mod test {
         let op_3 = op(plan_3, "-c1 > 1 and c2 + 1 > 1")?.unwrap();
         let op_4 = op(plan_4, "c1 + 1 > 1 and -c2 > 1")?.unwrap();
 
-        let cb_1_c1 = op_1.predicate.convert_binary(&0).unwrap();
+        let cb_1_c1 = op_1.predicate.convert_binary("t1", &0).unwrap();
         println!("op_1 => c1: {:#?}", cb_1_c1);
         assert_eq!(
             cb_1_c1,
@@ -351,7 +351,7 @@ mod test {
             })
         );
 
-        let cb_1_c2 = op_1.predicate.convert_binary(&1).unwrap();
+        let cb_1_c2 = op_1.predicate.convert_binary("t1", &1).unwrap();
         println!("op_1 => c2: {:#?}", cb_1_c2);
         assert_eq!(
             cb_1_c2,
@@ -361,7 +361,7 @@ mod test {
             })
         );
 
-        let cb_2_c1 = op_2.predicate.convert_binary(&0).unwrap();
+        let cb_2_c1 = op_2.predicate.convert_binary("t1", &0).unwrap();
         println!("op_2 => c1: {:#?}", cb_2_c1);
         assert_eq!(
             cb_2_c1,
@@ -371,7 +371,7 @@ mod test {
             })
         );
 
-        let cb_2_c2 = op_2.predicate.convert_binary(&1).unwrap();
+        let cb_2_c2 = op_2.predicate.convert_binary("t1", &1).unwrap();
         println!("op_2 => c2: {:#?}", cb_2_c2);
         assert_eq!(
             cb_1_c1,
@@ -381,7 +381,7 @@ mod test {
             })
         );
 
-        let cb_3_c1 = op_3.predicate.convert_binary(&0).unwrap();
+        let cb_3_c1 = op_3.predicate.convert_binary("t1", &0).unwrap();
         println!("op_3 => c1: {:#?}", cb_3_c1);
         assert_eq!(
             cb_3_c1,
@@ -391,7 +391,7 @@ mod test {
             })
         );
 
-        let cb_3_c2 = op_3.predicate.convert_binary(&1).unwrap();
+        let cb_3_c2 = op_3.predicate.convert_binary("t1", &1).unwrap();
         println!("op_3 => c2: {:#?}", cb_3_c2);
         assert_eq!(
             cb_3_c2,
@@ -401,7 +401,7 @@ mod test {
             })
         );
 
-        let cb_4_c1 = op_4.predicate.convert_binary(&0).unwrap();
+        let cb_4_c1 = op_4.predicate.convert_binary("t1", &0).unwrap();
         println!("op_4 => c1: {:#?}", cb_4_c1);
         assert_eq!(
             cb_4_c1,
@@ -411,7 +411,7 @@ mod test {
             })
         );
 
-        let cb_4_c2 = op_4.predicate.convert_binary(&1).unwrap();
+        let cb_4_c2 = op_4.predicate.convert_binary("t1", &1).unwrap();
         println!("op_4 => c2: {:#?}", cb_4_c2);
         assert_eq!(
             cb_4_c2,
@@ -448,7 +448,7 @@ mod test {
 
         let op_1 = op(plan_1, "c1 > c2 or c1 > 1")?.unwrap();
 
-        let cb_1_c1 = op_1.predicate.convert_binary(&0).unwrap();
+        let cb_1_c1 = op_1.predicate.convert_binary("t1", &0).unwrap();
         println!("op_1 => c1: {:#?}", cb_1_c1);
         assert_eq!(cb_1_c1, None);
 
@@ -479,7 +479,7 @@ mod test {
 
         let op_1 = op(plan_1, "c1 = 4 and c2 > c1 or c1 > 1")?.unwrap();
 
-        let cb_1_c1 = op_1.predicate.convert_binary(&0).unwrap();
+        let cb_1_c1 = op_1.predicate.convert_binary("t1", &0).unwrap();
         println!("op_1 => c1: {:#?}", cb_1_c1);
         assert_eq!(
             cb_1_c1,
@@ -518,7 +518,7 @@ mod test {
 
         let op_1 = op(plan_1, "c1 is null")?.unwrap();
 
-        let cb_1_c1 = op_1.predicate.convert_binary(&0).unwrap();
+        let cb_1_c1 = op_1.predicate.convert_binary("t1", &0).unwrap();
         println!("op_1 => c1: {:#?}", cb_1_c1);
         assert_eq!(cb_1_c1, Some(ConstantBinary::Eq(Arc::new(DataValue::Null))));
 
@@ -548,7 +548,7 @@ mod test {
 
         let op_1 = op(plan_1, "c1 is not null")?.unwrap();
 
-        let cb_1_c1 = op_1.predicate.convert_binary(&0).unwrap();
+        let cb_1_c1 = op_1.predicate.convert_binary("t1", &0).unwrap();
         println!("op_1 => c1: {:#?}", cb_1_c1);
         assert_eq!(
             cb_1_c1,
@@ -581,7 +581,7 @@ mod test {
 
         let op_1 = op(plan_1, "c1 in (1, 2, 3)")?.unwrap();
 
-        let cb_1_c1 = op_1.predicate.convert_binary(&0).unwrap();
+        let cb_1_c1 = op_1.predicate.convert_binary("t1", &0).unwrap();
         println!("op_1 => c1: {:#?}", cb_1_c1);
         assert_eq!(
             cb_1_c1,
@@ -618,7 +618,7 @@ mod test {
 
         let op_1 = op(plan_1, "c1 not in (1, 2, 3)")?.unwrap();
 
-        let cb_1_c1 = op_1.predicate.convert_binary(&0).unwrap();
+        let cb_1_c1 = op_1.predicate.convert_binary("t1", &0).unwrap();
         println!("op_1 => c1: {:#?}", cb_1_c1);
         assert_eq!(
             cb_1_c1,

--- a/src/planner/operator/aggregate.rs
+++ b/src/planner/operator/aggregate.rs
@@ -8,6 +8,7 @@ use std::fmt::Formatter;
 pub struct AggregateOperator {
     pub groupby_exprs: Vec<ScalarExpression>,
     pub agg_calls: Vec<ScalarExpression>,
+    pub is_distinct: bool,
 }
 
 impl AggregateOperator {
@@ -15,11 +16,13 @@ impl AggregateOperator {
         children: LogicalPlan,
         agg_calls: Vec<ScalarExpression>,
         groupby_exprs: Vec<ScalarExpression>,
+        is_distinct: bool,
     ) -> LogicalPlan {
         LogicalPlan::new(
             Operator::Aggregate(Self {
                 groupby_exprs,
                 agg_calls,
+                is_distinct,
             }),
             vec![children],
         )

--- a/src/storage/kip.rs
+++ b/src/storage/kip.rs
@@ -624,10 +624,8 @@ mod test {
             .await?;
         let transaction = fnck_sql.storage.transaction().await?;
 
-        let table = transaction
-            .table(Arc::new("t1".to_string()))
-            .unwrap()
-            .clone();
+        let table_name = Arc::new("t1".to_string());
+        let table = transaction.table(table_name.clone()).unwrap().clone();
         let tuple_ids = vec![
             Arc::new(DataValue::Int32(Some(0))),
             Arc::new(DataValue::Int32(Some(2))),
@@ -641,6 +639,7 @@ mod test {
             index_meta: Arc::new(IndexMeta {
                 id: 0,
                 column_ids: vec![0],
+                table_name,
                 name: "pk_a".to_string(),
                 is_unique: false,
                 is_primary: true,

--- a/src/storage/table_codec.rs
+++ b/src/storage/table_codec.rs
@@ -353,6 +353,7 @@ mod tests {
         let index_meta = IndexMeta {
             id: 0,
             column_ids: vec![0],
+            table_name: Arc::new("T1".to_string()),
             name: "index_1".to_string(),
             is_unique: false,
             is_primary: false,
@@ -447,6 +448,7 @@ mod tests {
             let index_meta = IndexMeta {
                 id: index_id as u32,
                 column_ids: vec![],
+                table_name: Arc::new(table_name.to_string()),
                 name: "".to_string(),
                 is_unique: false,
                 is_primary: false,

--- a/src/types/index.rs
+++ b/src/types/index.rs
@@ -1,3 +1,4 @@
+use crate::catalog::TableName;
 use crate::expression::simplify::ConstantBinary;
 use crate::types::value::ValueRef;
 use crate::types::ColumnId;
@@ -20,6 +21,7 @@ pub struct IndexInfo {
 pub struct IndexMeta {
     pub id: IndexId,
     pub column_ids: Vec<ColumnId>,
+    pub table_name: TableName,
     pub name: String,
     pub is_unique: bool,
     pub is_primary: bool,


### PR DESCRIPTION
### What problem does this PR solve?

- feat: added `NormalizationRuleImpl::ColumnRemapper` to optimize expression mapping and avoid polling search
- fix: duplicate ColumnIds between multiple tables may cause constant relationship extraction errors

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
