### PR TITLE
feat: support `Expression` on `Default`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ strum_macros          = { version = "0.26.2" }
 thiserror             = { version = "1.0.58" }
 tokio                 = { version = "1.36.0", features = ["full"] }
 tracing               = { version = "0.1.40" }
+typetag               = { version = "0.2" }
 
 [dev-dependencies]
 cargo-tarpaulin       = { version = "0.27.1" }

--- a/src/binder/insert.rs
+++ b/src/binder/insert.rs
@@ -78,11 +78,10 @@ impl<'a, T: Transaction> Binder<'a, T> {
                         row.push(value);
                     }
                     ScalarExpression::Empty => {
-                        row.push(schema_ref[i].default_value().ok_or_else(|| {
-                            DatabaseError::InvalidColumn(
-                                "column does not exist default".to_string(),
-                            )
-                        })?);
+                        let default_value = schema_ref[i]
+                            .default_value()?
+                            .ok_or(DatabaseError::DefaultNotExist)?;
+                        row.push(default_value);
                     }
                     _ => return Err(DatabaseError::UnsupportedStmt(expr.to_string())),
                 }

--- a/src/binder/update.rs
+++ b/src/binder/update.rs
@@ -53,11 +53,10 @@ impl<'a, T: Transaction> Binder<'a, T> {
                                     row.push(value.clone());
                                 }
                                 ScalarExpression::Empty => {
-                                    row.push(column.default_value().ok_or_else(|| {
-                                        DatabaseError::InvalidColumn(
-                                            "column does not exist default".to_string(),
-                                        )
-                                    })?);
+                                    let default_value = column
+                                        .default_value()?
+                                        .ok_or(DatabaseError::DefaultNotExist)?;
+                                    row.push(default_value);
                                 }
                                 _ => return Err(DatabaseError::UnsupportedStmt(value.to_string())),
                             }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,6 +29,8 @@ pub enum DatabaseError {
         #[source]
         csv::Error,
     ),
+    #[error("default does not exist")]
+    DefaultNotExist,
     #[error("column: {0} already exists")]
     DuplicateColumn(String),
     #[error("index: {0} already exists")]

--- a/src/execution/volcano/ddl/add_column.rs
+++ b/src/execution/volcano/ddl/add_column.rs
@@ -50,7 +50,7 @@ impl AddColumn {
         for tuple in build_read(self.input, transaction) {
             let mut tuple: Tuple = tuple?;
 
-            if let Some(value) = column.default_value() {
+            if let Some(value) = column.default_value()? {
                 if let Some(unique_values) = &mut unique_values {
                     unique_values.push((tuple.id.clone().unwrap(), value.clone()));
                 }

--- a/src/execution/volcano/dml/insert.rs
+++ b/src/execution/volcano/dml/insert.rs
@@ -76,10 +76,14 @@ impl Insert {
                 let mut values = Vec::with_capacity(table_catalog.columns_len());
 
                 for col in table_catalog.columns() {
-                    let value = tuple_map
-                        .remove(&col.id())
-                        .or_else(|| col.default_value())
-                        .unwrap_or_else(|| Arc::new(DataValue::none(col.datatype())));
+                    let value = {
+                        let mut value = tuple_map.remove(&col.id());
+
+                        if value.is_none() {
+                            value = col.default_value()?;
+                        }
+                        value.unwrap_or_else(|| Arc::new(DataValue::none(col.datatype())))
+                    };
                     if value.is_null() && !col.nullable {
                         return Err(DatabaseError::NotNull);
                     }

--- a/src/execution/volcano/dql/describe.rs
+++ b/src/execution/volcano/dql/describe.rs
@@ -52,6 +52,12 @@ impl Describe {
 
         for column in table.columns() {
             let datatype = column.datatype();
+            let default = column
+                .desc
+                .default
+                .as_ref()
+                .map(|expr| format!("{}", expr))
+                .unwrap_or_else(|| "null".to_string());
             let values = vec![
                 Arc::new(DataValue::Utf8(Some(column.name().to_string()))),
                 Arc::new(DataValue::Utf8(Some(datatype.to_string()))),
@@ -63,9 +69,7 @@ impl Describe {
                 ))),
                 Arc::new(DataValue::Utf8(Some(column.nullable.to_string()))),
                 key_fn(column),
-                column
-                    .default_value()
-                    .unwrap_or_else(|| Arc::new(DataValue::none(datatype))),
+                Arc::new(DataValue::Utf8(Some(default))),
             ];
             yield Tuple { id: None, values };
         }

--- a/src/expression/function.rs
+++ b/src/expression/function.rs
@@ -4,6 +4,7 @@ use crate::expression::ScalarExpression;
 use crate::types::tuple::Tuple;
 use crate::types::value::DataValue;
 use crate::types::LogicalType;
+use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
@@ -14,7 +15,7 @@ use std::sync::Arc;
 /// - `Some(false)` monotonically decreasing
 pub type FuncMonotonicity = Vec<Option<bool>>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScalarFunction {
     pub(crate) args: Vec<ScalarExpression>,
     pub(crate) inner: Arc<dyn ScalarFunctionImpl>,
@@ -34,12 +35,13 @@ impl Hash for ScalarFunction {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize)]
 pub struct FunctionSummary {
     pub(crate) name: String,
     pub(crate) arg_types: Vec<LogicalType>,
 }
 
+#[typetag::serde(tag = "type")]
 pub trait ScalarFunctionImpl: Debug + Send + Sync {
     fn eval(
         &self,

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -20,7 +20,7 @@ pub mod range_detacher;
 pub mod simplify;
 pub mod value_compute;
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
 pub enum AliasType {
     Name(String),
     Expr(Box<ScalarExpression>),
@@ -30,7 +30,7 @@ pub enum AliasType {
 /// SELECT a+1, b FROM t1.
 /// a+1 -> ScalarExpression::Unary(a + 1)
 /// b   -> ScalarExpression::ColumnRef()
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
 pub enum ScalarExpression {
     Constant(ValueRef),
     ColumnRef(ColumnRef),

--- a/src/marcos/mod.rs
+++ b/src/marcos/mod.rs
@@ -68,7 +68,7 @@ macro_rules! implement_from_tuple {
 #[macro_export]
 macro_rules! function {
     ($struct_name:ident::$function_name:ident($($arg_ty:expr),*) -> $return_ty:expr => $closure:expr) => {
-        #[derive(Debug)]
+        #[derive(Debug, Serialize, Deserialize)]
         pub(crate) struct $struct_name {
             summary: FunctionSummary
         }
@@ -91,6 +91,7 @@ macro_rules! function {
             }
         }
 
+        #[typetag::serde]
         impl ScalarFunctionImpl for $struct_name {
             fn eval(&self, args: &[ScalarExpression], tuple: &Tuple, schema: &[ColumnRef]) -> Result<DataValue, DatabaseError> {
                 let mut _index = 0;
@@ -132,6 +133,8 @@ mod test {
     use crate::types::tuple::{SchemaRef, Tuple};
     use crate::types::value::{DataValue, ValueRef};
     use crate::types::LogicalType;
+    use serde::Deserialize;
+    use serde::Serialize;
     use std::sync::Arc;
 
     fn build_tuple() -> (Tuple, SchemaRef) {
@@ -187,9 +190,9 @@ mod test {
         assert_eq!(my_struct.c2, "LOL");
     }
 
-    function!(MyFunction::sum(LogicalType::Integer, LogicalType::Integer) -> LogicalType::Integer => |v1: ValueRef, v2: ValueRef| {
+    function!(MyFunction::sum(LogicalType::Integer, LogicalType::Integer) -> LogicalType::Integer => (|v1: ValueRef, v2: ValueRef| {
         DataValue::binary_op(&v1, &v2, &BinaryOperator::Plus)
-    });
+    }));
 
     #[test]
     fn test_function() -> Result<(), DatabaseError> {

--- a/src/storage/kip.rs
+++ b/src/storage/kip.rs
@@ -232,7 +232,7 @@ impl Transaction for KipTransaction {
         if_not_exists: bool,
     ) -> Result<ColumnId, DatabaseError> {
         if let Some(mut table) = self.table(table_name.clone()).cloned() {
-            if !column.nullable && column.default_value().is_none() {
+            if !column.nullable && column.default_value()?.is_none() {
                 return Err(DatabaseError::NeedNullAbleOrDefault);
             }
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -4,7 +4,17 @@ use crate::types::LogicalType;
 use comfy_table::{Cell, Table};
 use integer_encoding::FixedInt;
 use itertools::Itertools;
+use lazy_static::lazy_static;
 use std::sync::Arc;
+
+lazy_static! {
+    pub static ref EMPTY_TUPLE: Tuple = {
+        Tuple {
+            id: None,
+            values: vec![],
+        }
+    };
+}
 
 const BITS_MAX_INDEX: usize = 8;
 

--- a/tests/slt/create.slt
+++ b/tests/slt/create.slt
@@ -21,3 +21,6 @@ create table if not exists t(id int primary key, v1 int, v2 int, v3 int)
 
 statement ok
 create table if not exists t(id int primary key, v1 int, v2 int, v3 int)
+
+statement error
+create table test_default_expr(id int primary key, v1 int, v2 int, v3 int default (v1 + 1))


### PR DESCRIPTION
### What problem does this PR solve?

prefix function of `CURRENT_DATE` on SQL 2016

e.g.
on udf test
function: test(arg1, arg2)
`CREATE TABLE test (id int primary key, c1 int, c2 int default test(1, 2));`

Issue link:

### What is changed and how it works?

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
