### PR TITLE
fix: expand `DataValue::Utf8` so that it can correspond to `Char` and `Varchar` respectively.

### DIFF
--- a/src/binder/expr.rs
+++ b/src/binder/expr.rs
@@ -15,7 +15,7 @@ use crate::expression::function::{FunctionSummary, ScalarFunction};
 use crate::expression::{AliasType, ScalarExpression};
 use crate::planner::LogicalPlan;
 use crate::storage::Transaction;
-use crate::types::value::DataValue;
+use crate::types::value::{DataValue, Utf8Type};
 use crate::types::LogicalType;
 
 macro_rules! try_alias {
@@ -67,7 +67,11 @@ impl<'a, T: Transaction> Binder<'a, T> {
             } => self.bind_cast(expr, data_type),
             Expr::TypedString { data_type, value } => {
                 let logical_type = LogicalType::try_from(data_type.clone())?;
-                let value = DataValue::Utf8(Some(value.to_string())).cast(&logical_type)?;
+                let value = DataValue::Utf8 {
+                    value: Some(value.to_string()),
+                    ty: Utf8Type::Variable,
+                }
+                .cast(&logical_type)?;
 
                 Ok(ScalarExpression::Constant(Arc::new(value)))
             }
@@ -597,6 +601,9 @@ impl<'a, T: Transaction> Binder<'a, T> {
     }
 
     fn wildcard_expr() -> ScalarExpression {
-        ScalarExpression::Constant(Arc::new(DataValue::Utf8(Some("*".to_string()))))
+        ScalarExpression::Constant(Arc::new(DataValue::Utf8 {
+            value: Some("*".to_string()),
+            ty: Utf8Type::Variable,
+        }))
     }
 }

--- a/src/execution/volcano/dml/analyze.rs
+++ b/src/execution/volcano/dml/analyze.rs
@@ -9,7 +9,7 @@ use crate::planner::LogicalPlan;
 use crate::storage::Transaction;
 use crate::types::index::IndexMetaRef;
 use crate::types::tuple::Tuple;
-use crate::types::value::DataValue;
+use crate::types::value::{DataValue, Utf8Type};
 use futures_async_stream::try_stream;
 use itertools::Itertools;
 use std::fmt::Formatter;
@@ -106,7 +106,10 @@ impl Analyze {
             let meta = StatisticsMeta::new(histogram, sketch);
 
             meta.to_file(&path)?;
-            values.push(Arc::new(DataValue::Utf8(Some(path.clone()))));
+            values.push(Arc::new(DataValue::Utf8 {
+                value: Some(path.clone()),
+                ty: Utf8Type::Variable,
+            }));
             transaction.save_table_meta(&table_name, path, meta)?;
         }
         yield Tuple { id: None, values };

--- a/src/execution/volcano/dql/describe.rs
+++ b/src/execution/volcano/dql/describe.rs
@@ -4,16 +4,24 @@ use crate::execution::volcano::{BoxedExecutor, ReadExecutor};
 use crate::planner::operator::describe::DescribeOperator;
 use crate::storage::Transaction;
 use crate::types::tuple::Tuple;
-use crate::types::value::{DataValue, ValueRef};
+use crate::types::value::{DataValue, Utf8Type, ValueRef};
 use futures_async_stream::try_stream;
 use lazy_static::lazy_static;
 use std::sync::Arc;
 
 lazy_static! {
-    static ref PRIMARY_KEY_TYPE: ValueRef =
-        Arc::new(DataValue::Utf8(Some(String::from("PRIMARY"))));
-    static ref UNIQUE_KEY_TYPE: ValueRef = Arc::new(DataValue::Utf8(Some(String::from("UNIQUE"))));
-    static ref EMPTY_KEY_TYPE: ValueRef = Arc::new(DataValue::Utf8(Some(String::from("EMPTY"))));
+    static ref PRIMARY_KEY_TYPE: ValueRef = Arc::new(DataValue::Utf8 {
+        value: Some(String::from("PRIMARY")),
+        ty: Utf8Type::Variable
+    });
+    static ref UNIQUE_KEY_TYPE: ValueRef = Arc::new(DataValue::Utf8 {
+        value: Some(String::from("UNIQUE")),
+        ty: Utf8Type::Variable
+    });
+    static ref EMPTY_KEY_TYPE: ValueRef = Arc::new(DataValue::Utf8 {
+        value: Some(String::from("EMPTY")),
+        ty: Utf8Type::Variable
+    });
 }
 
 pub struct Describe {
@@ -59,17 +67,27 @@ impl Describe {
                 .map(|expr| format!("{}", expr))
                 .unwrap_or_else(|| "null".to_string());
             let values = vec![
-                Arc::new(DataValue::Utf8(Some(column.name().to_string()))),
-                Arc::new(DataValue::Utf8(Some(datatype.to_string()))),
-                Arc::new(DataValue::Utf8(Some(
-                    datatype
-                        .raw_len()
-                        .map(|len| len.to_string())
-                        .unwrap_or_else(|| "DYNAMIC".to_string()),
-                ))),
-                Arc::new(DataValue::Utf8(Some(column.nullable.to_string()))),
+                Arc::new(DataValue::Utf8 {
+                    value: Some(column.name().to_string()),
+                    ty: Utf8Type::Variable,
+                }),
+                Arc::new(DataValue::Utf8 {
+                    value: Some(datatype.to_string()),
+                    ty: Utf8Type::Variable,
+                }),
+                Arc::new(DataValue::Utf8 {
+                    value: datatype.raw_len().map(|len| len.to_string()),
+                    ty: Utf8Type::Variable,
+                }),
+                Arc::new(DataValue::Utf8 {
+                    value: Some(column.nullable.to_string()),
+                    ty: Utf8Type::Variable,
+                }),
                 key_fn(column),
-                Arc::new(DataValue::Utf8(Some(default))),
+                Arc::new(DataValue::Utf8 {
+                    value: Some(default),
+                    ty: Utf8Type::Variable,
+                }),
             ];
             yield Tuple { id: None, values };
         }

--- a/src/execution/volcano/dql/explain.rs
+++ b/src/execution/volcano/dql/explain.rs
@@ -3,7 +3,7 @@ use crate::execution::volcano::{BoxedExecutor, ReadExecutor};
 use crate::planner::LogicalPlan;
 use crate::storage::Transaction;
 use crate::types::tuple::Tuple;
-use crate::types::value::DataValue;
+use crate::types::value::{DataValue, Utf8Type};
 use futures_async_stream::try_stream;
 use std::sync::Arc;
 
@@ -26,7 +26,10 @@ impl<T: Transaction> ReadExecutor<T> for Explain {
 impl Explain {
     #[try_stream(boxed, ok = Tuple, error = DatabaseError)]
     pub async fn _execute(self) {
-        let values = vec![Arc::new(DataValue::Utf8(Some(self.plan.explain(0))))];
+        let values = vec![Arc::new(DataValue::Utf8 {
+            value: Some(self.plan.explain(0)),
+            ty: Utf8Type::Variable,
+        })];
 
         yield Tuple { id: None, values };
     }

--- a/src/execution/volcano/dql/show_table.rs
+++ b/src/execution/volcano/dql/show_table.rs
@@ -3,7 +3,7 @@ use crate::errors::DatabaseError;
 use crate::execution::volcano::{BoxedExecutor, ReadExecutor};
 use crate::storage::Transaction;
 use crate::types::tuple::Tuple;
-use crate::types::value::DataValue;
+use crate::types::value::{DataValue, Utf8Type};
 use futures_async_stream::try_stream;
 use std::sync::Arc;
 
@@ -21,7 +21,10 @@ impl ShowTables {
         let metas = transaction.table_metas()?;
 
         for TableMeta { table_name } in metas {
-            let values = vec![Arc::new(DataValue::Utf8(Some(table_name.to_string())))];
+            let values = vec![Arc::new(DataValue::Utf8 {
+                value: Some(table_name.to_string()),
+                ty: Utf8Type::Variable,
+            })];
 
             yield Tuple { id: None, values };
         }

--- a/src/expression/evaluator.rs
+++ b/src/expression/evaluator.rs
@@ -3,7 +3,7 @@ use crate::errors::DatabaseError;
 use crate::expression::function::ScalarFunction;
 use crate::expression::{AliasType, BinaryOperator, ScalarExpression};
 use crate::types::tuple::Tuple;
-use crate::types::value::{DataValue, ValueRef};
+use crate::types::value::{DataValue, Utf8Type, ValueRef};
 use crate::types::LogicalType;
 use itertools::Itertools;
 use lazy_static::lazy_static;
@@ -23,7 +23,10 @@ macro_rules! eval_to_num {
         {
             num_i32
         } else {
-            return Ok(Arc::new(DataValue::Utf8(None)));
+            return Ok(Arc::new(DataValue::Utf8 {
+                value: None,
+                ty: Utf8Type::Variable,
+            }));
         }
     };
 }
@@ -164,7 +167,10 @@ impl ScalarExpression {
                             from += len_i + 1;
                         }
                         if from > len_i {
-                            return Ok(Arc::new(DataValue::Utf8(None)));
+                            return Ok(Arc::new(DataValue::Utf8 {
+                                value: None,
+                                ty: Utf8Type::Variable,
+                            }));
                         }
                         string = string.split_off(from as usize);
                     }
@@ -174,9 +180,15 @@ impl ScalarExpression {
                         let _ = string.split_off(for_i);
                     }
 
-                    Ok(Arc::new(DataValue::Utf8(Some(string))))
+                    Ok(Arc::new(DataValue::Utf8 {
+                        value: Some(string),
+                        ty: Utf8Type::Variable,
+                    }))
                 } else {
-                    Ok(Arc::new(DataValue::Utf8(None)))
+                    Ok(Arc::new(DataValue::Utf8 {
+                        value: None,
+                        ty: Utf8Type::Variable,
+                    }))
                 }
             }
             ScalarExpression::Position { expr, in_expr } => {

--- a/src/expression/value_compute.rs
+++ b/src/expression/value_compute.rs
@@ -1,6 +1,6 @@
 use crate::errors::DatabaseError;
 use crate::expression::{BinaryOperator, UnaryOperator};
-use crate::types::value::{DataValue, ValueRef};
+use crate::types::value::{DataValue, Utf8Type, ValueRef};
 use crate::types::LogicalType;
 use regex::Regex;
 use std::cmp::Ordering;
@@ -14,7 +14,7 @@ fn unpack_bool(value: DataValue) -> Option<bool> {
 
 fn unpack_utf8(value: DataValue) -> Option<String> {
     match value {
-        DataValue::Utf8(inner) => inner,
+        DataValue::Utf8 { value: inner, .. } => inner,
         _ => None,
     }
 }
@@ -574,7 +574,10 @@ impl DataValue {
                             _ => None,
                         };
 
-                        DataValue::Utf8(value)
+                        DataValue::Utf8 {
+                            value,
+                            ty: Utf8Type::Variable,
+                        }
                     }
                     _ => return Err(DatabaseError::UnsupportedBinaryOperator(unified_type, *op)),
                 }

--- a/src/optimizer/core/histogram.rs
+++ b/src/optimizer/core/histogram.rs
@@ -256,7 +256,7 @@ impl Histogram {
         let float_value = |value: &DataValue, prefix_len: usize| {
             let value = match value.logical_type() {
                 LogicalType::Varchar(_) | LogicalType::Char(_) => match value {
-                    DataValue::Utf8(value) => value.as_ref().map(|string| {
+                    DataValue::Utf8 { value, .. } => value.as_ref().map(|string| {
                         if prefix_len > string.len() {
                             return 0.0;
                         }

--- a/src/optimizer/rule/normalization/column_pruning.rs
+++ b/src/optimizer/rule/normalization/column_pruning.rs
@@ -6,7 +6,7 @@ use crate::optimizer::core::pattern::{Pattern, PatternChildrenPredicate};
 use crate::optimizer::core::rule::{MatchPattern, NormalizationRule};
 use crate::optimizer::heuristic::graph::{HepGraph, HepNodeId};
 use crate::planner::operator::Operator;
-use crate::types::value::DataValue;
+use crate::types::value::{DataValue, Utf8Type};
 use crate::types::LogicalType;
 use itertools::Itertools;
 use lazy_static::lazy_static;
@@ -61,7 +61,10 @@ impl ColumnPruning {
                     Self::clear_exprs(&column_references, &mut op.agg_calls);
 
                     if op.agg_calls.is_empty() && op.groupby_exprs.is_empty() {
-                        let value = Arc::new(DataValue::Utf8(Some("*".to_string())));
+                        let value = Arc::new(DataValue::Utf8 {
+                            value: Some("*".to_string()),
+                            ty: Utf8Type::Variable,
+                        });
                         // only single COUNT(*) is not depend on any column
                         // removed all expressions from the aggregate: push a COUNT(*)
                         op.agg_calls.push(ScalarExpression::AggCall {

--- a/src/storage/table_codec.rs
+++ b/src/storage/table_codec.rs
@@ -227,7 +227,7 @@ impl TableCodec {
     ) -> Result<(Bytes, Bytes), DatabaseError> {
         let key = TableCodec::encode_index_key(name, index, Some(tuple_id))?;
         let mut bytes = Vec::new();
-        tuple_id.to_raw(&mut bytes, None)?;
+        tuple_id.to_raw(&mut bytes)?;
 
         Ok((Bytes::from(key), Bytes::from(bytes)))
     }
@@ -269,7 +269,7 @@ impl TableCodec {
 
         if let Some(tuple_id) = tuple_id {
             if matches!(index.ty, IndexType::Normal | IndexType::Composite) {
-                tuple_id.to_raw(&mut key_prefix, None)?;
+                tuple_id.to_raw(&mut key_prefix)?;
             }
         }
         Ok(key_prefix)

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -125,7 +125,7 @@ impl Tuple {
                 bytes[i / BITS_MAX_INDEX] = flip_bit(bytes[i / BITS_MAX_INDEX], i % BITS_MAX_INDEX);
             } else {
                 let logical_type = types[i];
-                let value_len = value.to_raw(&mut bytes, Some(logical_type))?;
+                let value_len = value.to_raw(&mut bytes)?;
 
                 if logical_type.raw_len().is_none() {
                     let index = bytes.len() - value_len;

--- a/src/types/tuple_builder.rs
+++ b/src/types/tuple_builder.rs
@@ -1,6 +1,6 @@
 use crate::errors::DatabaseError;
 use crate::types::tuple::{Schema, Tuple};
-use crate::types::value::DataValue;
+use crate::types::value::{DataValue, Utf8Type};
 use std::sync::Arc;
 
 pub struct TupleBuilder<'a> {
@@ -13,7 +13,10 @@ impl<'a> TupleBuilder<'a> {
     }
 
     pub fn build_result(message: String) -> Tuple {
-        let values = vec![Arc::new(DataValue::Utf8(Some(message)))];
+        let values = vec![Arc::new(DataValue::Utf8 {
+            value: Some(message),
+            ty: Utf8Type::Variable,
+        })];
 
         Tuple { id: None, values }
     }
@@ -26,8 +29,13 @@ impl<'a> TupleBuilder<'a> {
         let mut primary_key = None;
 
         for (i, value) in row.into_iter().enumerate() {
-            let data_value =
-                Arc::new(DataValue::Utf8(Some(value.to_string())).cast(self.schema[i].datatype())?);
+            let data_value = Arc::new(
+                DataValue::Utf8 {
+                    value: Some(value.to_string()),
+                    ty: Utf8Type::Variable,
+                }
+                .cast(self.schema[i].datatype())?,
+            );
 
             if primary_key.is_none() && self.schema[i].desc.is_primary {
                 primary_key = Some(data_value.clone());


### PR DESCRIPTION
### What problem does this PR solve?
originally, both `LogicalType::Char` and `LogicalType::Varchar` used `DataValue::Utf8`, but `DataValue::Utf8` does not know its own logical_type


### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
