### PR TITLE
feat: support `UDF`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ then use `psql` to enter sql
 ![pg](./static/images/pg.gif)
 Using FnckSQL in code
 ```rust
-let fnck_sql = Database::with_kipdb("./data").await?;
+let fnck_sql = DataBaseBuilder::path("./data")
+    .build()
+    .await?;
 let tuples = fnck_sql.run("select * from t1").await?;
 ```
 Storage Support:
@@ -79,6 +81,18 @@ implement_from_tuple!(
         }
     )
 );
+```
+- User-Defined Function: `features = ["marcos"]`
+```rust
+function!(TestFunction::test(LogicalType::Integer, LogicalType::Integer) -> LogicalType::Integer => |v1: ValueRef, v2: ValueRef| {
+    let value = DataValue::binary_op(&v1, &v2, &BinaryOperator::Plus)?;
+    DataValue::unary_op(&value, &UnaryOperator::Minus)
+});
+
+let fnck_sql = DataBaseBuilder::path("./data")
+    .register_function(TestFunction::new())
+    .build()
+    .await?;
 ```
 - Optimizer
   - RBO

--- a/benchmarks/query_benchmark.rs
+++ b/benchmarks/query_benchmark.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use fnck_sql::db::Database;
+use fnck_sql::db::{DataBaseBuilder, Database};
 use fnck_sql::errors::DatabaseError;
 use fnck_sql::execution::volcano;
 use fnck_sql::storage::kip::KipStorage;
@@ -18,7 +18,8 @@ const QUERY_BENCH_SQLITE_PATH: &'static str = "./sqlite_bench";
 const TABLE_ROW_NUM: u64 = 2_00_000;
 
 async fn init_fncksql_query_bench() -> Result<(), DatabaseError> {
-    let database = Database::with_kipdb(QUERY_BENCH_FNCK_SQL_PATH)
+    let database = DataBaseBuilder::path(QUERY_BENCH_FNCK_SQL_PATH)
+        .build()
         .await
         .unwrap();
     database
@@ -96,7 +97,8 @@ fn query_on_execute(c: &mut Criterion) {
             init_fncksql_query_bench().await.unwrap();
         }
 
-        Database::<KipStorage>::with_kipdb(QUERY_BENCH_FNCK_SQL_PATH)
+        DataBaseBuilder::path(QUERY_BENCH_FNCK_SQL_PATH)
+            .build()
             .await
             .unwrap()
     });

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,4 +1,4 @@
-use fnck_sql::db::Database;
+use fnck_sql::db::DataBaseBuilder;
 use fnck_sql::errors::DatabaseError;
 use fnck_sql::implement_from_tuple;
 use fnck_sql::types::tuple::Tuple;
@@ -30,7 +30,7 @@ implement_from_tuple!(
 #[cfg(feature = "marcos")]
 #[tokio::main]
 async fn main() -> Result<(), DatabaseError> {
-    let database = Database::with_kipdb("./hello_world").await?;
+    let database = DataBaseBuilder::path("./hello_world").build().await?;
 
     let _ = database
         .run("create table if not exists my_struct (c1 int primary key, c2 int)")

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -1,9 +1,9 @@
-use fnck_sql::db::Database;
+use fnck_sql::db::DataBaseBuilder;
 use fnck_sql::errors::DatabaseError;
 
 #[tokio::main]
 async fn main() -> Result<(), DatabaseError> {
-    let database = Database::with_kipdb("./transaction").await?;
+    let database = DataBaseBuilder::path("./transaction").build().await?;
     let mut tx_1 = database.new_transaction().await?;
 
     let _ = tx_1

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use clap::Parser;
-use fnck_sql::db::{DBTransaction, Database};
+use fnck_sql::db::{DBTransaction, DataBaseBuilder, Database};
 use fnck_sql::errors::DatabaseError;
 use fnck_sql::storage::kip::KipStorage;
 use fnck_sql::types::tuple::Tuple;
@@ -79,7 +79,7 @@ impl MakeHandler for FnckSQLBackend {
 
 impl FnckSQLBackend {
     pub async fn new(path: impl Into<PathBuf> + Send) -> Result<FnckSQLBackend, DatabaseError> {
-        let database = Database::with_kipdb(path).await?;
+        let database = DataBaseBuilder::path(path).build().await?;
 
         Ok(FnckSQLBackend {
             inner: Arc::new(database),

--- a/src/binder/create_table.rs
+++ b/src/binder/create_table.rs
@@ -148,9 +148,10 @@ mod tests {
         let temp_dir = TempDir::new().expect("unable to create temporary working directory");
         let storage = KipStorage::new(temp_dir.path()).await?;
         let transaction = storage.transaction().await?;
+        let functions = Default::default();
 
         let sql = "create table t1 (id int primary key, name varchar(10) null)";
-        let mut binder = Binder::new(BinderContext::new(&transaction));
+        let mut binder = Binder::new(BinderContext::new(&transaction, &functions));
         let stmt = crate::parser::parse_sql(sql).unwrap();
         let plan1 = binder.bind(&stmt[0]).unwrap();
 

--- a/src/binder/insert.rs
+++ b/src/binder/insert.rs
@@ -1,6 +1,5 @@
 use crate::binder::{lower_case_name, Binder};
 use crate::errors::DatabaseError;
-use crate::expression::value_compute::unary_op;
 use crate::expression::ScalarExpression;
 use crate::planner::operator::insert::InsertOperator;
 use crate::planner::operator::values::ValuesOperator;
@@ -72,7 +71,8 @@ impl<'a, T: Transaction> Binder<'a, T> {
                         ScalarExpression::Unary { expr, op, .. } => {
                             if let ScalarExpression::Constant(value) = expr.as_ref() {
                                 row.push(Arc::new(
-                                    unary_op(value, op)?.cast(schema_ref[i].datatype())?,
+                                    DataValue::unary_op(value, op)?
+                                        .cast(schema_ref[i].datatype())?,
                                 ))
                             } else {
                                 unreachable!()

--- a/src/execution/volcano/dml/copy_from_file.rs
+++ b/src/execution/volcano/dml/copy_from_file.rs
@@ -108,7 +108,7 @@ fn return_result(size: usize, tx: Sender<Tuple>) -> Result<(), DatabaseError> {
 #[cfg(test)]
 mod tests {
     use crate::catalog::{ColumnCatalog, ColumnDesc, ColumnSummary};
-    use crate::db::Database;
+    use crate::db::DataBaseBuilder;
     use futures::StreamExt;
     use std::io::Write;
     use std::sync::Arc;
@@ -176,7 +176,7 @@ mod tests {
         };
 
         let temp_dir = TempDir::new().unwrap();
-        let db = Database::with_kipdb(temp_dir.path()).await?;
+        let db = DataBaseBuilder::path(temp_dir.path()).build().await?;
         let _ = db
             .run("create table test_copy (a int primary key, b float, c varchar(10))")
             .await;

--- a/src/execution/volcano/dql/aggregate/avg.rs
+++ b/src/execution/volcano/dql/aggregate/avg.rs
@@ -1,7 +1,6 @@
 use crate::errors::DatabaseError;
 use crate::execution::volcano::dql::aggregate::sum::SumAccumulator;
 use crate::execution::volcano::dql::aggregate::Accumulator;
-use crate::expression::value_compute::binary_op;
 use crate::expression::BinaryOperator;
 use crate::types::value::{DataValue, ValueRef};
 use crate::types::LogicalType;
@@ -40,7 +39,7 @@ impl Accumulator for AvgAccumulator {
             DataValue::UInt32(Some(self.count as u32))
         };
 
-        Ok(Arc::new(binary_op(
+        Ok(Arc::new(DataValue::binary_op(
             &value,
             &quantity,
             &BinaryOperator::Divide,

--- a/src/execution/volcano/dql/aggregate/min_max.rs
+++ b/src/execution/volcano/dql/aggregate/min_max.rs
@@ -1,6 +1,5 @@
 use crate::errors::DatabaseError;
 use crate::execution::volcano::dql::aggregate::Accumulator;
-use crate::expression::value_compute::binary_op;
 use crate::expression::BinaryOperator;
 use crate::types::value::{DataValue, ValueRef};
 use crate::types::LogicalType;
@@ -32,7 +31,9 @@ impl Accumulator for MinMaxAccumulator {
     fn update_value(&mut self, value: &ValueRef) -> Result<(), DatabaseError> {
         if !value.is_null() {
             if let Some(inner_value) = &self.inner {
-                if let DataValue::Boolean(Some(result)) = binary_op(inner_value, value, &self.op)? {
+                if let DataValue::Boolean(Some(result)) =
+                    DataValue::binary_op(inner_value, value, &self.op)?
+                {
                     result
                 } else {
                     unreachable!()

--- a/src/execution/volcano/dql/aggregate/mod.rs
+++ b/src/execution/volcano/dql/aggregate/mod.rs
@@ -43,7 +43,7 @@ fn create_accumulator(expr: &ScalarExpression) -> Box<dyn Accumulator> {
         }
     } else {
         unreachable!(
-            "create_accumulator called with non-aggregate expression {:?}",
+            "create_accumulator called with non-aggregate expression {}",
             expr
         );
     }

--- a/src/execution/volcano/dql/aggregate/sum.rs
+++ b/src/execution/volcano/dql/aggregate/sum.rs
@@ -1,6 +1,5 @@
 use crate::errors::DatabaseError;
 use crate::execution::volcano::dql::aggregate::Accumulator;
-use crate::expression::value_compute::binary_op;
 use crate::expression::BinaryOperator;
 use crate::types::value::{DataValue, ValueRef};
 use crate::types::LogicalType;
@@ -25,7 +24,7 @@ impl SumAccumulator {
 impl Accumulator for SumAccumulator {
     fn update_value(&mut self, value: &ValueRef) -> Result<(), DatabaseError> {
         if !value.is_null() {
-            self.result = binary_op(&self.result, value, &BinaryOperator::Plus)?;
+            self.result = DataValue::binary_op(&self.result, value, &BinaryOperator::Plus)?;
         }
 
         Ok(())

--- a/src/expression/function.rs
+++ b/src/expression/function.rs
@@ -1,0 +1,57 @@
+use crate::errors::DatabaseError;
+use crate::expression::ScalarExpression;
+use crate::types::tuple::Tuple;
+use crate::types::value::DataValue;
+use crate::types::LogicalType;
+use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+/// for `datafusion`
+/// - `None` unknown monotonicity or non-monotonicity
+/// - `Some(true)` monotonically increasing
+/// - `Some(false)` monotonically decreasing
+pub type FuncMonotonicity = Vec<Option<bool>>;
+
+#[derive(Debug, Clone)]
+pub struct ScalarFunction {
+    pub(crate) args: Vec<ScalarExpression>,
+    pub(crate) inner: Arc<dyn ScalarFunctionImpl>,
+}
+
+impl PartialEq for ScalarFunction {
+    fn eq(&self, other: &Self) -> bool {
+        self.summary() == other.summary()
+    }
+}
+
+impl Eq for ScalarFunction {}
+
+impl Hash for ScalarFunction {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.summary().hash(state);
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+pub struct FunctionSummary {
+    pub(crate) name: String,
+    pub(crate) arg_types: Vec<LogicalType>,
+}
+
+pub trait ScalarFunctionImpl: Debug + Send + Sync {
+    fn eval(&self, args: &[ScalarExpression], tuple: &Tuple) -> Result<DataValue, DatabaseError>;
+
+    // TODO: Exploiting monotonicity when optimizing `ScalarFunctionImpl::monotonicity()`
+    fn monotonicity(&self) -> Option<FuncMonotonicity>;
+
+    fn return_type(&self) -> &LogicalType;
+
+    fn summary(&self) -> &FunctionSummary;
+}
+
+impl ScalarFunction {
+    pub fn summary(&self) -> &FunctionSummary {
+        self.inner.summary()
+    }
+}

--- a/src/storage/kip.rs
+++ b/src/storage/kip.rs
@@ -525,7 +525,7 @@ impl Iter for KipIter<'_> {
 #[cfg(test)]
 mod test {
     use crate::catalog::{ColumnCatalog, ColumnDesc};
-    use crate::db::Database;
+    use crate::db::DataBaseBuilder;
     use crate::errors::DatabaseError;
     use crate::expression::simplify::ConstantBinary;
     use crate::storage::kip::KipStorage;
@@ -616,7 +616,7 @@ mod test {
     #[tokio::test]
     async fn test_index_iter_pk() -> Result<(), DatabaseError> {
         let temp_dir = TempDir::new().expect("unable to create temporary working directory");
-        let fnck_sql = Database::with_kipdb(temp_dir.path()).await?;
+        let fnck_sql = DataBaseBuilder::path(temp_dir.path()).build().await?;
 
         let _ = fnck_sql.run("create table t1 (a int primary key)").await?;
         let _ = fnck_sql
@@ -671,7 +671,7 @@ mod test {
     #[tokio::test]
     async fn test_read_by_index() -> Result<(), DatabaseError> {
         let temp_dir = TempDir::new().expect("unable to create temporary working directory");
-        let fnck_sql = Database::with_kipdb(temp_dir.path()).await?;
+        let fnck_sql = DataBaseBuilder::path(temp_dir.path()).build().await?;
         let _ = fnck_sql
             .run("create table t1 (a int primary key, b int unique)")
             .await?;

--- a/tests/sqllogictest/src/main.rs
+++ b/tests/sqllogictest/src/main.rs
@@ -1,4 +1,4 @@
-use fnck_sql::db::Database;
+use fnck_sql::db::DataBaseBuilder;
 use sqllogictest::Runner;
 use sqllogictest_test::KipSQL;
 use std::fs::File;
@@ -26,7 +26,8 @@ async fn main() {
             .to_string();
         println!("-> Now the test file is: {}", filepath);
 
-        let db = Database::with_kipdb(temp_dir.path())
+        let db = DataBaseBuilder::path(temp_dir.path())
+            .build()
             .await
             .expect("init db error");
         let mut tester = Runner::new(KipSQL { db });


### PR DESCRIPTION
### What problem does this PR solve?

```rust
function!(TestFunction::test(LogicalType::Integer, LogicalType::Integer) -> LogicalType::Integer => |v1: ValueRef, v2: ValueRef| {
   let value = DataValue::binary_op(&v1, &v2, &BinaryOperator::Plus)?;
   DataValue::unary_op(&value, &UnaryOperator::Minus)
});
```

```
select test(c1, 1) from test

+------------------+
| test(test.c1, 1) |
+==================+
| -2               |
|------------------|
| -3               |
|------------------|
| -2               |
|------------------|
| -4               |
+------------------+
```

Tips: 
The reason for supporting UDF is because SQL 2016 needs to support a large number of methods, and I don’t want to cause `ScalarExpression` to bloat, so UDF is supported to implement some functions in SQL 2016.

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
