### PR TITLE
invalid: fix `cfg(linux)` -> `cfg(unix)` & `ScalarExpression::constant_calculation` adds new expression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ tokio-test            = { version = "0.4.3" }
 # Benchmark
 sqlite                = { version = "0.34.0" }
 
-[target.'cfg(linux)'.dev-dependencies]
+[target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.13", features = ["flamegraph", "criterion"] }
 
 [workspace]

--- a/benchmarks/query_benchmark.rs
+++ b/benchmarks/query_benchmark.rs
@@ -3,7 +3,7 @@ use fnck_sql::db::DataBaseBuilder;
 use fnck_sql::errors::DatabaseError;
 use indicatif::{ProgressBar, ProgressStyle};
 use itertools::Itertools;
-#[cfg(linux)]
+#[cfg(unix)]
 use pprof::criterion::{Output, PProfProfiler};
 use sqlite::Error;
 use std::fs;


### PR DESCRIPTION
### What problem does this PR solve?

- fix benchmark errors in ubuntu environment
- `ScalarExpression::constant_calculation` adds new expression

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
