### PR TITLE
fix: In multi-level nested subquery, the field relationships of different tables are wrong

### DIFF
--- a/src/binder/create_table.rs
+++ b/src/binder/create_table.rs
@@ -142,6 +142,7 @@ mod tests {
     use crate::storage::kip::KipStorage;
     use crate::storage::Storage;
     use crate::types::LogicalType;
+    use std::sync::atomic::AtomicUsize;
     use tempfile::TempDir;
 
     #[tokio::test]
@@ -152,7 +153,11 @@ mod tests {
         let functions = Default::default();
 
         let sql = "create table t1 (id int primary key, name varchar(10) null)";
-        let mut binder = Binder::new(BinderContext::new(&transaction, &functions));
+        let mut binder = Binder::new(BinderContext::new(
+            &transaction,
+            &functions,
+            Arc::new(AtomicUsize::new(0)),
+        ));
         let stmt = crate::parser::parse_sql(sql).unwrap();
         let plan1 = binder.bind(&stmt[0]).unwrap();
 

--- a/src/binder/create_table.rs
+++ b/src/binder/create_table.rs
@@ -153,11 +153,10 @@ mod tests {
         let functions = Default::default();
 
         let sql = "create table t1 (id int primary key, name varchar(10) null)";
-        let mut binder = Binder::new(BinderContext::new(
-            &transaction,
-            &functions,
-            Arc::new(AtomicUsize::new(0)),
-        ));
+        let mut binder = Binder::new(
+            BinderContext::new(&transaction, &functions, Arc::new(AtomicUsize::new(0))),
+            None,
+        );
         let stmt = crate::parser::parse_sql(sql).unwrap();
         let plan1 = binder.bind(&stmt[0]).unwrap();
 

--- a/src/binder/expr.rs
+++ b/src/binder/expr.rs
@@ -306,22 +306,20 @@ impl<'a, T: Transaction> Binder<'a, T> {
         } else {
             let op = |got_column: &mut Option<&'a ColumnRef>, context: &BinderContext<'a, T>| {
                 for table_catalog in context.bind_table.values() {
-                    if let Some(column_catalog) = table_catalog.get_column_by_name(&column_name) {
-                        *got_column = Some(column_catalog);
-                    }
                     if got_column.is_some() {
                         break;
+                    }
+                    if let Some(column_catalog) = table_catalog.get_column_by_name(&column_name) {
+                        *got_column = Some(column_catalog);
                     }
                 }
             };
             // handle col syntax
             let mut got_column = None;
-            op(&mut got_column, &self.context);
 
-            if got_column.is_none() {
-                if let Some(parent) = self.parent {
-                    op(&mut got_column, &parent.context);
-                }
+            op(&mut got_column, &self.context);
+            if let Some(parent) = self.parent {
+                op(&mut got_column, &parent.context);
             }
             let column_catalog =
                 got_column.ok_or_else(|| DatabaseError::NotFound("column", column_name))?;

--- a/src/binder/mod.rs
+++ b/src/binder/mod.rs
@@ -18,6 +18,7 @@ mod update;
 
 use sqlparser::ast::{Ident, ObjectName, ObjectType, SetExpr, Statement};
 use std::collections::{BTreeMap, HashMap};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use crate::catalog::{TableCatalog, TableName};
@@ -55,7 +56,7 @@ pub enum SubQueryType {
 
 #[derive(Clone)]
 pub struct BinderContext<'a, T: Transaction> {
-    functions: &'a Functions,
+    pub(crate) functions: &'a Functions,
     pub(crate) transaction: &'a T,
     // Tips: When there are multiple tables and Wildcard, use BTreeMap to ensure that the order of the output tables is certain.
     pub(crate) bind_table: BTreeMap<(TableName, Option<JoinType>), &'a TableCatalog>,
@@ -69,12 +70,16 @@ pub struct BinderContext<'a, T: Transaction> {
     bind_step: QueryBindStep,
     sub_queries: HashMap<QueryBindStep, Vec<SubQueryType>>,
 
-    temp_table_id: usize,
+    temp_table_id: Arc<AtomicUsize>,
     pub(crate) allow_default: bool,
 }
 
 impl<'a, T: Transaction> BinderContext<'a, T> {
-    pub fn new(transaction: &'a T, functions: &'a Functions) -> Self {
+    pub fn new(
+        transaction: &'a T,
+        functions: &'a Functions,
+        temp_table_id: Arc<AtomicUsize>,
+    ) -> Self {
         BinderContext {
             functions,
             transaction,
@@ -85,14 +90,16 @@ impl<'a, T: Transaction> BinderContext<'a, T> {
             agg_calls: Default::default(),
             bind_step: QueryBindStep::From,
             sub_queries: Default::default(),
-            temp_table_id: 0,
+            temp_table_id,
             allow_default: false,
         }
     }
 
     pub fn temp_table(&mut self) -> TableName {
-        self.temp_table_id += 1;
-        Arc::new(format!("_temp_table_{}_", self.temp_table_id))
+        Arc::new(format!(
+            "_temp_table_{}_",
+            self.temp_table_id.fetch_add(1, Ordering::SeqCst)
+        ))
     }
 
     pub fn step(&mut self, bind_step: QueryBindStep) {
@@ -162,6 +169,33 @@ impl<'a, T: Transaction> BinderContext<'a, T> {
 
     pub fn has_agg_call(&self, expr: &ScalarExpression) -> bool {
         self.group_by_exprs.contains(expr)
+    }
+
+    pub fn merge_context(&mut self, context: BinderContext<'a, T>) -> Result<(), DatabaseError> {
+        let BinderContext {
+            expr_aliases,
+            table_aliases,
+            bind_table,
+            ..
+        } = context;
+
+        for (alias, expr) in expr_aliases {
+            if self.expr_aliases.contains_key(&alias) {
+                return Err(DatabaseError::DuplicateAliasExpr(alias));
+            }
+            self.expr_aliases.insert(alias, expr);
+        }
+        for (alias, table_name) in table_aliases {
+            if self.table_aliases.contains_key(&alias) {
+                return Err(DatabaseError::DuplicateAliasTable(alias));
+            }
+            self.table_aliases.insert(alias, table_name);
+        }
+        for (key, table) in bind_table {
+            self.bind_table.insert(key, table);
+        }
+
+        Ok(())
     }
 }
 
@@ -305,6 +339,7 @@ pub mod test {
     use crate::storage::{Storage, Transaction};
     use crate::types::LogicalType::Integer;
     use std::path::PathBuf;
+    use std::sync::atomic::AtomicUsize;
     use std::sync::Arc;
     use tempfile::TempDir;
 
@@ -358,7 +393,11 @@ pub mod test {
         let storage = build_test_catalog(temp_dir.path()).await?;
         let transaction = storage.transaction().await?;
         let functions = Default::default();
-        let mut binder = Binder::new(BinderContext::new(&transaction, &functions));
+        let mut binder = Binder::new(BinderContext::new(
+            &transaction,
+            &functions,
+            Arc::new(AtomicUsize::new(0)),
+        ));
         let stmt = crate::parser::parse_sql(sql)?;
 
         Ok(binder.bind(&stmt[0])?)

--- a/src/db.rs
+++ b/src/db.rs
@@ -99,11 +99,10 @@ impl<S: Storage> Database<S> {
         if stmts.is_empty() {
             return Err(DatabaseError::EmptyStatement);
         }
-        let mut binder = Binder::new(BinderContext::new(
-            transaction,
-            functions,
-            Arc::new(AtomicUsize::new(0)),
-        ));
+        let mut binder = Binder::new(
+            BinderContext::new(transaction, functions, Arc::new(AtomicUsize::new(0))),
+            None,
+        );
         /// Build a logical plan.
         ///
         /// SELECT a,b FROM t1 ORDER BY a LIMIT 1;

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,6 @@
 use ahash::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
 use crate::binder::{Binder, BinderContext};
@@ -98,7 +99,11 @@ impl<S: Storage> Database<S> {
         if stmts.is_empty() {
             return Err(DatabaseError::EmptyStatement);
         }
-        let mut binder = Binder::new(BinderContext::new(transaction, functions));
+        let mut binder = Binder::new(BinderContext::new(
+            transaction,
+            functions,
+            Arc::new(AtomicUsize::new(0)),
+        ));
         /// Build a logical plan.
         ///
         /// SELECT a,b FROM t1 ORDER BY a LIMIT 1;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,10 +29,6 @@ pub enum DatabaseError {
         #[source]
         csv::Error,
     ),
-    #[error("alias expr: {0} already exists")]
-    DuplicateAliasExpr(String),
-    #[error("alias table: {0} already exists")]
-    DuplicateAliasTable(String),
     #[error("column: {0} already exists")]
     DuplicateColumn(String),
     #[error("index: {0} already exists")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,12 +29,16 @@ pub enum DatabaseError {
         #[source]
         csv::Error,
     ),
-    #[error("duplicate primary key")]
-    DuplicatePrimaryKey,
+    #[error("alias expr: {0} already exists")]
+    DuplicateAliasExpr(String),
+    #[error("alias table: {0} already exists")]
+    DuplicateAliasTable(String),
     #[error("column: {0} already exists")]
     DuplicateColumn(String),
     #[error("index: {0} already exists")]
     DuplicateIndex(String),
+    #[error("duplicate primary key")]
+    DuplicatePrimaryKey,
     #[error("the column has been declared unique and the value already exists")]
     DuplicateUniqueValue,
     #[error("empty plan")]

--- a/src/optimizer/core/memo.rs
+++ b/src/optimizer/core/memo.rs
@@ -98,6 +98,7 @@ mod tests {
     use crate::types::LogicalType;
     use petgraph::stable_graph::NodeIndex;
     use std::ops::Bound;
+    use std::sync::atomic::AtomicUsize;
     use std::sync::Arc;
     use tempfile::TempDir;
 
@@ -121,7 +122,11 @@ mod tests {
 
         let transaction = database.storage.transaction().await?;
         let functions = Default::default();
-        let mut binder = Binder::new(BinderContext::new(&transaction, &functions));
+        let mut binder = Binder::new(BinderContext::new(
+            &transaction,
+            &functions,
+            Arc::new(AtomicUsize::new(0)),
+        ));
         let stmt = crate::parser::parse_sql(
             // FIXME: Only by bracketing (c1 > 40 or c1 = 2) can the filter be pushed down below the join
             "select c1, c3 from t1 inner join t2 on c1 = c3 where (c1 > 40 or c1 = 2) and c3 > 22",

--- a/src/optimizer/core/memo.rs
+++ b/src/optimizer/core/memo.rs
@@ -122,11 +122,10 @@ mod tests {
 
         let transaction = database.storage.transaction().await?;
         let functions = Default::default();
-        let mut binder = Binder::new(BinderContext::new(
-            &transaction,
-            &functions,
-            Arc::new(AtomicUsize::new(0)),
-        ));
+        let mut binder = Binder::new(
+            BinderContext::new(&transaction, &functions, Arc::new(AtomicUsize::new(0))),
+            None,
+        );
         let stmt = crate::parser::parse_sql(
             // FIXME: Only by bracketing (c1 > 40 or c1 = 2) can the filter be pushed down below the join
             "select c1, c3 from t1 inner join t2 on c1 = c3 where (c1 > 40 or c1 = 2) and c3 > 22",

--- a/tests/slt/subquery.slt
+++ b/tests/slt/subquery.slt
@@ -72,10 +72,10 @@ select * from t1 where a not in (select 1) and b = 3
 statement ok
 drop table t1;
 
+# https://github.com/KipData/FnckSQL/issues/169
 statement ok
 create table t2(id int primary key, a int not null, b int not null);
 
-# https://github.com/KipData/FnckSQL/issues/169
 statement ok
 create table t3(id int primary key, a int not null, c int not null);
 

--- a/tests/slt/subquery.slt
+++ b/tests/slt/subquery.slt
@@ -39,10 +39,10 @@ select * from t1 where a <= (select 4) and a > (select 1)
 ----
 1 3 4
 
-# query III
-# select * from t1 where a <= (select 4) and (-a + 1) < (select 1) - 1
-# ----
-# 1 3 4
+query III
+select * from t1 where a <= (select 4) and (-a + 1) < (select 1) - 1
+----
+1 3 4
 
 statement ok
 insert into t1 values (2, 3, 3), (3, 1, 4);
@@ -71,3 +71,28 @@ select * from t1 where a not in (select 1) and b = 3
 
 statement ok
 drop table t1;
+
+statement ok
+create table t2(id int primary key, a int not null, b int not null);
+
+# https://github.com/KipData/FnckSQL/issues/169
+statement ok
+create table t3(id int primary key, a int not null, c int not null);
+
+statement ok
+insert into t2 values (0, 1, 2), (3, 4, 5);
+
+statement ok
+insert into t3 values (0, 2, 2), (3, 8, 5);
+
+query III
+SELECT id, a, b FROM t2 WHERE a*2 in (SELECT a FROM t3 where a/2 in (select a from t2));
+----
+0 1 2
+3 4 5
+
+statement ok
+drop table t2;
+
+statement ok
+drop table t3;


### PR DESCRIPTION
### What problem does this PR solve?
ref:
- https://github.com/duckdb/duckdb/blob/main/src/planner/binder/tableref/bind_subqueryref.cpp#L7C1-L31C2

Issue link: https://github.com/KipData/FnckSQL/issues/169


```shell
explain SELECT b FROM t1 WHERE a in (SELECT a FROM t2 where a in (select a from t1));

+-------------------------------------------------------------------------+
| PLAN                                                                    |
+=========================================================================+
| Projection [t1.b] [Project]                                             |
|   LeftSemi Join On t1.a = (t2.a) as (_temp_table_1_.a) [HashJoin]       |
|     Scan t1 -> [a, b] [SeqScan]                                         |
|     Projection [(t2.a) as (_temp_table_1_.a)] [Project]                 |
|       Projection [t2.a] [Project]                                       |
|         LeftSemi Join On t2.a = (t1.a) as (_temp_table_0_.a) [HashJoin] |
|           Scan t2 -> [a] [SeqScan]                                      |
|           Projection [(t1.a) as (_temp_table_0_.a)] [Project]           |
|             Projection [t1.a] [Project]                                 |
|               Scan t1 -> [a] [SeqScan]                                  |
+-------------------------------------------------------------------------+
```

### What is changed and how it works?

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
