### PR TITLE
fix: bind correlated subqueries

### DIFF
--- a/src/binder/expr.rs
+++ b/src/binder/expr.rs
@@ -299,7 +299,7 @@ impl<'a, T: Transaction> Binder<'a, T> {
             try_default!(&table_name, column_name);
         }
         if let Some(table) = table_name.or(bind_table_name) {
-            let table_catalog = self.context.bind_table(&table)?;
+            let table_catalog = self.context.bind_table(&table, self.parent)?;
 
             let column_catalog = table_catalog
                 .get_column_by_name(&column_name)


### PR DESCRIPTION
### What problem does this PR solve?


Issue link: #192 

there is something wrong when binding correlated subqueries because parent context is ignored.

```sql
explain select a,b from t where a in (select a from t1 where a > t.a);
ERROR:  invalid table: t
```

This PR is to resolve this problem


### What is changed and how it works?

the main idea is to take parent binder into consideration, too. After changing, it looks like this:

```sql
                               PLAN
------------------------------------------------------------------
 Projection [t.a, t.b] [Project]                                 +
   LeftSemi Join On t.a = (t1.a) as (_temp_table_0_.a) [HashJoin]+
     Scan t -> [a, b] [SeqScan]                                  +
     Projection [(t1.a) as (_temp_table_0_.a)] [Project]         +
       Projection [t1.a] [Project]                               +
         Filter (t1.a > t.a), Is Having: false [Filter]          +
           Scan t1 -> [a] [SeqScan]
```

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
