### PR TITLE
feat: add support for `TRIM()`

### DIFF
--- a/src/binder/aggregate.rs
+++ b/src/binder/aggregate.rs
@@ -140,9 +140,13 @@ impl<'a, 'b, T: Transaction> Binder<'a, 'b, T> {
                 self.visit_column_agg_expr(expr)?;
                 self.visit_column_agg_expr(in_expr)?;
             }
-            ScalarExpression::Trim { expr, trim_what_expr, ..} => {
+            ScalarExpression::Trim {
+                expr,
+                trim_what_expr,
+                ..
+            } => {
                 self.visit_column_agg_expr(expr)?;
-                if let Some(trim_what_expr) = trim_what_expr{
+                if let Some(trim_what_expr) = trim_what_expr {
                     self.visit_column_agg_expr(trim_what_expr)?;
                 }
             }
@@ -371,7 +375,11 @@ impl<'a, 'b, T: Transaction> Binder<'a, 'b, T> {
                 self.validate_having_orderby(in_expr)?;
                 Ok(())
             }
-            ScalarExpression::Trim { expr, trim_what_expr, ..} => {
+            ScalarExpression::Trim {
+                expr,
+                trim_what_expr,
+                ..
+            } => {
                 self.validate_having_orderby(expr)?;
                 if let Some(trim_what_expr) = trim_what_expr {
                     self.validate_having_orderby(trim_what_expr)?;

--- a/src/binder/aggregate.rs
+++ b/src/binder/aggregate.rs
@@ -140,6 +140,12 @@ impl<'a, 'b, T: Transaction> Binder<'a, 'b, T> {
                 self.visit_column_agg_expr(expr)?;
                 self.visit_column_agg_expr(in_expr)?;
             }
+            ScalarExpression::Trim { expr, trim_what_expr, ..} => {
+                self.visit_column_agg_expr(expr)?;
+                if let Some(trim_what_expr) = trim_what_expr{
+                    self.visit_column_agg_expr(trim_what_expr)?;
+                }
+            }
             ScalarExpression::Constant(_) | ScalarExpression::ColumnRef { .. } => (),
             ScalarExpression::Reference { .. } | ScalarExpression::Empty => unreachable!(),
             ScalarExpression::Tuple(args)
@@ -363,6 +369,13 @@ impl<'a, 'b, T: Transaction> Binder<'a, 'b, T> {
             ScalarExpression::Position { expr, in_expr } => {
                 self.validate_having_orderby(expr)?;
                 self.validate_having_orderby(in_expr)?;
+                Ok(())
+            }
+            ScalarExpression::Trim { expr, trim_what_expr, ..} => {
+                self.validate_having_orderby(expr)?;
+                if let Some(trim_what_expr) = trim_what_expr {
+                    self.validate_having_orderby(trim_what_expr)?;
+                }
                 Ok(())
             }
             ScalarExpression::Constant(_) => Ok(()),

--- a/src/binder/expr.rs
+++ b/src/binder/expr.rs
@@ -113,6 +113,17 @@ impl<'a, 'b, T: Transaction> Binder<'a, 'b, T> {
                 expr: Box::new(self.bind_expr(expr)?),
                 in_expr: Box::new(self.bind_expr(r#in)?),
             }),
+            Expr::Trim { expr, trim_what, trim_where } => {
+                let mut trim_what_expr = None;
+                if let Some(trim_what) = trim_what {
+                    trim_what_expr = Some(Box::new(self.bind_expr(trim_what)?))
+                }
+                Ok(ScalarExpression::Trim {
+                    expr: Box::new(self.bind_expr(expr)?),
+                    trim_what_expr,
+                    trim_where: *trim_where
+                })
+            },
             Expr::Subquery(subquery) => {
                 let (sub_query, column) = self.bind_subquery(subquery)?;
                 let (expr, sub_query) = if !self.context.is_step(&QueryBindStep::Where) {

--- a/src/binder/expr.rs
+++ b/src/binder/expr.rs
@@ -113,7 +113,11 @@ impl<'a, 'b, T: Transaction> Binder<'a, 'b, T> {
                 expr: Box::new(self.bind_expr(expr)?),
                 in_expr: Box::new(self.bind_expr(r#in)?),
             }),
-            Expr::Trim { expr, trim_what, trim_where } => {
+            Expr::Trim {
+                expr,
+                trim_what,
+                trim_where,
+            } => {
                 let mut trim_what_expr = None;
                 if let Some(trim_what) = trim_what {
                     trim_what_expr = Some(Box::new(self.bind_expr(trim_what)?))
@@ -121,9 +125,9 @@ impl<'a, 'b, T: Transaction> Binder<'a, 'b, T> {
                 Ok(ScalarExpression::Trim {
                     expr: Box::new(self.bind_expr(expr)?),
                     trim_what_expr,
-                    trim_where: *trim_where
+                    trim_where: *trim_where,
                 })
-            },
+            }
             Expr::Subquery(subquery) => {
                 let (sub_query, column) = self.bind_subquery(subquery)?;
                 let (expr, sub_query) = if !self.context.is_step(&QueryBindStep::Where) {

--- a/src/expression/evaluator.rs
+++ b/src/expression/evaluator.rs
@@ -8,14 +8,11 @@ use crate::types::value::{DataValue, Utf8Type, ValueRef};
 use crate::types::LogicalType;
 use itertools::Itertools;
 use lazy_static::lazy_static;
-use sqlparser::ast::{
-    CharLengthUnits,
-    TrimWhereField
-};
+use regex::Regex;
+use sqlparser::ast::{CharLengthUnits, TrimWhereField};
 use std::cmp;
 use std::cmp::Ordering;
 use std::sync::Arc;
-use regex::Regex;
 
 lazy_static! {
     static ref NULL_VALUE: ValueRef = Arc::new(DataValue::Null);
@@ -228,27 +225,35 @@ impl ScalarExpression {
                     str.find(&pattern).map(|pos| pos as i32 + 1).unwrap_or(0),
                 ))))
             }
-            ScalarExpression::Trim { expr, trim_what_expr, trim_where } => {
+            ScalarExpression::Trim {
+                expr,
+                trim_what_expr,
+                trim_where,
+            } => {
                 if let Some(string) = DataValue::clone(expr.eval(tuple, schema)?.as_ref())
                     .cast(&LogicalType::Varchar(None, CharLengthUnits::Characters))?
                     .utf8()
-                {   
+                {
                     let mut trim_what = String::from(" ");
                     if let Some(trim_what_expr) = trim_what_expr {
-                        trim_what =  DataValue::clone(trim_what_expr.eval(tuple, schema)?.as_ref())
+                        trim_what = DataValue::clone(trim_what_expr.eval(tuple, schema)?.as_ref())
                             .cast(&LogicalType::Varchar(None, CharLengthUnits::Characters))?
                             .utf8()
                             .unwrap_or_default();
                     }
                     let trim_regex = match trim_where {
-                        Some(TrimWhereField::Both) | None => {
-                            Regex::new(&format!(r"^(?:{0})*([\w\W]*?)(?:{0})*$", regex::escape(&trim_what))).unwrap()
-                        },
+                        Some(TrimWhereField::Both) | None => Regex::new(&format!(
+                            r"^(?:{0})*([\w\W]*?)(?:{0})*$",
+                            regex::escape(&trim_what)
+                        ))
+                        .unwrap(),
                         Some(TrimWhereField::Leading) => {
-                            Regex::new(&format!(r"^(?:{0})*([\w\W]*?)", regex::escape(&trim_what))).unwrap()
-                        },
+                            Regex::new(&format!(r"^(?:{0})*([\w\W]*?)", regex::escape(&trim_what)))
+                                .unwrap()
+                        }
                         Some(TrimWhereField::Trailing) => {
-                            Regex::new(&format!(r"([\w\W]*?)(?:{0})*$", regex::escape(&trim_what))).unwrap()
+                            Regex::new(&format!(r"([\w\W]*?)(?:{0})*$", regex::escape(&trim_what)))
+                                .unwrap()
                         }
                     };
                     let string_trimmed = trim_regex.replace_all(&string, "$1").to_string();

--- a/src/expression/range_detacher.rs
+++ b/src/expression/range_detacher.rs
@@ -219,6 +219,7 @@ impl<'a> RangeDetacher<'a> {
             | ScalarExpression::Between { expr, .. }
             | ScalarExpression::SubString { expr, .. } => self.detach(expr),
             ScalarExpression::Position { expr, .. } => self.detach(expr),
+            ScalarExpression::Trim { expr, .. } => self.detach(expr),
             ScalarExpression::IsNull { expr, negated, .. } => match expr.as_ref() {
                 ScalarExpression::ColumnRef(column) => {
                     if let (Some(col_id), Some(col_table)) = (column.id(), column.table_name()) {
@@ -245,6 +246,7 @@ impl<'a> RangeDetacher<'a> {
                 | ScalarExpression::Between { .. }
                 | ScalarExpression::SubString { .. }
                 | ScalarExpression::Position { .. }
+                | ScalarExpression::Trim { .. }
                 | ScalarExpression::Function(_)
                 | ScalarExpression::If { .. }
                 | ScalarExpression::IfNull { .. }

--- a/src/expression/simplify.rs
+++ b/src/expression/simplify.rs
@@ -88,6 +88,13 @@ impl ScalarExpression {
             ScalarExpression::Position { expr, in_expr } => {
                 expr.exist_column(table_name, col_id) || in_expr.exist_column(table_name, col_id)
             }
+            ScalarExpression::Trim { expr, trim_what_expr, .. } => {
+                expr.exist_column(table_name, col_id)
+                || trim_what_expr
+                    .as_ref()
+                    .map(|expr| expr.exist_column(table_name, col_id))
+                    == Some(true)
+            }
             ScalarExpression::Constant(_) => false,
             ScalarExpression::Reference { .. } | ScalarExpression::Empty => unreachable!(),
             ScalarExpression::If {
@@ -315,6 +322,12 @@ impl ScalarExpression {
             ScalarExpression::Position { expr, in_expr } => {
                 expr.constant_calculation()?;
                 in_expr.constant_calculation()?;
+            }
+            ScalarExpression::Trim { expr, trim_what_expr, .. } => {
+                expr.constant_calculation()?;
+                if let Some(trim_what_expr) = trim_what_expr { 
+                    trim_what_expr.constant_calculation()?;
+                }
             }
             ScalarExpression::Tuple(exprs) | ScalarExpression::Coalesce { exprs, .. } => {
                 for expr in exprs {

--- a/src/expression/simplify.rs
+++ b/src/expression/simplify.rs
@@ -88,12 +88,16 @@ impl ScalarExpression {
             ScalarExpression::Position { expr, in_expr } => {
                 expr.exist_column(table_name, col_id) || in_expr.exist_column(table_name, col_id)
             }
-            ScalarExpression::Trim { expr, trim_what_expr, .. } => {
+            ScalarExpression::Trim {
+                expr,
+                trim_what_expr,
+                ..
+            } => {
                 expr.exist_column(table_name, col_id)
-                || trim_what_expr
-                    .as_ref()
-                    .map(|expr| expr.exist_column(table_name, col_id))
-                    == Some(true)
+                    || trim_what_expr
+                        .as_ref()
+                        .map(|expr| expr.exist_column(table_name, col_id))
+                        == Some(true)
             }
             ScalarExpression::Constant(_) => false,
             ScalarExpression::Reference { .. } | ScalarExpression::Empty => unreachable!(),
@@ -323,9 +327,13 @@ impl ScalarExpression {
                 expr.constant_calculation()?;
                 in_expr.constant_calculation()?;
             }
-            ScalarExpression::Trim { expr, trim_what_expr, .. } => {
+            ScalarExpression::Trim {
+                expr,
+                trim_what_expr,
+                ..
+            } => {
                 expr.constant_calculation()?;
-                if let Some(trim_what_expr) = trim_what_expr { 
+                if let Some(trim_what_expr) = trim_what_expr {
                     trim_what_expr.constant_calculation()?;
                 }
             }

--- a/tests/slt/sql_2016/E021_09.slt
+++ b/tests/slt/sql_2016/E021_09.slt
@@ -1,48 +1,46 @@
 # E021-09: TRIM function
 
-# TODO: TRIM()
+query T
+SELECT TRIM ( 'foo' )
+----
+'foo'
 
-# query T
-# SELECT TRIM ( 'foo' )
-# ----
-# 'foo'
+query T
+SELECT TRIM ( 'foo' FROM 'foo' )
+----
+''
 
-# query T
-# SELECT TRIM ( 'foo' FROM 'foo' )
-# ----
-# ''
+query T
+SELECT TRIM ( BOTH 'foo' FROM 'foo' )
+----
+''
 
-# query T
-# SELECT TRIM ( BOTH 'foo' FROM 'foo' )
-# ----
-# ''
+query T
+SELECT TRIM ( BOTH FROM 'foo' )
+----
+'foo'
 
-# query T
-# SELECT TRIM ( BOTH FROM 'foo' )
-# ----
-# 'foo'
+query T
+SELECT TRIM ( FROM 'foo' )
+----
+'foo'
 
-# query T
-# SELECT TRIM ( FROM 'foo' )
-# ----
-# 'foo'
+query T
+SELECT TRIM ( LEADING 'foo' FROM 'foo' )
+----
+''
 
-# query T
-# SELECT TRIM ( LEADING 'foo' FROM 'foo' )
-# ----
-# ''
+query T
+SELECT TRIM ( LEADING FROM 'foo' )
+----
+'foo'
 
-# query T
-# SELECT TRIM ( LEADING FROM 'foo' )
-# ----
-# 'foo'
+query T
+SELECT TRIM ( TRAILING 'foo' FROM 'foo' )
+----
+''
 
-# query T
-# SELECT TRIM ( TRAILING 'foo' FROM 'foo' )
-# ----
-# ''
-
-# query T
-# SELECT TRIM ( TRAILING FROM 'foo' )
-# ----
-# 'foo'
+query T
+SELECT TRIM ( TRAILING FROM 'foo' )
+----
+'foo'

--- a/tests/slt/sql_2016/E021_09.slt
+++ b/tests/slt/sql_2016/E021_09.slt
@@ -3,44 +3,44 @@
 query T
 SELECT TRIM ( 'foo' )
 ----
-'foo'
+foo
+
+query B
+SELECT TRIM ( 'foo' FROM 'foo' ) = ''
+----
+true
+
+query B
+SELECT TRIM ( BOTH 'foo' FROM 'foo' ) = ''
+----
+true
 
 query T
-SELECT TRIM ( 'foo' FROM 'foo' )
+SELECT TRIM ( BOTH 'foo' )
 ----
-''
+foo
 
 query T
-SELECT TRIM ( BOTH 'foo' FROM 'foo' )
+SELECT TRIM ( '' FROM 'foo' )
 ----
-''
+foo
+
+query B
+SELECT TRIM ( LEADING 'foo' FROM 'foo' ) = ''
+----
+true
 
 query T
-SELECT TRIM ( BOTH FROM 'foo' )
+SELECT TRIM ( LEADING 'foo' )
 ----
-'foo'
+foo
+
+query B
+SELECT TRIM ( TRAILING 'foo' FROM 'foo' ) = ''
+----
+true
 
 query T
-SELECT TRIM ( FROM 'foo' )
+SELECT TRIM ( TRAILING 'foo' )
 ----
-'foo'
-
-query T
-SELECT TRIM ( LEADING 'foo' FROM 'foo' )
-----
-''
-
-query T
-SELECT TRIM ( LEADING FROM 'foo' )
-----
-'foo'
-
-query T
-SELECT TRIM ( TRAILING 'foo' FROM 'foo' )
-----
-''
-
-query T
-SELECT TRIM ( TRAILING FROM 'foo' )
-----
-'foo'
+foo


### PR DESCRIPTION
### What problem does this PR solve?

Generally, according to [E21_09](https://modern-sql.com/caniuse/E021-09), adds support for the method `TRIM()`.

Issue link: #130

### What is changed and how it works?

Expression matching a pattern below will work fine:

```
TRIM([LEADING | TRAILING | BOTH] [trim_what FROM] exp)
```

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer

None
