### PR TITLE
perf: strip `table_cache` and `meta_cache` out of storage & optimize …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name          = "fnck_sql"
-version       = "0.0.2"
+version       = "0.0.3"
 edition       = "2021"
 authors       = ["Kould <kould2333@gmail.com>", "Xwg <loloxwg@gmail.com>"]
 description   = "SQL as a Function for Rust"

--- a/benchmarks/query_benchmark.rs
+++ b/benchmarks/query_benchmark.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 
 const QUERY_BENCH_FNCK_SQL_PATH: &'static str = "./fncksql_bench";
 const QUERY_BENCH_SQLITE_PATH: &'static str = "./sqlite_bench";
-const TABLE_ROW_NUM: u64 = 2_00_000;
+const TABLE_ROW_NUM: u64 = 200_000;
 
 fn query_cases() -> Vec<(&'static str, &'static str)> {
     vec![

--- a/src/binder/expr.rs
+++ b/src/binder/expr.rs
@@ -248,13 +248,14 @@ impl<'a, 'b, T: Transaction> Binder<'a, 'b, T> {
         subquery: &Query,
     ) -> Result<(LogicalPlan, Arc<ColumnCatalog>), DatabaseError> {
         let BinderContext {
+            table_cache,
             transaction,
             functions,
             temp_table_id,
             ..
         } = &self.context;
         let mut binder = Binder::new(
-            BinderContext::new(*transaction, functions, temp_table_id.clone()),
+            BinderContext::new(table_cache, *transaction, functions, temp_table_id.clone()),
             Some(self),
         );
         let mut sub_query = binder.bind_query(subquery)?;

--- a/src/binder/select.rs
+++ b/src/binder/select.rs
@@ -494,13 +494,14 @@ impl<'a: 'b, 'b, T: Transaction> Binder<'a, 'b, T> {
             _ => unimplemented!(),
         };
         let BinderContext {
+            table_cache,
             transaction,
             functions,
             temp_table_id,
             ..
         } = &self.context;
         let mut binder = Binder::new(
-            BinderContext::new(*transaction, functions, temp_table_id.clone()),
+            BinderContext::new(table_cache, *transaction, functions, temp_table_id.clone()),
             Some(self),
         );
         let mut right = binder.bind_single_table_ref(relation, Some(join_type))?;

--- a/src/execution/ddl/truncate.rs
+++ b/src/execution/ddl/truncate.rs
@@ -1,6 +1,6 @@
 use crate::execution::{Executor, WriteExecutor};
 use crate::planner::operator::truncate::TruncateOperator;
-use crate::storage::Transaction;
+use crate::storage::{StatisticsMetaCache, TableCache, Transaction};
 use crate::throw;
 use crate::types::tuple_builder::TupleBuilder;
 
@@ -15,7 +15,11 @@ impl From<TruncateOperator> for Truncate {
 }
 
 impl<'a, T: Transaction + 'a> WriteExecutor<'a, T> for Truncate {
-    fn execute_mut(self, transaction: &'a mut T) -> Executor<'a> {
+    fn execute_mut(
+        self,
+        _: (&'a TableCache, &'a StatisticsMetaCache),
+        transaction: &'a mut T,
+    ) -> Executor<'a> {
         Box::new(
             #[coroutine]
             move || {

--- a/src/execution/dql/dummy.rs
+++ b/src/execution/dql/dummy.rs
@@ -1,11 +1,11 @@
 use crate::execution::{Executor, ReadExecutor};
-use crate::storage::Transaction;
+use crate::storage::{StatisticsMetaCache, TableCache, Transaction};
 use crate::types::tuple::Tuple;
 
 pub struct Dummy {}
 
 impl<'a, T: Transaction + 'a> ReadExecutor<'a, T> for Dummy {
-    fn execute(self, _: &T) -> Executor<'a> {
+    fn execute(self, _: (&'a TableCache, &'a StatisticsMetaCache), _: &T) -> Executor<'a> {
         Box::new(
             #[coroutine]
             move || {

--- a/src/execution/dql/explain.rs
+++ b/src/execution/dql/explain.rs
@@ -1,6 +1,6 @@
 use crate::execution::{Executor, ReadExecutor};
 use crate::planner::LogicalPlan;
-use crate::storage::Transaction;
+use crate::storage::{StatisticsMetaCache, TableCache, Transaction};
 use crate::types::tuple::Tuple;
 use crate::types::value::{DataValue, Utf8Type};
 use sqlparser::ast::CharLengthUnits;
@@ -17,7 +17,7 @@ impl From<LogicalPlan> for Explain {
 }
 
 impl<'a, T: Transaction + 'a> ReadExecutor<'a, T> for Explain {
-    fn execute(self, _: &T) -> Executor<'a> {
+    fn execute(self, _: (&'a TableCache, &'a StatisticsMetaCache), _: &T) -> Executor<'a> {
         Box::new(
             #[coroutine]
             move || {

--- a/src/execution/dql/filter.rs
+++ b/src/execution/dql/filter.rs
@@ -2,7 +2,7 @@ use crate::execution::{build_read, Executor, ReadExecutor};
 use crate::expression::ScalarExpression;
 use crate::planner::operator::filter::FilterOperator;
 use crate::planner::LogicalPlan;
-use crate::storage::Transaction;
+use crate::storage::{StatisticsMetaCache, TableCache, Transaction};
 use crate::throw;
 use std::ops::Coroutine;
 use std::ops::CoroutineState;
@@ -20,7 +20,11 @@ impl From<(FilterOperator, LogicalPlan)> for Filter {
 }
 
 impl<'a, T: Transaction + 'a> ReadExecutor<'a, T> for Filter {
-    fn execute(self, transaction: &'a T) -> Executor<'a> {
+    fn execute(
+        self,
+        cache: (&'a TableCache, &'a StatisticsMetaCache),
+        transaction: &'a T,
+    ) -> Executor<'a> {
         Box::new(
             #[coroutine]
             move || {
@@ -31,7 +35,7 @@ impl<'a, T: Transaction + 'a> ReadExecutor<'a, T> for Filter {
 
                 let schema = input.output_schema().clone();
 
-                let mut coroutine = build_read(input, transaction);
+                let mut coroutine = build_read(input, cache, transaction);
 
                 while let CoroutineState::Yielded(tuple) = Pin::new(&mut coroutine).resume(()) {
                     let tuple = throw!(tuple);

--- a/src/execution/dql/show_table.rs
+++ b/src/execution/dql/show_table.rs
@@ -1,6 +1,6 @@
 use crate::catalog::TableMeta;
 use crate::execution::{Executor, ReadExecutor};
-use crate::storage::Transaction;
+use crate::storage::{StatisticsMetaCache, TableCache, Transaction};
 use crate::throw;
 use crate::types::tuple::Tuple;
 use crate::types::value::{DataValue, Utf8Type};
@@ -10,7 +10,11 @@ use std::sync::Arc;
 pub struct ShowTables;
 
 impl<'a, T: Transaction + 'a> ReadExecutor<'a, T> for ShowTables {
-    fn execute(self, transaction: &'a T) -> Executor<'a> {
+    fn execute(
+        self,
+        _: (&'a TableCache, &'a StatisticsMetaCache),
+        transaction: &'a T,
+    ) -> Executor<'a> {
         Box::new(
             #[coroutine]
             move || {

--- a/src/execution/dql/values.rs
+++ b/src/execution/dql/values.rs
@@ -1,6 +1,6 @@
 use crate::execution::{Executor, ReadExecutor};
 use crate::planner::operator::values::ValuesOperator;
-use crate::storage::Transaction;
+use crate::storage::{StatisticsMetaCache, TableCache, Transaction};
 use crate::types::tuple::Tuple;
 
 pub struct Values {
@@ -14,7 +14,7 @@ impl From<ValuesOperator> for Values {
 }
 
 impl<'a, T: Transaction + 'a> ReadExecutor<'a, T> for Values {
-    fn execute(self, _: &T) -> Executor<'a> {
+    fn execute(self, _: (&'a TableCache, &'a StatisticsMetaCache), _: &T) -> Executor<'a> {
         Box::new(
             #[coroutine]
             move || {

--- a/src/optimizer/core/memo.rs
+++ b/src/optimizer/core/memo.rs
@@ -117,7 +117,12 @@ mod tests {
         let transaction = database.storage.transaction()?;
         let functions = Default::default();
         let mut binder = Binder::new(
-            BinderContext::new(&transaction, &functions, Arc::new(AtomicUsize::new(0))),
+            BinderContext::new(
+                &database.table_cache,
+                &transaction,
+                &functions,
+                Arc::new(AtomicUsize::new(0)),
+            ),
             None,
         );
         // where: c1 => 2, (40, +inf)
@@ -149,7 +154,11 @@ mod tests {
             ImplementationRuleImpl::IndexScan,
         ];
 
-        let memo = Memo::new(&graph, &transaction.meta_loader(), &rules)?;
+        let memo = Memo::new(
+            &graph,
+            &transaction.meta_loader(&database.meta_cache),
+            &rules,
+        )?;
         let best_plan = graph.into_plan(Some(&memo));
         let exprs = &memo.groups.get(&NodeIndex::new(3)).unwrap();
 

--- a/src/utils/bit_vector.rs
+++ b/src/utils/bit_vector.rs
@@ -4,6 +4,7 @@ use std::slice;
 
 #[derive(Debug, Default)]
 pub struct BitVector {
+    #[allow(dead_code)]
     len: u64,
     bit_groups: Vec<i8>,
 }
@@ -31,14 +32,17 @@ impl BitVector {
         self.bit_groups[index / 8] >> (index % 8) & 1 != 0
     }
 
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.len as usize
     }
 
+    #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }
 
+    #[allow(dead_code)]
     pub fn to_raw(&self, bytes: &mut Vec<u8>) {
         bytes.append(&mut u64::encode_fixed_vec(self.len));
 
@@ -47,6 +51,7 @@ impl BitVector {
         }
     }
 
+    #[allow(dead_code)]
     pub fn from_raw(bytes: &[u8]) -> Self {
         let len = u64::decode_fixed(&bytes[0..8]);
         let bit_groups = bytes[8..]

--- a/src/utils/lru.rs
+++ b/src/utils/lru.rs
@@ -283,6 +283,7 @@ impl<K: Hash + Eq + PartialEq, V> LruCache<K, V> {
         }
     }
 
+    #[allow(dead_code)]
     #[inline]
     pub fn get(&mut self, key: &K) -> Option<&V> {
         if let Some(node) = self.inner.get(key) {
@@ -333,6 +334,7 @@ impl<K: Hash + Eq + PartialEq, V> LruCache<K, V> {
         }
     }
 
+    #[allow(dead_code)]
     #[inline]
     pub fn get_or_insert<F>(&mut self, key: K, fn_once: F) -> Result<&V, DatabaseError>
     where
@@ -342,6 +344,7 @@ impl<K: Hash + Eq + PartialEq, V> LruCache<K, V> {
             .map(|node| unsafe { &node.as_ref().value })
     }
 
+    #[allow(dead_code)]
     #[inline]
     pub fn len(&self) -> usize {
         self.inner.len()
@@ -352,6 +355,7 @@ impl<K: Hash + Eq + PartialEq, V> LruCache<K, V> {
         self.inner.is_empty()
     }
 
+    #[allow(dead_code)]
     #[inline]
     pub fn iter(&self) -> LruCacheIter<K, V> {
         LruCacheIter {


### PR DESCRIPTION
…`RocksIter`

### What problem does this PR solve?

- remove `Transaction::table_cache` & `Transaction::meta_cache`
- fix RocksIter's judgment of upper, extract and return None to avoid redundant reading in IndexIter


### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
