### PR TITLE
feat: add `DataType::Tuple`

### DIFF
--- a/src/binder/aggregate.rs
+++ b/src/binder/aggregate.rs
@@ -136,8 +136,12 @@ impl<'a, T: Transaction> Binder<'a, T> {
                 }
             }
             ScalarExpression::Constant(_) | ScalarExpression::ColumnRef { .. } => (),
-            ScalarExpression::Empty => unreachable!(),
-            ScalarExpression::Reference { .. } => unreachable!(),
+            ScalarExpression::Reference { .. } | ScalarExpression::Empty => unreachable!(),
+            ScalarExpression::Tuple(args) => {
+                for expr in args {
+                    self.visit_column_agg_expr(expr)?;
+                }
+            }
         }
 
         Ok(())
@@ -310,8 +314,13 @@ impl<'a, T: Transaction> Binder<'a, T> {
                 Ok(())
             }
             ScalarExpression::Constant(_) => Ok(()),
-            ScalarExpression::Empty => unreachable!(),
-            ScalarExpression::Reference { .. } => unreachable!(),
+            ScalarExpression::Reference { .. } | ScalarExpression::Empty => unreachable!(),
+            ScalarExpression::Tuple(args) => {
+                for expr in args {
+                    self.validate_having_orderby(expr)?;
+                }
+                Ok(())
+            }
         }
     }
 }

--- a/src/binder/expr.rs
+++ b/src/binder/expr.rs
@@ -113,6 +113,14 @@ impl<'a, T: Transaction> Binder<'a, T> {
                     )))),
                 })
             }
+            Expr::Tuple(exprs) => {
+                let mut bond_exprs = Vec::with_capacity(exprs.len());
+
+                for expr in exprs {
+                    bond_exprs.push(self.bind_expr(expr)?);
+                }
+                Ok(ScalarExpression::Tuple(bond_exprs))
+            }
             _ => {
                 todo!()
             }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,4 @@
+use crate::expression::BinaryOperator;
 use crate::types::LogicalType;
 use chrono::ParseError;
 use kip_db::KernelError;
@@ -161,9 +162,10 @@ pub enum DatabaseError {
     AggMiss(String),
     #[error("copy error: {0}")]
     UnsupportedCopySource(String),
+    #[error("the {0} cannot support {1} for calculations")]
+    UnsupportedBinaryOperator(LogicalType, BinaryOperator),
     #[error("can not compare two types: {0} and {1}")]
     Incomparable(LogicalType, LogicalType),
-
     #[error("transaction already exists")]
     TransactionAlreadyExists,
     #[error("no transaction begin")]

--- a/src/expression/evaluator.rs
+++ b/src/expression/evaluator.rs
@@ -168,6 +168,16 @@ impl ScalarExpression {
                     .unwrap_or_else(|| &NULL_VALUE)
                     .clone());
             }
+            ScalarExpression::Tuple(exprs) => {
+                let mut values = Vec::with_capacity(exprs.len());
+
+                for expr in exprs {
+                    values.push(expr.eval(tuple)?);
+                }
+                Ok(Arc::new(DataValue::Tuple(
+                    (!values.is_empty()).then_some(values),
+                )))
+            }
             ScalarExpression::Empty => unreachable!(),
         }
     }

--- a/src/optimizer/core/histogram.rs
+++ b/src/optimizer/core/histogram.rs
@@ -308,6 +308,7 @@ impl Histogram {
                 | LogicalType::Decimal(_, _) => {
                     value.clone().cast(&LogicalType::Double).unwrap().double()
                 }
+                LogicalType::Tuple => unreachable!(),
             }
             .unwrap_or(0.0)
         };

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -38,6 +38,7 @@ pub enum LogicalType {
     DateTime,
     // decimal (precision, scale)
     Decimal(Option<u8>, Option<u8>),
+    Tuple,
 }
 
 impl LogicalType {
@@ -97,6 +98,7 @@ impl LogicalType {
             LogicalType::Decimal(_, _) => Some(16),
             LogicalType::Date => Some(4),
             LogicalType::DateTime => Some(8),
+            LogicalType::Tuple => unreachable!(),
         }
     }
 
@@ -288,7 +290,7 @@ impl LogicalType {
             LogicalType::Varchar(_) => false,
             LogicalType::Date => matches!(to, LogicalType::DateTime | LogicalType::Varchar(_)),
             LogicalType::DateTime => matches!(to, LogicalType::Date | LogicalType::Varchar(_)),
-            LogicalType::Decimal(_, _) => false,
+            LogicalType::Decimal(_, _) | LogicalType::Tuple => false,
         }
     }
 }

--- a/tests/slt/tuple
+++ b/tests/slt/tuple
@@ -1,0 +1,60 @@
+query B
+select (1, 2) = (1, 2)
+----
+true
+
+query B
+select (1, 2) = (2, 1)
+----
+false
+
+query B
+select (1, 2) != (1, 2)
+----
+false
+
+query B
+select (1, 2) != (2, 1)
+----
+true
+
+statement ok
+create table t1(id int primary key, v1 int unique)
+
+statement ok
+insert into t1 values (1,1), (2,2), (3,3), (4,4)
+
+query T
+select (id, v1) from t1;
+----
+(1, 1)
+(2, 2)
+(3, 3)
+(4, 4)
+
+query T
+select * from t1 where (id,v1) == (1,1);
+----
+1 1
+
+query T
+select * from t1 where (id,v1) != (1,1);
+----
+(2, 2)
+(3, 3)
+(4, 4)
+
+query T
+select * from t1 where (id,v1) in ((1,1), (2, 2));
+----
+1 1
+2 2
+
+query T
+select * from t1 where (id,v1) not in ((1,1), (2, 2));
+----
+3 3
+4 4
+
+statement ok
+drop t1

--- a/tests/sqllogictest/src/lib.rs
+++ b/tests/sqllogictest/src/lib.rs
@@ -16,8 +16,7 @@ impl AsyncDB for KipSQL {
     async fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, Self::Error> {
         let start = Instant::now();
         let tuples = self.db.run(sql).await?;
-        println!("|— Input SQL:");
-        println!(" |— {}", sql);
+        println!("|— Input SQL: {}", sql);
         println!(" |— Time consuming: {:?}", start.elapsed());
 
         if tuples.is_empty() {


### PR DESCRIPTION
### What problem does this PR solve?

```shell
select * from test where (x, 1) in ((1, 1), (1, 2))

+----+---+---+
| id | x | y |
+============+
| 0  | 1 | 1 |
|----+---+---|
| 2  | 1 | 1 |
+----+---+---+

select * from test where (x, 1) != (1, 1)

+----+---+---+
| id | x | y |
+============+
| 1  | 2 | 2 |
|----+---+---|
| 3  | 3 | 3 |
+----+---+---+
```

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
