### PR TITLE
feat: add support for `POSITION()`

### DIFF
--- a/src/binder/aggregate.rs
+++ b/src/binder/aggregate.rs
@@ -136,6 +136,10 @@ impl<'a, T: Transaction> Binder<'a, T> {
                     self.visit_column_agg_expr(expr)?;
                 }
             }
+            ScalarExpression::Position { expr, in_expr } => {
+                self.visit_column_agg_expr(expr)?;
+                self.visit_column_agg_expr(in_expr)?;
+            }
             ScalarExpression::Constant(_) | ScalarExpression::ColumnRef { .. } => (),
             ScalarExpression::Reference { .. } | ScalarExpression::Empty => unreachable!(),
             ScalarExpression::Tuple(args)
@@ -354,6 +358,11 @@ impl<'a, T: Transaction> Binder<'a, T> {
                 if let Some(expr) = from_expr {
                     self.validate_having_orderby(expr)?;
                 }
+                Ok(())
+            }
+            ScalarExpression::Position { expr, in_expr } => {
+                self.validate_having_orderby(expr)?;
+                self.validate_having_orderby(in_expr)?;
                 Ok(())
             }
             ScalarExpression::Constant(_) => Ok(()),

--- a/src/binder/expr.rs
+++ b/src/binder/expr.rs
@@ -104,6 +104,10 @@ impl<'a, T: Transaction> Binder<'a, T> {
                     from_expr,
                 })
             }
+            Expr::Position { expr, r#in } => Ok(ScalarExpression::Position {
+                expr: Box::new(self.bind_expr(expr)?),
+                in_expr: Box::new(self.bind_expr(r#in)?),
+            }),
             Expr::Subquery(subquery) => {
                 let (sub_query, column) = self.bind_subquery(subquery)?;
                 self.context.sub_query(SubQueryType::SubQuery(sub_query));

--- a/src/expression/evaluator.rs
+++ b/src/expression/evaluator.rs
@@ -177,13 +177,9 @@ impl ScalarExpression {
                 };
                 let pattern = unpack(expr)?;
                 let str = unpack(in_expr)?;
-                Ok(Arc::new(DataValue::Int32(
-                    if let Some(pos) = str.find(&pattern) {
-                        Some(pos as i32 + 1)
-                    } else {
-                        Some(0)
-                    },
-                )))
+                Ok(Arc::new(DataValue::Int32(Some(
+                    str.find(&pattern).map(|pos| pos as i32 + 1).unwrap_or(0),
+                ))))
             }
             ScalarExpression::Reference { pos, .. } => {
                 return Ok(tuple

--- a/src/expression/range_detacher.rs
+++ b/src/expression/range_detacher.rs
@@ -223,6 +223,7 @@ impl<'a> RangeDetacher<'a> {
             | ScalarExpression::In { expr, .. }
             | ScalarExpression::Between { expr, .. }
             | ScalarExpression::SubString { expr, .. } => self.detach(expr),
+            ScalarExpression::Position { expr, .. } => self.detach(expr),
             ScalarExpression::IsNull { expr, negated, .. } => match expr.as_ref() {
                 ScalarExpression::ColumnRef(column) => {
                     if let (Some(col_id), Some(col_table)) = (column.id(), column.table_name()) {
@@ -248,6 +249,7 @@ impl<'a> RangeDetacher<'a> {
                 | ScalarExpression::In { .. }
                 | ScalarExpression::Between { .. }
                 | ScalarExpression::SubString { .. }
+                | ScalarExpression::Position { .. }
                 | ScalarExpression::Function(_)
                 | ScalarExpression::If { .. }
                 | ScalarExpression::IfNull { .. }

--- a/src/expression/simplify.rs
+++ b/src/expression/simplify.rs
@@ -84,6 +84,9 @@ impl ScalarExpression {
                         .map(|expr| expr.exist_column(table_name, col_id))
                         == Some(true)
             }
+            ScalarExpression::Position { expr, in_expr } => {
+                expr.exist_column(table_name, col_id) || in_expr.exist_column(table_name, col_id)
+            }
             ScalarExpression::Constant(_) => false,
             ScalarExpression::Reference { .. } | ScalarExpression::Empty => unreachable!(),
             ScalarExpression::If {

--- a/tests/slt/sql_2016/E021_11.slt
+++ b/tests/slt/sql_2016/E021_11.slt
@@ -1,7 +1,5 @@
 # E021-11: POSITION function
 
-# TODO: POSITION()
-
 query I
 SELECT POSITION ( 'foo' IN 'bar' )
 ----

--- a/tests/slt/sql_2016/E021_11.slt
+++ b/tests/slt/sql_2016/E021_11.slt
@@ -2,10 +2,10 @@
 
 # TODO: POSITION()
 
-# query I
-# SELECT POSITION ( 'foo' IN 'bar' )
-# ----
-# 0
+query I
+SELECT POSITION ( 'foo' IN 'bar' )
+----
+0
 
 # query I
 # SELECT POSITION ( 'foo' IN 'bar' USING CHARACTERS )


### PR DESCRIPTION
### What problem does this PR solve?

Support for `POSITION()`  Function. `POSITION(pattern in s USING CHARACTERS/OCTETS)` is not implemented since it's not supported by sqlparser

Issue link: #130 

### What is changed and how it works?

```sql
=> SELECT POSITION('bc' in 'abcd');
 position(bc in abcd)
----------------------
                    2
(1 row)

=> SELECT POSITION('de' in 'abcd');
 position(de in abcd)
----------------------
                    0
(1 row)

```

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
