### PR TITLE
feat: support `Select Into`

### DIFF
--- a/src/binder/insert.rs
+++ b/src/binder/insert.rs
@@ -55,7 +55,7 @@ impl<'a, T: Transaction> Binder<'a, T> {
             let mut rows = Vec::with_capacity(expr_rows.len());
             for expr_row in expr_rows {
                 if expr_row.len() != values_len {
-                    return Err(DatabaseError::ValuesLenNotSame());
+                    return Err(DatabaseError::ValuesLenMismatch(expr_row.len(), values_len));
                 }
                 let mut row = Vec::with_capacity(expr_row.len());
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -152,8 +152,6 @@ pub enum DatabaseError {
     AmbiguousColumn(String),
     #[error("values length not match, expect {0}, got {1}")]
     ValuesLenMismatch(usize, usize),
-    #[error("values list must all be the same length")]
-    ValuesLenNotSame(),
     #[error("binary operator types mismatch: {0} != {1}")]
     BinaryOpTypeMismatch(String, String),
     #[error("subquery error: {0}")]

--- a/tests/slt/basic_test.slt
+++ b/tests/slt/basic_test.slt
@@ -3,15 +3,15 @@ select 1
 ----
 1
 
-# query R
-# select 10000.00::FLOAT + 234.567::FLOAT
-# ----
-# 10234.567
+query R
+select 10000.00::FLOAT + 234.567::FLOAT
+----
+10234.567
 
-# query R
-# select 100.0::DOUBLE/8.0::DOUBLE
-# ----
-# 12.5
+query R
+select 100.0::DOUBLE/8.0::DOUBLE
+----
+12.5
 
 query B
 select 2>1

--- a/tests/slt/group_by.slt
+++ b/tests/slt/group_by.slt
@@ -4,7 +4,6 @@ create table t (id int primary key, v1 int, v2 int)
 statement ok
 insert into t values (0,1,1), (1,2,1), (2,3,2), (3,4,2), (4,5,3)
 
-# TODO: check on binder
 statement error
 select v2 + 1, v1 from t group by v2 + 1
 

--- a/tests/slt/having.slt
+++ b/tests/slt/having.slt
@@ -19,11 +19,10 @@ select count(x) as a, y + 1 as b from test group by b having b + 1 = 24;
 ----
 1 23
 
-# TODO: Filter pushed down to Agg
-# query II
-# select x from test group by x having max(y) = 22
-# ----
-# 11
+query II
+select x from test group by x having max(y) = 22
+----
+11
 
 # query II
 # select y + 1 as i from test group by y + 1 having count(x) > 1 and y + 1 = 3 or y + 1 = 23 order by i;

--- a/tests/slt/select_into.slt
+++ b/tests/slt/select_into.slt
@@ -1,0 +1,44 @@
+statement ok
+create table t1 (v1 int not null primary key, v2 int not null);
+
+statement ok
+create table t2 (v1 int not null primary key, v2 int not null);
+
+statement ok
+create table t3 (v1 int not null primary key, v2 int not null);
+
+statement ok
+insert into t1 values (1, 1), (4, 6), (3, 2), (2, 1);
+
+query II rowsort
+select * from t1;
+----
+1 1
+2 1
+3 2
+4 6
+
+statement ok
+select * into t2 from t1;
+
+statement ok
+select v2, v1 into t3 from t2 where v2 != 6;
+
+query II rowsort
+select * from t2;
+----
+1 1
+2 1
+3 2
+4 6
+
+query II rowsort
+select * from t3;
+----
+1 1
+2 1
+3 2
+
+statement ok
+drop table t1;
+

--- a/tests/slt/where.slt
+++ b/tests/slt/where.slt
@@ -69,12 +69,11 @@ create table t(id int primary key, v1 int null, v2 int);
 statement ok
 insert into t values (0, 1, 1), (1, null, 2), (2, null, 3), (3, 4, 4);
 
-# TODO: Support `IsNull`
-# query I
-# select v2 from t where v1 is null;
-# ----
-# 2
-# 3
+query I
+select v2 from t where v1 is null;
+----
+2
+3
 
 # query I
 # select v2 from t where v1 is not null;


### PR DESCRIPTION
### What problem does this PR solve?

- optimize HashJoin implementation
- support `Select Into`

```
EXPLAIN SELECT A INTO TABLE_E111_01_013 FROM TABLE_E111_01_011

+--------------------------------------------------------+
| PLAN                                                   |
+========================================================+
| Insert table_e111_01_013, Is Overwrite: false [Insert] |
|   Projection [table_e111_01_011.a] [Project]           |
|     Scan table_e111_01_011 -> [id, a] [SeqScan]        |
+--------------------------------------------------------+
```
Tips: I tried to implement `Semi/Anti` Join, but I didn’t have any good ideas

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
