### PR TITLE
fix: fucntion `substring` for out of bounds error

### DIFF
--- a/src/binder/select.rs
+++ b/src/binder/select.rs
@@ -177,6 +177,7 @@ impl<'a, T: Transaction> Binder<'a, T> {
                 }
                 Ok(UnionOperator::build(
                     left_schema.clone(),
+                    right_schema.clone(),
                     left_plan,
                     right_plan,
                 ))
@@ -192,7 +193,8 @@ impl<'a, T: Transaction> Binder<'a, T> {
                     ));
                 }
                 let union_op = Operator::Union(UnionOperator {
-                    schema_ref: left_schema.clone(),
+                    left_schema_ref: left_schema.clone(),
+                    _right_schema_ref: right_schema.clone(),
                 });
                 let distinct_exprs = left_schema
                     .iter()

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -90,7 +90,10 @@ impl LogicalPlan {
                     Arc::new(out_columns)
                 }
                 Operator::Values(ValuesOperator { schema_ref, .. })
-                | Operator::Union(UnionOperator { schema_ref }) => schema_ref.clone(),
+                | Operator::Union(UnionOperator {
+                    left_schema_ref: schema_ref,
+                    ..
+                }) => schema_ref.clone(),
                 Operator::Dummy => Arc::new(vec![]),
                 Operator::Show => Arc::new(vec![
                     Arc::new(ColumnCatalog::new_dummy("TABLE".to_string())),

--- a/src/planner/operator/union.rs
+++ b/src/planner/operator/union.rs
@@ -7,17 +7,23 @@ use std::fmt::Formatter;
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct UnionOperator {
-    pub schema_ref: SchemaRef,
+    pub left_schema_ref: SchemaRef,
+    // mainly use `left_schema` as output and `right_schema` for `column pruning`
+    pub _right_schema_ref: SchemaRef,
 }
 
 impl UnionOperator {
     pub fn build(
-        schema_ref: SchemaRef,
+        left_schema_ref: SchemaRef,
+        right_schema_ref: SchemaRef,
         left_plan: LogicalPlan,
         right_plan: LogicalPlan,
     ) -> LogicalPlan {
         LogicalPlan::new(
-            Operator::Union(UnionOperator { schema_ref }),
+            Operator::Union(UnionOperator {
+                left_schema_ref,
+                _right_schema_ref: right_schema_ref,
+            }),
             vec![left_plan, right_plan],
         )
     }
@@ -26,7 +32,7 @@ impl UnionOperator {
 impl fmt::Display for UnionOperator {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let schema = self
-            .schema_ref
+            .left_schema_ref
             .iter()
             .map(|column| column.name().to_string())
             .join(", ");

--- a/tests/slt/substring.slt
+++ b/tests/slt/substring.slt
@@ -9,7 +9,7 @@ select substring('pineapple' from -5 for 10 )
 apple
 
 query T
-select substr('pineapple', -15, 10 )
+select substring('pineapple', -15, 10 )
 ----
 apple
 

--- a/tests/slt/substring.slt
+++ b/tests/slt/substring.slt
@@ -1,7 +1,17 @@
 query T
 select substring('pineapple' from 5 for 10 )
 ----
-app
+apple
+
+query T
+select substring('pineapple' from -5 for 10 )
+----
+apple
+
+query T
+select substr('pineapple', -15, 10 )
+----
+apple
 
 query T
 select substring('pineapple' for 4 )
@@ -16,11 +26,20 @@ apple
 query T
 select substring('pineapple' from 1 for null )
 ----
+null
 
 query T
 select substring('pineapple' from null for 4 )
 ----
+null
 
 query T
 select substring(null from 1 for 4 )
 ----
+null
+
+# issue: https://github.com/KipData/FnckSQL/issues/160
+query T
+select substring('abc', 1, 10);
+----
+abc

--- a/tests/slt/tuple.slt
+++ b/tests/slt/tuple.slt
@@ -33,16 +33,16 @@ select (id, v1) from t1;
 (4, 4)
 
 query T
-select * from t1 where (id,v1) == (1,1);
+select * from t1 where (id,v1) = (1,1);
 ----
 1 1
 
 query T
 select * from t1 where (id,v1) != (1,1);
 ----
-(2, 2)
-(3, 3)
-(4, 4)
+2 2
+3 3
+4 4
 
 query T
 select * from t1 where (id,v1) in ((1,1), (2, 2));
@@ -57,4 +57,4 @@ select * from t1 where (id,v1) not in ((1,1), (2, 2));
 4 4
 
 statement ok
-drop t1
+drop table t1

--- a/tests/slt/union.slt
+++ b/tests/slt/union.slt
@@ -21,7 +21,7 @@ select 1 union all select 1
 1
 1
 
-query T
+query T rowsort
 select (1, 2) union select (2, 1) union select (1, 2)
 ----
 (1, 2)
@@ -33,15 +33,17 @@ create table t1(id int primary key, v1 int unique)
 statement ok
 insert into t1 values (1,1), (2,2), (3,3), (4,4)
 
-query I
-select v1 from t1 union select * from t1
+query I rowsort
+select id from t1 union select v1 from t1
+----
 1
 2
 3
 4
 
 query I rowsort
-select v1 from t1 union all select * from t1
+select id from t1 union all select v1 from t1
+----
 1
 1
 2
@@ -52,4 +54,4 @@ select v1 from t1 union all select * from t1
 4
 
 statement ok
-drop t1
+drop table t1

--- a/tests/slt/update.slt
+++ b/tests/slt/update.slt
@@ -13,6 +13,7 @@ update t set v2 = 9 where v1 = 1
 query IIII rowsort
 select * from t;
 ----
+0 1 9 100
 1 1 9 100
 2 2 20 200
 3 3 30 300
@@ -24,17 +25,19 @@ update t set v2 = 9
 query IIII rowsort
 select * from t
 ----
+0 1 9 100
 1 1 9 100
 2 2 9 200
 3 3 9 300
 4 4 9 400
 
 statement ok
-update t set v2 = default
+update t set v3 = default
 
 query IIII rowsort
 select * from t
 ----
+0 1 9 233
 1 1 9 233
 2 2 9 233
 3 3 9 233


### PR DESCRIPTION
### What problem does this PR solve?

- fix: `substring` for out of bounds error 
  - https://github.com/KipData/FnckSQL/issues/160
- feat: `substring` supports `from` expr as a negative number
- invalid: some slt files have incorrect file suffixes and are not allowed

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
