### PR TITLE
fix: range detection error when nesting `and` & `or`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "fnck_sql"
-version = "0.0.1-alpha.11.fix2"
+version = "0.0.1-alpha.11.fix3"
 edition = "2021"
 authors = ["Kould <kould2333@gmail.com>", "Xwg <loloxwg@gmail.com>"]
 description = "Fast Insert OLTP SQL DBMS"
@@ -52,7 +52,7 @@ ahash = "0.8.3"
 lazy_static = "1.4.0"
 comfy-table = "7.0.1"
 bytes = "1.5.0"
-kip_db = "0.1.2-alpha.25"
+kip_db = "0.1.2-alpha.25.fix1"
 rust_decimal = "1"
 csv = "1"
 regex = "1.10.2"

--- a/tests/slt/dummy.slt
+++ b/tests/slt/dummy.slt
@@ -12,6 +12,11 @@ SELECT 'a'
 a
 
 query B
+SELECT 1.01=1.01
+----
+true
+
+query B
 SELECT NULL=NULL
 ----
 null

--- a/tests/slt/where_by_index.slt
+++ b/tests/slt/where_by_index.slt
@@ -121,3 +121,12 @@ select * from t1 where (id >= 0 or id <= 3) and (id >= 9 or id <= 12) limit 10;
 21 22 23
 24 25 26
 27 28 29
+
+query IIT
+select * from t1 where id = 5 or (id > 5 and (id > 6 or id < 8)  and id < 12);
+----
+6 7 8
+9 10 11
+
+statement ok
+drop table t1;


### PR DESCRIPTION
### What problem does this PR solve?

fix case: 
```
query IIT
select * from t1 where id = 5 or (id > 5 and (id > 6 or id < 8)  and id < 12);
----
6 7 8
9 10 11
```

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
