### PR TITLE
fix: memcomparable for `DataValue::Tuple`

### DIFF
--- a/src/storage/table_codec.rs
+++ b/src/storage/table_codec.rs
@@ -211,7 +211,7 @@ impl TableCodec {
     }
 
     /// NonUnique Index:
-    /// Key: {TableName}{INDEX_TAG}{BOUND_MIN_TAG}{IndexID}{BOUND_MIN_TAG}{DataValue1}{DataValue2} .. {TupleId}
+    /// Key: {TableName}{INDEX_TAG}{BOUND_MIN_TAG}{IndexID}{BOUND_MIN_TAG}{DataValue1}{BOUND_MIN_TAG}{DataValue2} .. {TupleId}
     /// Value: TupleID
     ///
     /// Unique Index:

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3,7 +3,7 @@ pub mod tuple;
 pub mod tuple_builder;
 pub mod value;
 
-use chrono::{NaiveDate, NaiveDateTime};
+use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::any::TypeId;
@@ -72,6 +72,8 @@ impl LogicalType {
             Some(LogicalType::Date)
         } else if type_id == TypeId::of::<NaiveDateTime>() {
             Some(LogicalType::DateTime)
+        } else if type_id == TypeId::of::<NaiveTime>() {
+            Some(LogicalType::Time)
         } else if type_id == TypeId::of::<Decimal>() {
             Some(LogicalType::Decimal(None, None))
         } else if type_id == TypeId::of::<String>() {

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -807,6 +807,7 @@ impl DataValue {
             DataValue::Tuple(Some(values)) => {
                 for v in values.iter() {
                     v.memcomparable_encode(b)?;
+                    b.push(0u8);
                 }
             }
             value => {
@@ -1571,6 +1572,7 @@ impl fmt::Debug for DataValue {
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
     use crate::errors::DatabaseError;
     use crate::types::value::DataValue;
 
@@ -1658,6 +1660,36 @@ mod test {
         println!("{:?} < {:?}", key_f64_2, key_f64_3);
         assert!(key_f64_1 < key_f64_2);
         assert!(key_f64_2 < key_f64_3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_mem_comparable_tuple() -> Result<(), DatabaseError> {
+        let mut key_tuple_1 = Vec::new();
+        let mut key_tuple_2 = Vec::new();
+        let mut key_tuple_3 = Vec::new();
+
+        DataValue::Tuple(Some(vec![
+            Arc::new(DataValue::Int8(None)),
+            Arc::new(DataValue::Int8(Some(0))),
+            Arc::new(DataValue::Int8(Some(1))),
+        ])).memcomparable_encode(&mut key_tuple_1)?;
+        DataValue::Tuple(Some(vec![
+            Arc::new(DataValue::Int8(Some(0))),
+            Arc::new(DataValue::Int8(Some(0))),
+            Arc::new(DataValue::Int8(Some(1))),
+        ])).memcomparable_encode(&mut key_tuple_2)?;
+        DataValue::Tuple(Some(vec![
+            Arc::new(DataValue::Int8(Some(0))),
+            Arc::new(DataValue::Int8(Some(0))),
+            Arc::new(DataValue::Int8(Some(2))),
+        ])).memcomparable_encode(&mut key_tuple_3)?;
+
+        println!("{:?} < {:?}", key_tuple_1, key_tuple_2);
+        println!("{:?} < {:?}", key_tuple_2, key_tuple_3);
+        assert!(key_tuple_1 < key_tuple_2);
+        assert!(key_tuple_2 < key_tuple_3);
 
         Ok(())
     }

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -1572,9 +1572,9 @@ impl fmt::Debug for DataValue {
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
     use crate::errors::DatabaseError;
     use crate::types::value::DataValue;
+    use std::sync::Arc;
 
     #[test]
     fn test_mem_comparable_int() -> Result<(), DatabaseError> {
@@ -1674,17 +1674,20 @@ mod test {
             Arc::new(DataValue::Int8(None)),
             Arc::new(DataValue::Int8(Some(0))),
             Arc::new(DataValue::Int8(Some(1))),
-        ])).memcomparable_encode(&mut key_tuple_1)?;
+        ]))
+        .memcomparable_encode(&mut key_tuple_1)?;
         DataValue::Tuple(Some(vec![
             Arc::new(DataValue::Int8(Some(0))),
             Arc::new(DataValue::Int8(Some(0))),
             Arc::new(DataValue::Int8(Some(1))),
-        ])).memcomparable_encode(&mut key_tuple_2)?;
+        ]))
+        .memcomparable_encode(&mut key_tuple_2)?;
         DataValue::Tuple(Some(vec![
             Arc::new(DataValue::Int8(Some(0))),
             Arc::new(DataValue::Int8(Some(0))),
             Arc::new(DataValue::Int8(Some(2))),
-        ])).memcomparable_encode(&mut key_tuple_3)?;
+        ]))
+        .memcomparable_encode(&mut key_tuple_3)?;
 
         println!("{:?} < {:?}", key_tuple_1, key_tuple_2);
         println!("{:?} < {:?}", key_tuple_2, key_tuple_3);


### PR DESCRIPTION
### What problem does this PR solve?

Insert 0u8 as the delimiter when encoding values ​​to avoid confusion when it is null.

Refer to `TableCodec::encode_index`
```rust
/// NonUnique Index:
/// Key: {TableName}{INDEX_TAG}{BOUND_MIN_TAG}{IndexID}{BOUND_MIN_TAG}{DataValue1}{BOUND_MIN_TAG}{DataValue2} .. {TupleId}
/// Value: TupleID
```

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
