### PR TITLE
perf: Optimize table catalog cache

### DIFF
--- a/src/storage/kip.rs
+++ b/src/storage/kip.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 pub struct KipStorage {
     pub inner: Arc<storage::KipStorage>,
     pub(crate) meta_cache: Arc<ShardingLruCache<TableName, Vec<StatisticsMeta>>>,
+    pub(crate) table_cache: Arc<ShardingLruCache<String, TableCatalog>>,
 }
 
 impl KipStorage {
@@ -31,10 +32,12 @@ impl KipStorage {
             storage::KipStorage::open_with_config(Config::new(path).enable_level_0_memorization())
                 .await?;
         let meta_cache = Arc::new(ShardingLruCache::new(128, 16, RandomState::new()).unwrap());
+        let table_cache = Arc::new(ShardingLruCache::new(128, 16, RandomState::new()).unwrap());
 
         Ok(KipStorage {
             inner: Arc::new(storage),
             meta_cache,
+            table_cache,
         })
     }
 }
@@ -47,7 +50,7 @@ impl Storage for KipStorage {
 
         Ok(KipTransaction {
             tx,
-            table_cache: ShardingLruCache::new(8, 2, RandomState::default())?,
+            table_cache: Arc::clone(&self.table_cache),
             meta_cache: self.meta_cache.clone(),
         })
     }
@@ -55,7 +58,7 @@ impl Storage for KipStorage {
 
 pub struct KipTransaction {
     tx: mvcc::Transaction,
-    table_cache: ShardingLruCache<String, TableCatalog>,
+    table_cache: Arc<ShardingLruCache<String, TableCatalog>>,
     meta_cache: Arc<ShardingLruCache<TableName, Vec<StatisticsMeta>>>,
 }
 


### PR DESCRIPTION
### What problem does this PR solve?


Every time run a sql will create a `KipTransaction` and they all have their all table catalog cache. But table catalog cache may be not changed all the the time. So I move table catalog cache to `KipStorage`, and make `KipTransaction` share this cache.  

Issue link: #162 

### What is changed and how it works?

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
