### PR TITLE
refactor: impl `ReferenceSerialization`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ chrono                = { version = "0.4" }
 clap                  = { version = "4.5", features = ["derive"], optional = true }
 comfy-table           = { version = "7" }
 csv                   = { version = "1" }
+encode_unicode        = { version = "1" }
 dirs                  = { version = "5" }
 env_logger            = { version = "0.11", optional = true }
 futures               = { version = "0.3", optional = true }

--- a/src/binder/create_table.rs
+++ b/src/binder/create_table.rs
@@ -96,7 +96,7 @@ impl<'a, 'b, T: Transaction> Binder<'a, 'b, T> {
             false,
             false,
             None,
-        );
+        )?;
         let mut nullable = true;
 
         // TODO: 这里可以对更多字段可设置内容进行补充
@@ -182,7 +182,7 @@ mod tests {
                 debug_assert_eq!(op.columns[0].nullable, false);
                 debug_assert_eq!(
                     op.columns[0].desc,
-                    ColumnDesc::new(LogicalType::Integer, true, false, None)
+                    ColumnDesc::new(LogicalType::Integer, true, false, None)?
                 );
                 debug_assert_eq!(op.columns[1].name(), "name");
                 debug_assert_eq!(op.columns[1].nullable, true);
@@ -193,7 +193,7 @@ mod tests {
                         false,
                         false,
                         None
-                    )
+                    )?
                 );
             }
             _ => unreachable!(),

--- a/src/binder/expr.rs
+++ b/src/binder/expr.rs
@@ -231,7 +231,7 @@ impl<'a, 'b, T: Transaction> Binder<'a, 'b, T> {
         sub_query: LogicalPlan,
     ) -> Result<(ScalarExpression, LogicalPlan), DatabaseError> {
         let mut alias_column = ColumnCatalog::clone(&column);
-        alias_column.set_table_name(self.context.temp_table());
+        alias_column.set_ref_table(self.context.temp_table(), 0);
 
         let alias_expr = ScalarExpression::Alias {
             expr: Box::new(ScalarExpression::ColumnRef(column)),

--- a/src/binder/mod.rs
+++ b/src/binder/mod.rs
@@ -409,12 +409,12 @@ pub mod test {
                 ColumnCatalog::new(
                     "c1".to_string(),
                     false,
-                    ColumnDesc::new(Integer, true, false, None),
+                    ColumnDesc::new(Integer, true, false, None)?,
                 ),
                 ColumnCatalog::new(
                     "c2".to_string(),
                     false,
-                    ColumnDesc::new(Integer, false, true, None),
+                    ColumnDesc::new(Integer, false, true, None)?,
                 ),
             ],
             false,
@@ -427,12 +427,12 @@ pub mod test {
                 ColumnCatalog::new(
                     "c3".to_string(),
                     false,
-                    ColumnDesc::new(Integer, true, false, None),
+                    ColumnDesc::new(Integer, true, false, None)?,
                 ),
                 ColumnCatalog::new(
                     "c4".to_string(),
                     false,
-                    ColumnDesc::new(Integer, false, false, None),
+                    ColumnDesc::new(Integer, false, false, None)?,
                 ),
             ],
             false,

--- a/src/binder/select.rs
+++ b/src/binder/select.rs
@@ -352,7 +352,7 @@ impl<'a: 'b, 'b, T: Transaction> Binder<'a, 'b, T> {
         for (alias, column) in aliases_with_columns {
             let mut alias_column = ColumnCatalog::clone(&column);
             alias_column.set_name(alias.clone());
-            alias_column.set_table_name(table_alias.clone());
+            alias_column.set_ref_table(table_alias.clone(), column.id().unwrap_or(0));
 
             let alias_column_expr = ScalarExpression::Alias {
                 expr: Box::new(ScalarExpression::ColumnRef(column)),

--- a/src/db.rs
+++ b/src/db.rs
@@ -322,17 +322,17 @@ pub(crate) mod test {
             ColumnCatalog::new(
                 "c1".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Integer, true, false, None),
+                ColumnDesc::new(LogicalType::Integer, true, false, None).unwrap(),
             ),
             ColumnCatalog::new(
                 "c2".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Boolean, false, false, None),
+                ColumnDesc::new(LogicalType::Boolean, false, false, None).unwrap(),
             ),
             ColumnCatalog::new(
                 "c3".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Integer, false, false, None),
+                ColumnDesc::new(LogicalType::Integer, false, false, None).unwrap(),
             ),
         ];
         let _ =
@@ -369,7 +369,7 @@ pub(crate) mod test {
             Arc::new(vec![Arc::new(ColumnCatalog::new(
                 "current_date()".to_string(),
                 true,
-                ColumnDesc::new(LogicalType::Date, false, false, None)
+                ColumnDesc::new(LogicalType::Date, false, false, None).unwrap()
             ))])
         );
         debug_assert_eq!(
@@ -397,10 +397,9 @@ pub(crate) mod test {
         let mut column = ColumnCatalog::new(
             "number".to_string(),
             true,
-            ColumnDesc::new(LogicalType::Integer, false, false, None),
+            ColumnDesc::new(LogicalType::Integer, false, false, None).unwrap(),
         );
-        column.set_table_name(Arc::new("a".to_string()));
-        column.set_id(0);
+        column.set_ref_table(Arc::new("a".to_string()), 0);
 
         debug_assert_eq!(schema, Arc::new(vec![Arc::new(column)]));
         debug_assert_eq!(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,6 +30,8 @@ pub enum DatabaseError {
         #[source]
         csv::Error,
     ),
+    #[error("default cannot be a column related to the table")]
+    DefaultNotColumnRef,
     #[error("default does not exist")]
     DefaultNotExist,
     #[error("column: {0} already exists")]

--- a/src/execution/dml/copy_from_file.rs
+++ b/src/execution/dml/copy_from_file.rs
@@ -108,7 +108,7 @@ fn return_result(size: usize, tx: Sender<Tuple>) -> Result<(), DatabaseError> {
 
 #[cfg(test)]
 mod tests {
-    use crate::catalog::{ColumnCatalog, ColumnDesc, ColumnSummary};
+    use crate::catalog::{ColumnCatalog, ColumnDesc, ColumnRelation, ColumnSummary};
     use crate::db::DataBaseBuilder;
     use sqlparser::ast::CharLengthUnits;
     use std::io::Write;
@@ -133,27 +133,33 @@ mod tests {
         let columns = vec![
             Arc::new(ColumnCatalog {
                 summary: ColumnSummary {
-                    id: Some(0),
                     name: "a".to_string(),
-                    table_name: None,
+                    relation: ColumnRelation::Table {
+                        column_id: 0,
+                        table_name: Arc::new("t1".to_string()),
+                    },
                 },
                 nullable: false,
-                desc: ColumnDesc::new(LogicalType::Integer, true, false, None),
+                desc: ColumnDesc::new(LogicalType::Integer, true, false, None).unwrap(),
             }),
             Arc::new(ColumnCatalog {
                 summary: ColumnSummary {
-                    id: Some(1),
                     name: "b".to_string(),
-                    table_name: None,
+                    relation: ColumnRelation::Table {
+                        column_id: 1,
+                        table_name: Arc::new("t1".to_string()),
+                    },
                 },
                 nullable: false,
-                desc: ColumnDesc::new(LogicalType::Float, false, false, None),
+                desc: ColumnDesc::new(LogicalType::Float, false, false, None).unwrap(),
             }),
             Arc::new(ColumnCatalog {
                 summary: ColumnSummary {
-                    id: Some(1),
                     name: "c".to_string(),
-                    table_name: None,
+                    relation: ColumnRelation::Table {
+                        column_id: 2,
+                        table_name: Arc::new("t1".to_string()),
+                    },
                 },
                 nullable: false,
                 desc: ColumnDesc::new(
@@ -161,7 +167,8 @@ mod tests {
                     false,
                     false,
                     None,
-                ),
+                )
+                .unwrap(),
             }),
         ];
 

--- a/src/execution/dql/aggregate/hash_agg.rs
+++ b/src/execution/dql/aggregate/hash_agg.rs
@@ -189,7 +189,7 @@ mod test {
         let temp_dir = TempDir::new().expect("unable to create temporary working directory");
         let storage = RocksStorage::new(temp_dir.path()).unwrap();
         let transaction = storage.transaction()?;
-        let desc = ColumnDesc::new(LogicalType::Integer, false, false, None);
+        let desc = ColumnDesc::new(LogicalType::Integer, false, false, None)?;
 
         let t1_schema = Arc::new(vec![
             Arc::new(ColumnCatalog::new("c1".to_string(), true, desc.clone())),

--- a/src/execution/dql/join/hash_join.rs
+++ b/src/execution/dql/join/hash_join.rs
@@ -444,7 +444,7 @@ mod test {
         LogicalPlan,
         LogicalPlan,
     ) {
-        let desc = ColumnDesc::new(LogicalType::Integer, false, false, None);
+        let desc = ColumnDesc::new(LogicalType::Integer, false, false, None).unwrap();
 
         let t1_columns = vec![
             Arc::new(ColumnCatalog::new("c1".to_string(), true, desc.clone())),

--- a/src/execution/dql/join/nested_loop_join.rs
+++ b/src/execution/dql/join/nested_loop_join.rs
@@ -406,7 +406,7 @@ mod test {
         LogicalPlan,
         ScalarExpression,
     ) {
-        let desc = ColumnDesc::new(LogicalType::Integer, false, false, None);
+        let desc = ColumnDesc::new(LogicalType::Integer, false, false, None).unwrap();
 
         let t1_columns = vec![
             Arc::new(ColumnCatalog::new("c1".to_string(), true, desc.clone())),

--- a/src/execution/dql/seq_scan.rs
+++ b/src/execution/dql/seq_scan.rs
@@ -29,9 +29,7 @@ impl<'a, T: Transaction + 'a> ReadExecutor<'a, T> for SeqScan {
                     ..
                 } = self.op;
 
-                let mut iter = transaction
-                    .read(table_cache, table_name, limit, columns)
-                    .unwrap();
+                let mut iter = throw!(transaction.read(table_cache, table_name, limit, columns));
 
                 while let Some(tuple) = throw!(iter.next_tuple()) {
                     yield Ok(tuple);

--- a/src/execution/dql/sort.rs
+++ b/src/execution/dql/sort.rs
@@ -307,7 +307,7 @@ mod test {
         let schema = Arc::new(vec![Arc::new(ColumnCatalog::new(
             "c1".to_string(),
             true,
-            ColumnDesc::new(LogicalType::Integer, false, false, None),
+            ColumnDesc::new(LogicalType::Integer, false, false, None).unwrap(),
         ))]);
         let tuples = NullableVec(vec![
             Some((
@@ -476,12 +476,12 @@ mod test {
             Arc::new(ColumnCatalog::new(
                 "c1".to_string(),
                 true,
-                ColumnDesc::new(LogicalType::Integer, false, false, None),
+                ColumnDesc::new(LogicalType::Integer, false, false, None).unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c2".to_string(),
                 true,
-                ColumnDesc::new(LogicalType::Integer, false, false, None),
+                ColumnDesc::new(LogicalType::Integer, false, false, None).unwrap(),
             )),
         ]);
         let tuples = NullableVec(vec![

--- a/src/expression/agg.rs
+++ b/src/expression/agg.rs
@@ -1,4 +1,7 @@
+use crate::serdes::Serialization;
 use serde::{Deserialize, Serialize};
+use std::io;
+use std::io::{Read, Write};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum AggKind {
@@ -18,5 +21,34 @@ impl AggKind {
             AggKind::Sum => true,
             AggKind::Count => true,
         }
+    }
+}
+
+impl Serialization for AggKind {
+    type Error = io::Error;
+
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+        let type_id = match self {
+            AggKind::Avg => 0u8,
+            AggKind::Max => 1u8,
+            AggKind::Min => 2u8,
+            AggKind::Sum => 3u8,
+            AggKind::Count => 4u8,
+        };
+        writer.write_all(&[type_id])
+    }
+
+    fn decode<R: Read>(reader: &mut R) -> Result<Self, Self::Error> {
+        let mut type_bytes = [0u8; 1];
+        reader.read_exact(&mut type_bytes)?;
+
+        Ok(match type_bytes[0] {
+            0 => AggKind::Avg,
+            1 => AggKind::Max,
+            2 => AggKind::Min,
+            3 => AggKind::Sum,
+            4 => AggKind::Count,
+            _ => unreachable!(),
+        })
     }
 }

--- a/src/expression/function/scala.rs
+++ b/src/expression/function/scala.rs
@@ -5,7 +5,6 @@ use crate::expression::ScalarExpression;
 use crate::types::tuple::Tuple;
 use crate::types::value::DataValue;
 use crate::types::LogicalType;
-use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
@@ -16,7 +15,7 @@ use std::sync::Arc;
 /// - `Some(false)` monotonically decreasing
 pub type FuncMonotonicity = Vec<Option<bool>>;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct ScalarFunction {
     pub(crate) args: Vec<ScalarExpression>,
     pub(crate) inner: Arc<dyn ScalarFunctionImpl>,

--- a/src/expression/function/table.rs
+++ b/src/expression/function/table.rs
@@ -3,12 +3,11 @@ use crate::errors::DatabaseError;
 use crate::expression::function::FunctionSummary;
 use crate::expression::ScalarExpression;
 use crate::types::tuple::{SchemaRef, Tuple};
-use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct TableFunction {
     pub(crate) args: Vec<ScalarExpression>,
     pub(crate) inner: Arc<dyn TableFunctionImpl>,

--- a/src/expression/mod.rs
+++ b/src/expression/mod.rs
@@ -172,15 +172,8 @@ impl ScalarExpression {
         }
 
         match self {
-            ScalarExpression::Alias { expr, alias } => {
+            ScalarExpression::Alias { expr, .. } => {
                 expr.try_reference(output_exprs);
-
-                match alias {
-                    AliasType::Name(_) => (),
-                    AliasType::Expr(alias_expr) => {
-                        alias_expr.try_reference(output_exprs);
-                    }
-                }
             }
             ScalarExpression::TypeCast { expr, .. } => {
                 expr.try_reference(output_exprs);
@@ -478,13 +471,7 @@ impl ScalarExpression {
 
     pub fn has_count_star(&self) -> bool {
         match self {
-            ScalarExpression::Alias { expr, alias } => {
-                expr.has_count_star()
-                    || match alias {
-                        AliasType::Name(_) => false,
-                        AliasType::Expr(alias_expr) => alias_expr.has_count_star(),
-                    }
-            }
+            ScalarExpression::Alias { expr, .. } => expr.has_count_star(),
             ScalarExpression::TypeCast { expr, .. } => expr.has_count_star(),
             ScalarExpression::IsNull { expr, .. } => expr.has_count_star(),
             ScalarExpression::Unary { expr, .. } => expr.has_count_star(),
@@ -642,15 +629,8 @@ impl ScalarExpression {
                 ScalarExpression::ColumnRef(col) => {
                     vec.push(col.clone());
                 }
-                ScalarExpression::Alias { expr, alias } => {
+                ScalarExpression::Alias { expr, .. } => {
                     columns_collect(expr, vec, only_column_ref);
-
-                    match alias {
-                        AliasType::Name(_) => (),
-                        AliasType::Expr(alias_expr) => {
-                            columns_collect(alias_expr, vec, only_column_ref);
-                        }
-                    }
                 }
                 ScalarExpression::TypeCast { expr, .. } => {
                     columns_collect(expr, vec, only_column_ref)
@@ -776,13 +756,7 @@ impl ScalarExpression {
             ScalarExpression::ColumnRef(column) => {
                 column.table_name().is_some() && column.id().is_some()
             }
-            ScalarExpression::Alias { expr, alias } => {
-                expr.has_table_ref_column()
-                    || match alias {
-                        AliasType::Name(_) => false,
-                        AliasType::Expr(expr) => expr.has_table_ref_column(),
-                    }
-            }
+            ScalarExpression::Alias { expr, .. } => expr.has_table_ref_column(),
             ScalarExpression::TypeCast { expr, .. } | ScalarExpression::IsNull { expr, .. } => {
                 expr.has_table_ref_column()
             }
@@ -900,13 +874,7 @@ impl ScalarExpression {
             ScalarExpression::AggCall { .. } => true,
             ScalarExpression::Constant(_) => false,
             ScalarExpression::ColumnRef(_) => false,
-            ScalarExpression::Alias { expr, alias } => {
-                expr.has_agg_call()
-                    || match alias {
-                        AliasType::Name(_) => false,
-                        AliasType::Expr(alias_expr) => alias_expr.has_agg_call(),
-                    }
-            }
+            ScalarExpression::Alias { expr, .. } => expr.has_agg_call(),
             ScalarExpression::TypeCast { expr, .. } => expr.has_agg_call(),
             ScalarExpression::IsNull { expr, .. } => expr.has_agg_call(),
             ScalarExpression::Unary { expr, .. } => expr.has_agg_call(),

--- a/src/expression/range_detacher.rs
+++ b/src/expression/range_detacher.rs
@@ -3,6 +3,7 @@ use crate::expression::{BinaryOperator, ScalarExpression};
 use crate::types::value::{DataValue, ValueRef, NULL_VALUE};
 use crate::types::ColumnId;
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::collections::Bound;
 use std::fmt::Formatter;
@@ -12,7 +13,7 @@ use std::{fmt, mem};
 /// Used to represent binary relationships between fields and constants
 /// Tips: The NotEq case is ignored because it makes expression composition very complex
 /// - [`Range::Scope`]:
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
 pub enum Range {
     Scope {
         min: Bound<ValueRef>,

--- a/src/function/numbers.rs
+++ b/src/function/numbers.rs
@@ -21,7 +21,7 @@ lazy_static! {
             vec![ColumnCatalog::new(
                 "number".to_lowercase(),
                 true,
-                ColumnDesc::new(LogicalType::Integer, false, false, None),
+                ColumnDesc::new(LogicalType::Integer, false, false, None).unwrap(),
             )],
         )
         .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,7 @@ pub mod macros;
 mod optimizer;
 pub mod parser;
 pub mod planner;
+pub mod serdes;
 pub mod storage;
 pub mod types;
 pub(crate) mod utils;

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -154,7 +154,7 @@ macro_rules! table_function {
                 let mut columns = Vec::new();
 
                 $({
-                    columns.push(::fnck_sql::catalog::column::ColumnCatalog::new(stringify!($output_name).to_lowercase(), true, ::fnck_sql::catalog::column::ColumnDesc::new($output_ty, false, false, None)));
+                    columns.push(::fnck_sql::catalog::column::ColumnCatalog::new(stringify!($output_name).to_lowercase(), true, ::fnck_sql::catalog::column::ColumnDesc::new($output_ty, false, false, None).unwrap()));
                 })*
                 ::fnck_sql::catalog::table::TableCatalog::new(Arc::new(stringify!($function_name).to_lowercase()), columns).unwrap()
             };

--- a/src/optimizer/rule/normalization/simplification.rs
+++ b/src/optimizer/rule/normalization/simplification.rs
@@ -112,7 +112,7 @@ impl NormalizationRule for SimplifyFilter {
 #[cfg(test)]
 mod test {
     use crate::binder::test::select_sql_run;
-    use crate::catalog::{ColumnCatalog, ColumnDesc, ColumnSummary};
+    use crate::catalog::{ColumnCatalog, ColumnDesc, ColumnRelation, ColumnSummary};
     use crate::errors::DatabaseError;
     use crate::expression::range_detacher::{Range, RangeDetacher};
     use crate::expression::{BinaryOperator, ScalarExpression, UnaryOperator};
@@ -246,9 +246,11 @@ mod test {
         if let Operator::Filter(filter_op) = best_plan.childrens[0].clone().operator {
             let c1_col = ColumnCatalog {
                 summary: ColumnSummary {
-                    id: Some(0),
                     name: "c1".to_string(),
-                    table_name: Some(Arc::new("t1".to_string())),
+                    relation: ColumnRelation::Table {
+                        column_id: 0,
+                        table_name: Arc::new("t1".to_string()),
+                    },
                 },
                 nullable: false,
                 desc: ColumnDesc {
@@ -260,9 +262,11 @@ mod test {
             };
             let c2_col = ColumnCatalog {
                 summary: ColumnSummary {
-                    id: Some(1),
                     name: "c2".to_string(),
-                    table_name: Some(Arc::new("t1".to_string())),
+                    relation: ColumnRelation::Table {
+                        column_id: 1,
+                        table_name: Arc::new("t1".to_string()),
+                    },
                 },
                 nullable: false,
                 desc: ColumnDesc {

--- a/src/serdes/alias_type.rs
+++ b/src/serdes/alias_type.rs
@@ -1,0 +1,74 @@
+use crate::errors::DatabaseError;
+use crate::expression::{AliasType, ScalarExpression};
+use crate::serdes::{ReferenceSerialization, ReferenceTables, Serialization};
+use crate::storage::{TableCache, Transaction};
+use std::io::{Read, Write};
+
+impl ReferenceSerialization for AliasType {
+    fn encode<W: Write>(
+        &self,
+        writer: &mut W,
+        is_direct: bool,
+        reference_tables: &mut ReferenceTables,
+    ) -> Result<(), DatabaseError> {
+        match self {
+            AliasType::Name(name) => {
+                writer.write_all(&[0u8])?;
+
+                name.encode(writer)?;
+            }
+            AliasType::Expr(expr) => {
+                writer.write_all(&[1u8])?;
+
+                expr.encode(writer, is_direct, reference_tables)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn decode<T: Transaction, R: Read>(
+        reader: &mut R,
+        drive: Option<(&T, &TableCache)>,
+        reference_tables: &ReferenceTables,
+    ) -> Result<Self, DatabaseError> {
+        let mut type_bytes = [0u8; 1];
+        reader.read_exact(&mut type_bytes)?;
+
+        Ok(match type_bytes[0] {
+            0 => AliasType::Name(String::decode(reader)?),
+            1 => AliasType::Expr(Box::new(ScalarExpression::decode(
+                reader,
+                drive,
+                reference_tables,
+            )?)),
+            _ => unreachable!(),
+        })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use crate::errors::DatabaseError;
+    use crate::expression::AliasType;
+    use crate::serdes::{ReferenceSerialization, ReferenceTables};
+    use crate::storage::rocksdb::RocksTransaction;
+    use std::io::{Cursor, Seek, SeekFrom};
+
+    #[test]
+    fn test_serialization() -> Result<(), DatabaseError> {
+        let mut bytes = Vec::new();
+        let mut cursor = Cursor::new(&mut bytes);
+        let mut reference_tables = ReferenceTables::single();
+
+        let source = AliasType::Name("hello".to_string());
+        source.encode(&mut cursor, false, &mut reference_tables)?;
+        cursor.seek(SeekFrom::Start(0))?;
+        assert_eq!(
+            AliasType::decode::<RocksTransaction, _>(&mut cursor, None, &reference_tables)?,
+            source
+        );
+
+        Ok(())
+    }
+}

--- a/src/serdes/binary_operator.rs
+++ b/src/serdes/binary_operator.rs
@@ -1,0 +1,76 @@
+use crate::expression::BinaryOperator;
+use crate::serdes::Serialization;
+use std::io;
+use std::io::{Read, Write};
+
+impl Serialization for BinaryOperator {
+    type Error = io::Error;
+
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+        match self {
+            BinaryOperator::Plus => writer.write_all(&[0u8])?,
+            BinaryOperator::Minus => writer.write_all(&[1u8])?,
+            BinaryOperator::Multiply => writer.write_all(&[2u8])?,
+            BinaryOperator::Divide => writer.write_all(&[3u8])?,
+            BinaryOperator::Modulo => writer.write_all(&[4u8])?,
+            BinaryOperator::StringConcat => writer.write_all(&[5u8])?,
+            BinaryOperator::Gt => writer.write_all(&[6u8])?,
+            BinaryOperator::Lt => writer.write_all(&[7u8])?,
+            BinaryOperator::GtEq => writer.write_all(&[8u8])?,
+            BinaryOperator::LtEq => writer.write_all(&[9u8])?,
+            BinaryOperator::Spaceship => writer.write_all(&[10u8])?,
+            BinaryOperator::Eq => writer.write_all(&[11u8])?,
+            BinaryOperator::NotEq => writer.write_all(&[12u8])?,
+            BinaryOperator::Like(escape_char) => {
+                writer.write_all(&[13u8])?;
+
+                escape_char.encode(writer)?;
+            }
+            BinaryOperator::NotLike(escape_char) => {
+                writer.write_all(&[14u8])?;
+
+                escape_char.encode(writer)?;
+            }
+            BinaryOperator::And => writer.write_all(&[15u8])?,
+            BinaryOperator::Or => writer.write_all(&[16u8])?,
+            BinaryOperator::Xor => writer.write_all(&[17u8])?,
+        }
+
+        Ok(())
+    }
+
+    fn decode<R: Read>(reader: &mut R) -> Result<Self, Self::Error> {
+        let mut type_bytes = [0u8; 1];
+        reader.read_exact(&mut type_bytes)?;
+
+        Ok(match type_bytes[0] {
+            0 => BinaryOperator::Plus,
+            1 => BinaryOperator::Minus,
+            2 => BinaryOperator::Multiply,
+            3 => BinaryOperator::Divide,
+            4 => BinaryOperator::Modulo,
+            5 => BinaryOperator::StringConcat,
+            6 => BinaryOperator::Gt,
+            7 => BinaryOperator::Lt,
+            8 => BinaryOperator::GtEq,
+            9 => BinaryOperator::LtEq,
+            10 => BinaryOperator::Spaceship,
+            11 => BinaryOperator::Eq,
+            12 => BinaryOperator::NotEq,
+            13 => {
+                let escape_char = Option::<char>::decode(reader)?;
+
+                BinaryOperator::Like(escape_char)
+            }
+            14 => {
+                let escape_char = Option::<char>::decode(reader)?;
+
+                BinaryOperator::NotLike(escape_char)
+            }
+            15 => BinaryOperator::And,
+            16 => BinaryOperator::Or,
+            17 => BinaryOperator::Xor,
+            _ => unreachable!(),
+        })
+    }
+}

--- a/src/serdes/boolean.rs
+++ b/src/serdes/boolean.rs
@@ -1,0 +1,15 @@
+use crate::serdes::Serialization;
+use std::io;
+use std::io::{Read, Write};
+
+impl Serialization for bool {
+    type Error = io::Error;
+
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+        if *self { 1u8 } else { 0u8 }.encode(writer)
+    }
+
+    fn decode<R: Read>(reader: &mut R) -> Result<Self, Self::Error> {
+        Ok(u8::decode(reader)? == 1u8)
+    }
+}

--- a/src/serdes/char.rs
+++ b/src/serdes/char.rs
@@ -1,0 +1,22 @@
+use crate::serdes::Serialization;
+use encode_unicode::CharExt;
+use std::io;
+use std::io::{Read, Write};
+
+impl Serialization for char {
+    type Error = io::Error;
+
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+        let (bytes, _) = self.to_utf8_array();
+
+        writer.write_all(&bytes)
+    }
+
+    fn decode<R: Read>(reader: &mut R) -> Result<Self, Self::Error> {
+        let mut buf = [0u8; 4];
+        reader.read_exact(&mut buf)?;
+
+        // SAFETY
+        Ok(char::from_utf8_array(buf).unwrap())
+    }
+}

--- a/src/serdes/char_length_units.rs
+++ b/src/serdes/char_length_units.rs
@@ -1,0 +1,58 @@
+use crate::errors::DatabaseError;
+use crate::serdes::Serialization;
+use sqlparser::ast::CharLengthUnits;
+use std::io::{Read, Write};
+
+impl Serialization for CharLengthUnits {
+    type Error = DatabaseError;
+
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+        match self {
+            CharLengthUnits::Characters => 0u8,
+            CharLengthUnits::Octets => 1u8,
+        }
+        .encode(writer)?;
+
+        Ok(())
+    }
+
+    fn decode<R: Read>(reader: &mut R) -> Result<Self, Self::Error> {
+        let mut one_byte = [0u8; 1];
+        reader.read_exact(&mut one_byte)?;
+
+        Ok(match one_byte[0] {
+            0 => CharLengthUnits::Characters,
+            1 => CharLengthUnits::Octets,
+            _ => unreachable!(),
+        })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use crate::errors::DatabaseError;
+    use crate::serdes::Serialization;
+    use sqlparser::ast::CharLengthUnits;
+    use std::io::{Cursor, Seek, SeekFrom};
+
+    #[test]
+    fn test_serialization() -> Result<(), DatabaseError> {
+        let mut cursor = Cursor::new(Vec::new());
+
+        CharLengthUnits::Characters.encode(&mut cursor)?;
+        cursor.seek(SeekFrom::Start(0))?;
+        assert_eq!(
+            CharLengthUnits::decode(&mut cursor)?,
+            CharLengthUnits::Characters
+        );
+        cursor.seek(SeekFrom::Start(0))?;
+        CharLengthUnits::Octets.encode(&mut cursor)?;
+        cursor.seek(SeekFrom::Start(0))?;
+        assert_eq!(
+            CharLengthUnits::decode(&mut cursor)?,
+            CharLengthUnits::Octets
+        );
+
+        Ok(())
+    }
+}

--- a/src/serdes/column.rs
+++ b/src/serdes/column.rs
@@ -1,0 +1,359 @@
+use crate::catalog::{ColumnCatalog, ColumnDesc, ColumnRef, ColumnRelation, ColumnSummary};
+use crate::errors::DatabaseError;
+use crate::expression::ScalarExpression;
+use crate::serdes::{ReferenceSerialization, ReferenceTables, Serialization};
+use crate::storage::{TableCache, Transaction};
+use crate::types::{ColumnId, LogicalType};
+use std::io::{Read, Write};
+use std::sync::Arc;
+
+impl ReferenceSerialization for ColumnRef {
+    fn encode<W: Write>(
+        &self,
+        writer: &mut W,
+        is_direct: bool,
+        reference_tables: &mut ReferenceTables,
+    ) -> Result<(), DatabaseError> {
+        self.summary.encode(writer, is_direct, reference_tables)?;
+        if is_direct || matches!(self.summary.relation, ColumnRelation::None) {
+            self.nullable.encode(writer)?;
+            self.desc.encode(writer, is_direct, reference_tables)?;
+        }
+
+        Ok(())
+    }
+
+    fn decode<T: Transaction, R: Read>(
+        reader: &mut R,
+        drive: Option<(&T, &TableCache)>,
+        reference_tables: &ReferenceTables,
+    ) -> Result<Self, DatabaseError> {
+        let summary = ColumnSummary::decode(reader, drive, reference_tables)?;
+
+        if let (
+            ColumnRelation::Table {
+                column_id,
+                table_name,
+            },
+            Some((transaction, table_cache)),
+        ) = (&summary.relation, drive)
+        {
+            let table = transaction
+                .table(table_cache, table_name.clone())
+                .ok_or(DatabaseError::TableNotFound)?;
+            let column = table
+                .get_column_by_id(column_id)
+                .ok_or(DatabaseError::InvalidColumn(format!(
+                    "column id: {} not found",
+                    column_id
+                )))?;
+            Ok(column.clone())
+        } else {
+            let nullable = bool::decode(reader)?;
+            let desc = ColumnDesc::decode(reader, drive, reference_tables)?;
+
+            Ok(Arc::new(ColumnCatalog {
+                summary,
+                nullable,
+                desc,
+            }))
+        }
+    }
+}
+
+impl ReferenceSerialization for ColumnRelation {
+    fn encode<W: Write>(
+        &self,
+        writer: &mut W,
+        _: bool,
+        reference_tables: &mut ReferenceTables,
+    ) -> Result<(), DatabaseError> {
+        match self {
+            ColumnRelation::None => {
+                writer.write_all(&[0])?;
+            }
+            ColumnRelation::Table {
+                column_id,
+                table_name,
+            } => {
+                writer.write_all(&[1])?;
+
+                column_id.encode(writer)?;
+                (reference_tables.push_or_replace(table_name) as u32).encode(writer)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn decode<T: Transaction, R: Read>(
+        reader: &mut R,
+        _: Option<(&T, &TableCache)>,
+        reference_tables: &ReferenceTables,
+    ) -> Result<Self, DatabaseError> {
+        let mut type_bytes = [0u8; 1];
+        reader.read_exact(&mut type_bytes)?;
+
+        Ok(match type_bytes[0] {
+            0 => ColumnRelation::None,
+            1 => {
+                let column_id = ColumnId::decode(reader)?;
+                let table_name = reference_tables
+                    .get(u32::decode(reader)? as usize)
+                    .clone();
+
+                ColumnRelation::Table {
+                    column_id,
+                    table_name,
+                }
+            }
+            _ => unreachable!(),
+        })
+    }
+}
+
+impl ReferenceSerialization for ColumnSummary {
+    fn encode<W: Write>(
+        &self,
+        writer: &mut W,
+        is_direct: bool,
+        reference_tables: &mut ReferenceTables,
+    ) -> Result<(), DatabaseError> {
+        self.name.encode(writer)?;
+        self.relation.encode(writer, is_direct, reference_tables)?;
+
+        Ok(())
+    }
+
+    fn decode<T: Transaction, R: Read>(
+        reader: &mut R,
+        _: Option<(&T, &TableCache)>,
+        reference_tables: &ReferenceTables,
+    ) -> Result<Self, DatabaseError> {
+        let name = String::decode(reader)?;
+        let relation = ColumnRelation::decode::<T, R>(reader, None, reference_tables)?;
+
+        Ok(ColumnSummary { name, relation })
+    }
+}
+
+impl ReferenceSerialization for ColumnDesc {
+    fn encode<W: Write>(
+        &self,
+        writer: &mut W,
+        is_direct: bool,
+        reference_tables: &mut ReferenceTables,
+    ) -> Result<(), DatabaseError> {
+        self.is_unique.encode(writer)?;
+        self.is_primary.encode(writer)?;
+        self.column_datatype.encode(writer)?;
+        self.default.encode(writer, is_direct, reference_tables)?;
+
+        Ok(())
+    }
+
+    fn decode<T: Transaction, R: Read>(
+        reader: &mut R,
+        drive: Option<(&T, &TableCache)>,
+        reference_tables: &ReferenceTables,
+    ) -> Result<Self, DatabaseError> {
+        let is_unique = bool::decode(reader)?;
+        let is_primary = bool::decode(reader)?;
+        let column_datatype = LogicalType::decode(reader)?;
+        let default = Option::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+
+        ColumnDesc::new(
+            column_datatype,
+            is_primary,
+            is_unique,
+            default,
+        )
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use crate::catalog::{ColumnCatalog, ColumnDesc, ColumnRef, ColumnRelation, ColumnSummary};
+    use crate::db::test::build_table;
+    use crate::errors::DatabaseError;
+    use crate::expression::ScalarExpression;
+    use crate::serdes::ReferenceSerialization;
+    use crate::serdes::ReferenceTables;
+    use crate::storage::rocksdb::{RocksStorage, RocksTransaction};
+    use crate::storage::{StatisticsMetaCache, Storage, Transaction};
+    use crate::types::value::DataValue;
+    use crate::types::LogicalType;
+    use crate::utils::lru::ShardingLruCache;
+    use std::hash::RandomState;
+    use std::io::{Cursor, Seek, SeekFrom};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_column_serialization() -> Result<(), DatabaseError> {
+        let temp_dir = TempDir::new().expect("unable to create temporary working directory");
+        let storage = RocksStorage::new(temp_dir.path())?;
+        let mut transaction = storage.transaction()?;
+        let table_cache = Arc::new(ShardingLruCache::new(4, 1, RandomState::new())?);
+        let meta_cache = StatisticsMetaCache::new(4, 1, RandomState::new())?;
+
+        let table_name = Arc::new("t1".to_string());
+        build_table(&table_cache, &mut transaction)?;
+
+        let mut cursor = Cursor::new(Vec::new());
+        let mut reference_tables = ReferenceTables::single();
+
+        {
+            let ref_column = Arc::new(ColumnCatalog {
+                summary: ColumnSummary {
+                    name: "c3".to_string(),
+                    relation: ColumnRelation::Table {
+                        column_id: 2,
+                        table_name: table_name.clone(),
+                    },
+                },
+                nullable: false,
+                desc: ColumnDesc {
+                    column_datatype: LogicalType::Integer,
+                    is_primary: false,
+                    is_unique: false,
+                    default: None,
+                },
+            });
+
+            ref_column.encode(&mut cursor, false, &mut reference_tables)?;
+            cursor.seek(SeekFrom::Start(0))?;
+
+            assert_eq!(
+                ColumnRef::decode::<RocksTransaction, Cursor<Vec<u8>>>(
+                    &mut cursor,
+                    Some((&transaction, &table_cache)),
+                    &reference_tables
+                )?,
+                ref_column
+            );
+            cursor.seek(SeekFrom::Start(0))?;
+
+            transaction.drop_column(&table_cache, &meta_cache, &table_name, "c3")?;
+            assert!(ColumnRef::decode::<RocksTransaction, Cursor<Vec<u8>>>(
+                &mut cursor,
+                Some((&transaction, &table_cache)),
+                &reference_tables
+            )
+            .is_err());
+            cursor.seek(SeekFrom::Start(0))?;
+        }
+        {
+            let not_ref_column = Arc::new(ColumnCatalog {
+                summary: ColumnSummary {
+                    name: "c3".to_string(),
+                    relation: ColumnRelation::None,
+                },
+                nullable: false,
+                desc: ColumnDesc {
+                    column_datatype: LogicalType::Integer,
+                    is_primary: false,
+                    is_unique: false,
+                    default: Some(ScalarExpression::Constant(Arc::new(DataValue::UInt64(
+                        Some(42),
+                    )))),
+                },
+            });
+            not_ref_column.encode(&mut cursor, false, &mut reference_tables)?;
+            cursor.seek(SeekFrom::Start(0))?;
+
+            assert_eq!(
+                ColumnRef::decode::<RocksTransaction, Cursor<Vec<u8>>>(
+                    &mut cursor,
+                    None,
+                    &reference_tables
+                )?,
+                not_ref_column
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_column_summary_serialization() -> Result<(), DatabaseError> {
+        let mut cursor = Cursor::new(Vec::new());
+        let mut reference_tables = ReferenceTables::single();
+        let summary = ColumnSummary {
+            name: "c1".to_string(),
+            relation: ColumnRelation::Table {
+                column_id: 0,
+                table_name: Arc::new("t1".to_string()),
+            },
+        };
+        summary.encode(&mut cursor, false, &mut reference_tables)?;
+        cursor.seek(SeekFrom::Start(0))?;
+
+        assert_eq!(
+            ColumnSummary::decode::<RocksTransaction, Cursor<Vec<u8>>>(
+                &mut cursor,
+                None,
+                &reference_tables
+            )?,
+            summary
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_column_relation_serialization() -> Result<(), DatabaseError> {
+        let mut cursor = Cursor::new(Vec::new());
+        let mut reference_tables = ReferenceTables::single();
+        let none_relation = ColumnRelation::None;
+        none_relation.encode(&mut cursor, false, &mut reference_tables)?;
+        cursor.seek(SeekFrom::Start(0))?;
+
+        let decode_relation = ColumnRelation::decode::<RocksTransaction, Cursor<Vec<u8>>>(
+            &mut cursor,
+            None,
+            &reference_tables,
+        )?;
+        assert_eq!(none_relation, decode_relation);
+        cursor.seek(SeekFrom::Start(0))?;
+        let table_relation = ColumnRelation::Table {
+            column_id: 0,
+            table_name: Arc::new("t1".to_string()),
+        };
+        table_relation.encode(&mut cursor, false, &mut reference_tables)?;
+        cursor.seek(SeekFrom::Start(0))?;
+
+        let decode_relation = ColumnRelation::decode::<RocksTransaction, Cursor<Vec<u8>>>(
+            &mut cursor,
+            None,
+            &reference_tables,
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_column_desc_serialization() -> Result<(), DatabaseError> {
+        let mut cursor = Cursor::new(Vec::new());
+        let mut reference_tables = ReferenceTables::single();
+        let desc = ColumnDesc {
+            column_datatype: LogicalType::Integer,
+            is_primary: false,
+            is_unique: false,
+            default: Some(ScalarExpression::Constant(Arc::new(DataValue::UInt64(
+                Some(42),
+            )))),
+        };
+        desc.encode(&mut cursor, false, &mut reference_tables)?;
+        cursor.seek(SeekFrom::Start(0))?;
+
+        let decode_desc = ColumnDesc::decode::<RocksTransaction, Cursor<Vec<u8>>>(
+            &mut cursor,
+            None,
+            &reference_tables,
+        )?;
+        assert_eq!(desc, decode_desc);
+
+        Ok(())
+    }
+}

--- a/src/serdes/evaluator.rs
+++ b/src/serdes/evaluator.rs
@@ -1,0 +1,69 @@
+use crate::errors::DatabaseError;
+use crate::serdes::Serialization;
+use crate::types::evaluator::{BinaryEvaluatorBox, UnaryEvaluatorBox};
+use std::io::{Read, Write};
+
+impl Serialization for BinaryEvaluatorBox {
+    type Error = DatabaseError;
+
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+        let bytes = bincode::serialize(self)?;
+        (bytes.len() as u32).encode(writer)?;
+        writer.write_all(&bytes)?;
+
+        Ok(())
+    }
+
+    fn decode<R: Read>(reader: &mut R) -> Result<Self, Self::Error> {
+        let mut buf = vec![0u8; u32::decode(reader)? as usize];
+        reader.read_exact(&mut buf)?;
+
+        Ok(bincode::deserialize::<Self>(&buf)?)
+    }
+}
+
+impl Serialization for UnaryEvaluatorBox {
+    type Error = DatabaseError;
+
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+        let bytes = bincode::serialize(self)?;
+        (bytes.len() as u32).encode(writer)?;
+        writer.write_all(&bytes)?;
+
+        Ok(())
+    }
+
+    fn decode<R: Read>(reader: &mut R) -> Result<Self, Self::Error> {
+        let mut buf = vec![0u8; u32::decode(reader)? as usize];
+        reader.read_exact(&mut buf)?;
+
+        Ok(bincode::deserialize::<Self>(&buf)?)
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use crate::errors::DatabaseError;
+    use crate::serdes::Serialization;
+    use crate::types::evaluator::boolean::{BooleanNotEqBinaryEvaluator, BooleanNotUnaryEvaluator};
+    use crate::types::evaluator::{BinaryEvaluatorBox, UnaryEvaluatorBox};
+    use std::io::{Cursor, Seek, SeekFrom};
+    use std::sync::Arc;
+
+    #[test]
+    fn test_serialization() -> Result<(), DatabaseError> {
+        let mut cursor = Cursor::new(Vec::new());
+        let binary_evaluator = BinaryEvaluatorBox(Arc::new(BooleanNotEqBinaryEvaluator));
+        binary_evaluator.encode(&mut cursor)?;
+
+        cursor.seek(SeekFrom::Start(0))?;
+        assert_eq!(BinaryEvaluatorBox::decode(&mut cursor)?, binary_evaluator);
+        cursor.seek(SeekFrom::Start(0))?;
+        let unary_evaluator = UnaryEvaluatorBox(Arc::new(BooleanNotUnaryEvaluator));
+        unary_evaluator.encode(&mut cursor)?;
+        cursor.seek(SeekFrom::Start(0))?;
+        assert_eq!(UnaryEvaluatorBox::decode(&mut cursor)?, unary_evaluator);
+
+        Ok(())
+    }
+}

--- a/src/serdes/logic_type.rs
+++ b/src/serdes/logic_type.rs
@@ -1,0 +1,167 @@
+use crate::errors::DatabaseError;
+use crate::serdes::Serialization;
+use crate::types::LogicalType;
+use sqlparser::ast::CharLengthUnits;
+use std::io::{Read, Write};
+
+impl Serialization for LogicalType {
+    type Error = DatabaseError;
+
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+        match self {
+            LogicalType::Invalid => writer.write_all(&[0u8])?,
+            LogicalType::SqlNull => writer.write_all(&[1u8])?,
+            LogicalType::Boolean => writer.write_all(&[2u8])?,
+            LogicalType::Tinyint => writer.write_all(&[3u8])?,
+            LogicalType::UTinyint => writer.write_all(&[4u8])?,
+            LogicalType::Smallint => writer.write_all(&[5u8])?,
+            LogicalType::USmallint => writer.write_all(&[6u8])?,
+            LogicalType::Integer => writer.write_all(&[7u8])?,
+            LogicalType::UInteger => writer.write_all(&[8u8])?,
+            LogicalType::Bigint => writer.write_all(&[9u8])?,
+            LogicalType::UBigint => writer.write_all(&[10u8])?,
+            LogicalType::Float => writer.write_all(&[11u8])?,
+            LogicalType::Double => writer.write_all(&[12u8])?,
+            LogicalType::Char(len, units) => {
+                writer.write_all(&[13u8])?;
+                len.encode(writer)?;
+                units.encode(writer)?;
+            }
+            LogicalType::Varchar(len, units) => {
+                writer.write_all(&[14u8])?;
+
+                len.encode(writer)?;
+                units.encode(writer)?;
+            }
+            LogicalType::Date => writer.write_all(&[15u8])?,
+            LogicalType::DateTime => writer.write_all(&[16u8])?,
+            LogicalType::Time => writer.write_all(&[17u8])?,
+            LogicalType::Decimal(precision, scala) => {
+                writer.write_all(&[18u8])?;
+
+                precision.encode(writer)?;
+                scala.encode(writer)?;
+            }
+            LogicalType::Tuple => writer.write_all(&[19u8])?,
+        }
+
+        Ok(())
+    }
+
+    fn decode<R: Read>(reader: &mut R) -> Result<Self, Self::Error> {
+        let mut one_byte = [0u8; 1];
+        reader.read_exact(&mut one_byte)?;
+
+        Ok(match one_byte[0] {
+            0 => LogicalType::Invalid,
+            1 => LogicalType::SqlNull,
+            2 => LogicalType::Boolean,
+            3 => LogicalType::Tinyint,
+            4 => LogicalType::UTinyint,
+            5 => LogicalType::Smallint,
+            6 => LogicalType::USmallint,
+            7 => LogicalType::Integer,
+            8 => LogicalType::UInteger,
+            9 => LogicalType::Bigint,
+            10 => LogicalType::UBigint,
+            11 => LogicalType::Float,
+            12 => LogicalType::Double,
+            13 => {
+                let len = u32::decode(reader)?;
+                let units = CharLengthUnits::decode(reader)?;
+
+                LogicalType::Char(len, units)
+            }
+            14 => {
+                let len = Option::<u32>::decode(reader)?;
+                let units = CharLengthUnits::decode(reader)?;
+
+                LogicalType::Varchar(len, units)
+            }
+            15 => LogicalType::Date,
+            16 => LogicalType::DateTime,
+            17 => LogicalType::Time,
+            18 => {
+                let precision = Option::<u8>::decode(reader)?;
+                let scala = Option::<u8>::decode(reader)?;
+
+                LogicalType::Decimal(precision, scala)
+            }
+            19 => LogicalType::Tuple,
+            _ => unreachable!(),
+        })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use crate::errors::DatabaseError;
+    use crate::serdes::{ReferenceTables, Serialization};
+    use crate::types::LogicalType;
+    use sqlparser::ast::CharLengthUnits;
+    use std::io::{Cursor, Read, Seek, SeekFrom, Write};
+    use std::sync::Arc;
+
+    #[test]
+    fn test_logic_type_serialization() -> Result<(), DatabaseError> {
+        fn fn_assert(
+            cursor: &mut Cursor<Vec<u8>>,
+            logical_type: LogicalType,
+        ) -> Result<(), DatabaseError> {
+            logical_type.encode(cursor)?;
+
+            cursor.seek(SeekFrom::Start(0))?;
+            assert_eq!(LogicalType::decode(cursor)?, logical_type);
+            cursor.seek(SeekFrom::Start(0))?;
+
+            Ok(())
+        }
+
+        let mut cursor = Cursor::new(Vec::new());
+
+        fn_assert(&mut cursor, LogicalType::Invalid)?;
+        fn_assert(&mut cursor, LogicalType::SqlNull)?;
+        fn_assert(&mut cursor, LogicalType::Boolean)?;
+        fn_assert(&mut cursor, LogicalType::Tinyint)?;
+        fn_assert(&mut cursor, LogicalType::UTinyint)?;
+        fn_assert(&mut cursor, LogicalType::Smallint)?;
+        fn_assert(&mut cursor, LogicalType::USmallint)?;
+        fn_assert(&mut cursor, LogicalType::Integer)?;
+        fn_assert(&mut cursor, LogicalType::UInteger)?;
+        fn_assert(&mut cursor, LogicalType::Bigint)?;
+        fn_assert(&mut cursor, LogicalType::UBigint)?;
+        fn_assert(&mut cursor, LogicalType::Float)?;
+        fn_assert(&mut cursor, LogicalType::Double)?;
+        fn_assert(
+            &mut cursor,
+            LogicalType::Char(42, CharLengthUnits::Characters),
+        )?;
+        fn_assert(&mut cursor, LogicalType::Char(42, CharLengthUnits::Octets))?;
+        fn_assert(
+            &mut cursor,
+            LogicalType::Varchar(Some(42), CharLengthUnits::Characters),
+        )?;
+        fn_assert(
+            &mut cursor,
+            LogicalType::Varchar(None, CharLengthUnits::Characters),
+        )?;
+        fn_assert(
+            &mut cursor,
+            LogicalType::Varchar(Some(42), CharLengthUnits::Octets),
+        )?;
+        fn_assert(
+            &mut cursor,
+            LogicalType::Varchar(None, CharLengthUnits::Octets),
+        )?;
+        fn_assert(&mut cursor, LogicalType::Date)?;
+        fn_assert(&mut cursor, LogicalType::DateTime)?;
+        fn_assert(&mut cursor, LogicalType::Time)?;
+        fn_assert(&mut cursor, LogicalType::Decimal(Some(4), Some(2)))?;
+        fn_assert(&mut cursor, LogicalType::Decimal(Some(4), None))?;
+        fn_assert(&mut cursor, LogicalType::Decimal(None, Some(2)))?;
+        fn_assert(&mut cursor, LogicalType::Decimal(None, None))?;
+        fn_assert(&mut cursor, LogicalType::Tuple)?;
+
+        Ok(())
+    }
+}

--- a/src/serdes/logic_type.rs
+++ b/src/serdes/logic_type.rs
@@ -96,11 +96,10 @@ impl Serialization for LogicalType {
 #[cfg(test)]
 pub(crate) mod test {
     use crate::errors::DatabaseError;
-    use crate::serdes::{ReferenceTables, Serialization};
+    use crate::serdes::Serialization;
     use crate::types::LogicalType;
     use sqlparser::ast::CharLengthUnits;
-    use std::io::{Cursor, Read, Seek, SeekFrom, Write};
-    use std::sync::Arc;
+    use std::io::{Cursor, Seek, SeekFrom};
 
     #[test]
     fn test_logic_type_serialization() -> Result<(), DatabaseError> {

--- a/src/serdes/mod.rs
+++ b/src/serdes/mod.rs
@@ -55,6 +55,14 @@ impl ReferenceTables {
         ReferenceTables { tables: vec![] }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.tables.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.tables.len()
+    }
+
     pub fn get(&self, i: usize) -> &TableName {
         &self.tables[i]
     }

--- a/src/serdes/mod.rs
+++ b/src/serdes/mod.rs
@@ -1,0 +1,86 @@
+mod alias_type;
+mod binary_operator;
+mod boolean;
+mod char;
+mod char_length_units;
+mod column;
+mod evaluator;
+mod logic_type;
+mod num;
+mod option;
+mod ptr;
+mod scala_expression;
+mod scala_function;
+mod string;
+mod table_function;
+mod trim;
+mod unary_operator;
+
+use crate::catalog::TableName;
+use crate::errors::DatabaseError;
+use crate::storage::{TableCache, Transaction};
+use std::io::{Read, Write};
+use std::{io, mem};
+
+pub trait ReferenceSerialization: Sized {
+    fn encode<W: Write>(
+        &self,
+        writer: &mut W,
+        is_direct: bool,
+        reference_tables: &mut ReferenceTables,
+    ) -> Result<(), DatabaseError>;
+
+    fn decode<T: Transaction, R: Read>(
+        reader: &mut R,
+        drive: Option<(&T, &TableCache)>,
+        reference_tables: &ReferenceTables,
+    ) -> Result<Self, DatabaseError>;
+}
+
+pub trait Serialization: Sized {
+    type Error: From<io::Error> + std::error::Error + Send + Sync + 'static;
+
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error>;
+
+    fn decode<R: Read>(reader: &mut R) -> Result<Self, Self::Error>;
+}
+
+pub enum ReferenceTables {
+    Single(Option<TableName>),
+    Multiple(Vec<TableName>),
+}
+
+impl ReferenceTables {
+    pub fn single() -> Self {
+        ReferenceTables::Single(None)
+    }
+
+    pub fn multiple() -> Self {
+        ReferenceTables::Multiple(Vec::new())
+    }
+
+    pub fn get(&self, i: usize) -> &TableName {
+        match self {
+            ReferenceTables::Single(table_name) => table_name.as_ref().unwrap(),
+            ReferenceTables::Multiple(tables) => &tables[i],
+        }
+    }
+
+    pub fn push_or_replace(&mut self, table_name: &TableName) -> usize {
+        match self {
+            ReferenceTables::Single(table) => {
+                let _ = mem::replace(table, Some(table_name.clone()));
+                0
+            }
+            ReferenceTables::Multiple(tables) => {
+                for (i, item) in tables.iter().enumerate() {
+                    if item == table_name {
+                        return i;
+                    }
+                }
+                tables.push(table_name.clone());
+                tables.len() - 1
+            }
+        }
+    }
+}

--- a/src/serdes/num.rs
+++ b/src/serdes/num.rs
@@ -1,0 +1,87 @@
+use crate::serdes::Serialization;
+use std::io;
+use std::io::Read;
+use std::io::Write;
+use std::mem::size_of;
+
+#[macro_export]
+macro_rules! implement_num_serialization {
+    ($struct_name:ident) => {
+        impl Serialization for $struct_name {
+            type Error = io::Error;
+
+            fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+                writer.write_all(&self.to_le_bytes()[..])
+            }
+
+            fn decode<R: Read>(reader: &mut R) -> Result<Self, Self::Error> {
+                let mut bytes = [0u8; size_of::<Self>()];
+                reader.read_exact(&mut bytes)?;
+
+                Ok(Self::from_le_bytes(bytes))
+            }
+        }
+    };
+}
+
+implement_num_serialization!(i8);
+implement_num_serialization!(i16);
+implement_num_serialization!(i32);
+implement_num_serialization!(i64);
+implement_num_serialization!(u8);
+implement_num_serialization!(u16);
+implement_num_serialization!(u32);
+implement_num_serialization!(u64);
+
+#[cfg(test)]
+pub(crate) mod test {
+    use crate::errors::DatabaseError;
+    use crate::serdes::Serialization;
+    use std::io::{Cursor, Seek, SeekFrom};
+
+    #[test]
+    fn test_serialization() -> Result<(), DatabaseError> {
+        let source_0 = 8u8;
+        let source_1 = 16u16;
+        let source_2 = 32u32;
+        let source_3 = 64u64;
+        let source_4 = 8i8;
+        let source_5 = 16i16;
+        let source_6 = 32i32;
+        let source_7 = 64i64;
+
+        let mut bytes = Vec::new();
+        let mut cursor = Cursor::new(&mut bytes);
+
+        source_0.encode(&mut cursor)?;
+        source_1.encode(&mut cursor)?;
+        source_2.encode(&mut cursor)?;
+        source_3.encode(&mut cursor)?;
+        source_4.encode(&mut cursor)?;
+        source_5.encode(&mut cursor)?;
+        source_6.encode(&mut cursor)?;
+        source_7.encode(&mut cursor)?;
+
+        cursor.seek(SeekFrom::Start(0))?;
+
+        let decoded_0 = u8::decode(&mut cursor).unwrap();
+        let decoded_1 = u16::decode(&mut cursor).unwrap();
+        let decoded_2 = u32::decode(&mut cursor).unwrap();
+        let decoded_3 = u64::decode(&mut cursor).unwrap();
+        let decoded_4 = i8::decode(&mut cursor).unwrap();
+        let decoded_5 = i16::decode(&mut cursor).unwrap();
+        let decoded_6 = i32::decode(&mut cursor).unwrap();
+        let decoded_7 = i64::decode(&mut cursor).unwrap();
+
+        assert_eq!(source_0, decoded_0);
+        assert_eq!(source_1, decoded_1);
+        assert_eq!(source_2, decoded_2);
+        assert_eq!(source_3, decoded_3);
+        assert_eq!(source_4, decoded_4);
+        assert_eq!(source_5, decoded_5);
+        assert_eq!(source_6, decoded_6);
+        assert_eq!(source_7, decoded_7);
+
+        Ok(())
+    }
+}

--- a/src/serdes/option.rs
+++ b/src/serdes/option.rs
@@ -1,0 +1,65 @@
+use crate::errors::DatabaseError;
+use crate::serdes::{ReferenceSerialization, ReferenceTables, Serialization};
+use crate::storage::{TableCache, Transaction};
+use std::io::{Read, Write};
+
+impl<V> ReferenceSerialization for Option<V>
+where
+    V: ReferenceSerialization,
+{
+    fn encode<W: Write>(
+        &self,
+        writer: &mut W,
+        is_direct: bool,
+        reference_tables: &mut ReferenceTables,
+    ) -> Result<(), DatabaseError> {
+        match self {
+            None => 0u8.encode(writer)?,
+            Some(v) => {
+                1u8.encode(writer)?;
+                v.encode(writer, is_direct, reference_tables)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn decode<T: Transaction, R: Read>(
+        reader: &mut R,
+        drive: Option<(&T, &TableCache)>,
+        reference_tables: &ReferenceTables,
+    ) -> Result<Self, DatabaseError> {
+        match u8::decode(reader)? {
+            0 => Ok(None),
+            1 => Ok(Some(V::decode(reader, drive, reference_tables)?)),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<V> Serialization for Option<V>
+where
+    V: Serialization,
+{
+    type Error = V::Error;
+
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+        match self {
+            None => 0u8.encode(writer)?,
+            Some(v) => {
+                1u8.encode(writer)?;
+                v.encode(writer)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn decode<R: Read>(reader: &mut R) -> Result<Self, Self::Error> {
+        match u8::decode(reader)? {
+            0 => Ok(None),
+            1 => Ok(Some(V::decode(reader)?)),
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/serdes/ptr.rs
+++ b/src/serdes/ptr.rs
@@ -1,0 +1,55 @@
+use crate::serdes::DatabaseError;
+use crate::serdes::TableCache;
+use crate::serdes::Transaction;
+use crate::serdes::{ReferenceSerialization, ReferenceTables, Serialization};
+use std::io::{Read, Write};
+use std::sync::Arc;
+
+#[macro_export]
+macro_rules! implement_ptr_serialization {
+    ($struct_name:ident) => {
+        impl<V> ReferenceSerialization for $struct_name<V>
+        where
+            V: ReferenceSerialization,
+        {
+            fn encode<W: Write>(
+                &self,
+                writer: &mut W,
+                is_direct: bool,
+                reference_tables: &mut ReferenceTables,
+            ) -> Result<(), DatabaseError> {
+                self.as_ref().encode(writer, is_direct, reference_tables)
+            }
+
+            fn decode<T: Transaction, R: Read>(
+                reader: &mut R,
+                drive: Option<(&T, &TableCache)>,
+                reference_tables: &ReferenceTables,
+            ) -> Result<Self, DatabaseError> {
+                Ok($struct_name::from(V::decode(
+                    reader,
+                    drive,
+                    reference_tables,
+                )?))
+            }
+        }
+
+        impl<V> Serialization for $struct_name<V>
+        where
+            V: Serialization,
+        {
+            type Error = V::Error;
+
+            fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+                self.as_ref().encode(writer)
+            }
+
+            fn decode<R: Read>(reader: &mut R) -> Result<Self, Self::Error> {
+                Ok($struct_name::from(V::decode(reader)?))
+            }
+        }
+    };
+}
+
+implement_ptr_serialization!(Arc);
+implement_ptr_serialization!(Box);

--- a/src/serdes/scala_expression.rs
+++ b/src/serdes/scala_expression.rs
@@ -1,0 +1,911 @@
+use crate::catalog::ColumnRef;
+use crate::errors::DatabaseError;
+use crate::expression::agg::AggKind;
+use crate::expression::function::scala::ScalarFunction;
+use crate::expression::function::table::TableFunction;
+use crate::expression::{AliasType, BinaryOperator, ScalarExpression, UnaryOperator};
+use crate::serdes::{ReferenceSerialization, ReferenceTables, Serialization};
+use crate::storage::{TableCache, Transaction};
+use crate::types::evaluator::{BinaryEvaluatorBox, UnaryEvaluatorBox};
+use crate::types::value::DataValue;
+use crate::types::LogicalType;
+use sqlparser::ast::TrimWhereField;
+use std::io::{Read, Write};
+use std::sync::Arc;
+
+impl ReferenceSerialization for ScalarExpression {
+    fn encode<W: Write>(
+        &self,
+        writer: &mut W,
+        is_direct: bool,
+        reference_tables: &mut ReferenceTables,
+    ) -> Result<(), DatabaseError> {
+        match self {
+            ScalarExpression::Constant(value) => {
+                writer.write_all(&[0u8])?;
+
+                let logical_type = value.logical_type();
+
+                logical_type.encode(writer)?;
+                value.is_null().encode(writer)?;
+
+                if value.is_null() {
+                    return Ok(());
+                }
+                if logical_type.raw_len().is_none() {
+                    let mut bytes = Vec::new();
+                    (value.to_raw(&mut bytes)? as u32).encode(writer)?;
+                    writer.write_all(&bytes)?;
+                } else {
+                    let _ = value.to_raw(writer)?;
+                }
+            }
+            ScalarExpression::ColumnRef(column) => {
+                writer.write_all(&[1u8])?;
+
+                column.encode(writer, is_direct, reference_tables)?;
+            }
+            ScalarExpression::Alias { expr, alias } => {
+                writer.write_all(&[2u8])?;
+
+                expr.encode(writer, is_direct, reference_tables)?;
+                alias.encode(writer, is_direct, reference_tables)?;
+            }
+            ScalarExpression::TypeCast { expr, ty } => {
+                writer.write_all(&[3u8])?;
+
+                expr.encode(writer, is_direct, reference_tables)?;
+                ty.encode(writer)?;
+            }
+            ScalarExpression::IsNull { expr, negated } => {
+                writer.write_all(&[4u8])?;
+
+                expr.encode(writer, is_direct, reference_tables)?;
+                negated.encode(writer)?;
+            }
+            ScalarExpression::Unary {
+                op,
+                expr,
+                ty,
+                evaluator,
+            } => {
+                writer.write_all(&[5u8])?;
+
+                op.encode(writer)?;
+                expr.encode(writer, is_direct, reference_tables)?;
+                ty.encode(writer)?;
+                evaluator.encode(writer)?;
+            }
+            ScalarExpression::Binary {
+                op,
+                left_expr,
+                right_expr,
+                ty,
+                evaluator,
+            } => {
+                writer.write_all(&[6u8])?;
+
+                op.encode(writer)?;
+                left_expr.encode(writer, is_direct, reference_tables)?;
+                right_expr.encode(writer, is_direct, reference_tables)?;
+                ty.encode(writer)?;
+                evaluator.encode(writer)?;
+            }
+            ScalarExpression::AggCall {
+                distinct,
+                kind,
+                args,
+                ty,
+            } => {
+                writer.write_all(&[7u8])?;
+
+                distinct.encode(writer)?;
+                kind.encode(writer)?;
+                (args.len() as u32).encode(writer)?;
+                for arg in args.iter() {
+                    arg.encode(writer, is_direct, reference_tables)?
+                }
+                ty.encode(writer)?;
+            }
+            ScalarExpression::In {
+                negated,
+                expr,
+                args,
+            } => {
+                writer.write_all(&[8u8])?;
+
+                negated.encode(writer)?;
+                expr.encode(writer, is_direct, reference_tables)?;
+                (args.len() as u32).encode(writer)?;
+                for arg in args.iter() {
+                    arg.encode(writer, is_direct, reference_tables)?
+                }
+            }
+            ScalarExpression::Between {
+                negated,
+                expr,
+                left_expr,
+                right_expr,
+            } => {
+                writer.write_all(&[9u8])?;
+
+                negated.encode(writer)?;
+                expr.encode(writer, is_direct, reference_tables)?;
+                left_expr.encode(writer, is_direct, reference_tables)?;
+                right_expr.encode(writer, is_direct, reference_tables)?;
+            }
+            ScalarExpression::SubString {
+                expr,
+                for_expr,
+                from_expr,
+            } => {
+                writer.write_all(&[10u8])?;
+
+                expr.encode(writer, is_direct, reference_tables)?;
+                for_expr.encode(writer, is_direct, reference_tables)?;
+                from_expr.encode(writer, is_direct, reference_tables)?;
+            }
+            ScalarExpression::Position { expr, in_expr } => {
+                writer.write_all(&[11u8])?;
+
+                expr.encode(writer, is_direct, reference_tables)?;
+                in_expr.encode(writer, is_direct, reference_tables)?;
+            }
+            ScalarExpression::Trim {
+                expr,
+                trim_what_expr,
+                trim_where,
+            } => {
+                writer.write_all(&[12u8])?;
+
+                expr.encode(writer, is_direct, reference_tables)?;
+                trim_what_expr.encode(writer, is_direct, reference_tables)?;
+                trim_where.encode(writer)?;
+            }
+            ScalarExpression::Empty => writer.write_all(&[13u8])?,
+            ScalarExpression::Reference { expr, pos } => {
+                writer.write_all(&[14u8])?;
+
+                expr.encode(writer, is_direct, reference_tables)?;
+                (*pos as u32).encode(writer)?;
+            }
+            ScalarExpression::Tuple(exprs) => {
+                writer.write_all(&[15u8])?;
+
+                (exprs.len() as u32).encode(writer)?;
+                for expr in exprs.iter() {
+                    expr.encode(writer, is_direct, reference_tables)?
+                }
+            }
+            ScalarExpression::ScalaFunction(function) => {
+                writer.write_all(&[16u8])?;
+
+                function.encode(writer, is_direct, reference_tables)?;
+            }
+            ScalarExpression::TableFunction(function) => {
+                writer.write_all(&[17u8])?;
+
+                function.encode(writer, is_direct, reference_tables)?;
+            }
+            ScalarExpression::If {
+                condition,
+                left_expr,
+                right_expr,
+                ty,
+            } => {
+                writer.write_all(&[18u8])?;
+
+                condition.encode(writer, is_direct, reference_tables)?;
+                left_expr.encode(writer, is_direct, reference_tables)?;
+                right_expr.encode(writer, is_direct, reference_tables)?;
+                ty.encode(writer)?;
+            }
+            ScalarExpression::IfNull {
+                left_expr,
+                right_expr,
+                ty,
+            } => {
+                writer.write_all(&[19u8])?;
+
+                left_expr.encode(writer, is_direct, reference_tables)?;
+                right_expr.encode(writer, is_direct, reference_tables)?;
+                ty.encode(writer)?;
+            }
+            ScalarExpression::NullIf {
+                left_expr,
+                right_expr,
+                ty,
+            } => {
+                writer.write_all(&[20u8])?;
+
+                left_expr.encode(writer, is_direct, reference_tables)?;
+                right_expr.encode(writer, is_direct, reference_tables)?;
+                ty.encode(writer)?;
+            }
+            ScalarExpression::Coalesce { exprs, ty } => {
+                writer.write_all(&[21u8])?;
+
+                (exprs.len() as u32).encode(writer)?;
+                for expr in exprs.iter() {
+                    expr.encode(writer, is_direct, reference_tables)?
+                }
+                ty.encode(writer)?;
+            }
+            ScalarExpression::CaseWhen {
+                operand_expr,
+                expr_pairs,
+                else_expr,
+                ty,
+            } => {
+                writer.write_all(&[22u8])?;
+
+                operand_expr.encode(writer, is_direct, reference_tables)?;
+                (expr_pairs.len() as u32).encode(writer)?;
+                for (left_expr, right_expr) in expr_pairs.iter() {
+                    left_expr.encode(writer, is_direct, reference_tables)?;
+                    right_expr.encode(writer, is_direct, reference_tables)?;
+                }
+                else_expr.encode(writer, is_direct, reference_tables)?;
+                ty.encode(writer)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn decode<T: Transaction, R: Read>(
+        reader: &mut R,
+        drive: Option<(&T, &TableCache)>,
+        reference_tables: &ReferenceTables,
+    ) -> Result<Self, DatabaseError> {
+        let mut type_bytes = [0u8; 1];
+        reader.read_exact(&mut type_bytes)?;
+
+        Ok(match type_bytes[0] {
+            0 => {
+                let logical_type = LogicalType::decode(reader)?;
+                let is_null = bool::decode(reader)?;
+
+                let value = if is_null {
+                    DataValue::none(&logical_type)
+                } else {
+                    let value_len = match logical_type.raw_len() {
+                        None => u32::decode(reader)? as usize,
+                        Some(len) => len,
+                    };
+                    let mut buf = vec![0u8; value_len];
+                    reader.read_exact(&mut buf)?;
+
+                    DataValue::from_raw(&buf, &logical_type)
+                };
+
+                ScalarExpression::Constant(Arc::new(value))
+            }
+            1 => {
+                let column_ref = ColumnRef::decode(reader, drive, reference_tables)?;
+
+                ScalarExpression::ColumnRef(column_ref)
+            }
+            2 => {
+                let expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let alias = AliasType::decode(reader, drive, reference_tables)?;
+
+                ScalarExpression::Alias { expr, alias }
+            }
+            3 => {
+                let expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let ty = LogicalType::decode(reader)?;
+
+                ScalarExpression::TypeCast { expr, ty }
+            }
+            4 => {
+                let expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let negated = bool::decode(reader)?;
+
+                ScalarExpression::IsNull { negated, expr }
+            }
+            5 => {
+                let op = UnaryOperator::decode(reader)?;
+                let expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let ty = LogicalType::decode(reader)?;
+                let evaluator = Option::<UnaryEvaluatorBox>::decode(reader)?;
+
+                ScalarExpression::Unary {
+                    op,
+                    expr,
+                    evaluator,
+                    ty,
+                }
+            }
+            6 => {
+                let op = BinaryOperator::decode(reader)?;
+                let left_expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let right_expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let ty = LogicalType::decode(reader)?;
+                let evaluator = Option::<BinaryEvaluatorBox>::decode(reader)?;
+
+                ScalarExpression::Binary {
+                    op,
+                    left_expr,
+                    right_expr,
+                    evaluator,
+                    ty,
+                }
+            }
+            7 => {
+                let distinct = bool::decode(reader)?;
+                let kind = AggKind::decode(reader)?;
+                let args_len = u32::decode(reader)? as usize;
+
+                let mut args = Vec::with_capacity(args_len);
+                for _ in 0..args_len {
+                    args.push(ScalarExpression::decode(reader, drive, reference_tables)?);
+                }
+                let ty = LogicalType::decode(reader)?;
+
+                ScalarExpression::AggCall {
+                    distinct,
+                    kind,
+                    args,
+                    ty,
+                }
+            }
+            8 => {
+                let negated = bool::decode(reader)?;
+                let expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let args_len = u32::decode(reader)? as usize;
+
+                let mut args = Vec::with_capacity(args_len);
+                for _ in 0..args_len {
+                    args.push(ScalarExpression::decode(reader, drive, reference_tables)?);
+                }
+
+                ScalarExpression::In {
+                    negated,
+                    expr,
+                    args,
+                }
+            }
+            9 => {
+                let negated = bool::decode(reader)?;
+                let expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let left_expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let right_expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+
+                ScalarExpression::Between {
+                    negated,
+                    expr,
+                    left_expr,
+                    right_expr,
+                }
+            }
+            10 => {
+                let expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let for_expr =
+                    Option::<Box<ScalarExpression>>::decode(reader, drive, reference_tables)?;
+                let from_expr =
+                    Option::<Box<ScalarExpression>>::decode(reader, drive, reference_tables)?;
+
+                ScalarExpression::SubString {
+                    expr,
+                    for_expr,
+                    from_expr,
+                }
+            }
+            11 => {
+                let expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let in_expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+
+                ScalarExpression::Position { expr, in_expr }
+            }
+            12 => {
+                let expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let trim_what_expr =
+                    Option::<Box<ScalarExpression>>::decode(reader, drive, reference_tables)?;
+                let trim_where = Option::<TrimWhereField>::decode(reader)?;
+
+                ScalarExpression::Trim {
+                    expr,
+                    trim_what_expr,
+                    trim_where,
+                }
+            }
+            13 => ScalarExpression::Empty,
+            14 => {
+                let expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let pos = u32::decode(reader)? as usize;
+
+                ScalarExpression::Reference { expr, pos }
+            }
+            15 => {
+                let exprs_len = u32::decode(reader)? as usize;
+
+                let mut exprs = Vec::with_capacity(exprs_len);
+                for _ in 0..exprs_len {
+                    exprs.push(ScalarExpression::decode(reader, drive, reference_tables)?);
+                }
+
+                ScalarExpression::Tuple(exprs)
+            }
+            16 => {
+                let function = ScalarFunction::decode(reader, drive, reference_tables)?;
+
+                ScalarExpression::ScalaFunction(function)
+            }
+            17 => {
+                let function = TableFunction::decode(reader, drive, reference_tables)?;
+
+                ScalarExpression::TableFunction(function)
+            }
+            18 => {
+                let condition = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let left_expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let right_expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let ty = LogicalType::decode(reader)?;
+
+                ScalarExpression::If {
+                    condition,
+                    left_expr,
+                    right_expr,
+                    ty,
+                }
+            }
+            19 => {
+                let left_expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let right_expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let ty = LogicalType::decode(reader)?;
+
+                ScalarExpression::IfNull {
+                    left_expr,
+                    right_expr,
+                    ty,
+                }
+            }
+            20 => {
+                let left_expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let right_expr = Box::<ScalarExpression>::decode(reader, drive, reference_tables)?;
+                let ty = LogicalType::decode(reader)?;
+
+                ScalarExpression::NullIf {
+                    left_expr,
+                    right_expr,
+                    ty,
+                }
+            }
+            21 => {
+                let exprs_len = u32::decode(reader)? as usize;
+
+                let mut exprs = Vec::with_capacity(exprs_len);
+                for _ in 0..exprs_len {
+                    exprs.push(ScalarExpression::decode(reader, drive, reference_tables)?);
+                }
+                let ty = LogicalType::decode(reader)?;
+
+                ScalarExpression::Coalesce { exprs, ty }
+            }
+            22 => {
+                let operand_expr =
+                    Option::<Box<ScalarExpression>>::decode(reader, drive, reference_tables)?;
+
+                let pairs_len = u32::decode(reader)? as usize;
+
+                let mut expr_pairs = Vec::with_capacity(pairs_len);
+                for _ in 0..pairs_len {
+                    let left_expr = ScalarExpression::decode(reader, drive, reference_tables)?;
+                    let right_expr = ScalarExpression::decode(reader, drive, reference_tables)?;
+
+                    expr_pairs.push((left_expr, right_expr));
+                }
+                let else_expr =
+                    Option::<Box<ScalarExpression>>::decode(reader, drive, reference_tables)?;
+                let ty = LogicalType::decode(reader)?;
+
+                ScalarExpression::CaseWhen {
+                    operand_expr,
+                    expr_pairs,
+                    else_expr,
+                    ty,
+                }
+            }
+            _ => unreachable!(),
+        })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use crate::catalog::{ColumnCatalog, ColumnDesc, ColumnRelation, ColumnSummary};
+    use crate::db::test::build_table;
+    use crate::errors::DatabaseError;
+    use crate::expression::agg::AggKind;
+    use crate::expression::function::scala::ScalarFunction;
+    use crate::expression::function::table::TableFunction;
+    use crate::expression::{AliasType, BinaryOperator, ScalarExpression, UnaryOperator};
+    use crate::function::current_date::CurrentDate;
+    use crate::function::numbers::Numbers;
+    use crate::serdes::{ReferenceSerialization, ReferenceTables};
+    use crate::storage::rocksdb::{RocksStorage, RocksTransaction};
+    use crate::storage::{Storage, TableCache};
+    use crate::types::evaluator::boolean::BooleanNotUnaryEvaluator;
+    use crate::types::evaluator::int32::Int32PlusBinaryEvaluator;
+    use crate::types::evaluator::{BinaryEvaluatorBox, UnaryEvaluatorBox};
+    use crate::types::value::{DataValue, Utf8Type};
+    use crate::types::LogicalType;
+    use crate::utils::lru::ShardingLruCache;
+    use sqlparser::ast::{CharLengthUnits, TrimWhereField};
+    use std::hash::RandomState;
+    use std::io::{Cursor, Seek, SeekFrom};
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_serialization() -> Result<(), DatabaseError> {
+        fn fn_assert(
+            cursor: &mut Cursor<Vec<u8>>,
+            expr: ScalarExpression,
+            drive: Option<(&RocksTransaction, &TableCache)>,
+            reference_tables: &mut ReferenceTables,
+        ) -> Result<(), DatabaseError> {
+            expr.encode(cursor, false, reference_tables)?;
+
+            cursor.seek(SeekFrom::Start(0))?;
+            assert_eq!(
+                ScalarExpression::decode(cursor, drive, reference_tables)?,
+                expr
+            );
+            cursor.seek(SeekFrom::Start(0))?;
+
+            Ok(())
+        }
+
+        let temp_dir = TempDir::new().expect("unable to create temporary working directory");
+        let storage = RocksStorage::new(temp_dir.path())?;
+        let mut transaction = storage.transaction()?;
+        let table_cache = Arc::new(ShardingLruCache::new(4, 1, RandomState::new())?);
+
+        build_table(&table_cache, &mut transaction)?;
+
+        let mut cursor = Cursor::new(Vec::new());
+        let mut reference_tables = ReferenceTables::single();
+
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::Constant(Arc::new(DataValue::Int32(None))),
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::Constant(Arc::new(DataValue::Int32(Some(42)))),
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::Constant(Arc::new(DataValue::Utf8 {
+                value: Some("hello".to_string()),
+                ty: Utf8Type::Variable(None),
+                unit: CharLengthUnits::Characters,
+            })),
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::ColumnRef(Arc::new(ColumnCatalog {
+                summary: ColumnSummary {
+                    name: "c3".to_string(),
+                    relation: ColumnRelation::Table {
+                        column_id: 2,
+                        table_name: Arc::new("t1".to_string()),
+                    },
+                },
+                nullable: false,
+                desc: ColumnDesc::new(LogicalType::Integer, false, false, None).unwrap(),
+            })),
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::ColumnRef(Arc::new(ColumnCatalog {
+                summary: ColumnSummary {
+                    name: "c4".to_string(),
+                    relation: ColumnRelation::None,
+                },
+                nullable: false,
+                desc: ColumnDesc::new(LogicalType::Boolean, false, false, None).unwrap(),
+            })),
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::Alias {
+                expr: Box::new(ScalarExpression::Empty),
+                alias: AliasType::Name("Hello".to_string()),
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::Alias {
+                expr: Box::new(ScalarExpression::Empty),
+                alias: AliasType::Expr(Box::new(ScalarExpression::Empty)),
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::TypeCast {
+                expr: Box::new(ScalarExpression::Empty),
+                ty: LogicalType::Integer,
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::IsNull {
+                negated: true,
+                expr: Box::new(ScalarExpression::Empty),
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::Unary {
+                op: UnaryOperator::Plus,
+                expr: Box::new(ScalarExpression::Empty),
+                evaluator: Some(UnaryEvaluatorBox(Arc::new(BooleanNotUnaryEvaluator))),
+                ty: LogicalType::Integer,
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::Unary {
+                op: UnaryOperator::Plus,
+                expr: Box::new(ScalarExpression::Empty),
+                evaluator: None,
+                ty: LogicalType::Integer,
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::Binary {
+                op: BinaryOperator::Plus,
+                left_expr: Box::new(ScalarExpression::Empty),
+                right_expr: Box::new(ScalarExpression::Empty),
+                evaluator: Some(BinaryEvaluatorBox(Arc::new(Int32PlusBinaryEvaluator))),
+                ty: LogicalType::Integer,
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::Binary {
+                op: BinaryOperator::Plus,
+                left_expr: Box::new(ScalarExpression::Empty),
+                right_expr: Box::new(ScalarExpression::Empty),
+                evaluator: None,
+                ty: LogicalType::Integer,
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::AggCall {
+                distinct: true,
+                kind: AggKind::Avg,
+                args: vec![ScalarExpression::Empty],
+                ty: LogicalType::Integer,
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::In {
+                negated: true,
+                expr: Box::new(ScalarExpression::Empty),
+                args: vec![ScalarExpression::Empty],
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::Between {
+                negated: true,
+                expr: Box::new(ScalarExpression::Empty),
+                left_expr: Box::new(ScalarExpression::Empty),
+                right_expr: Box::new(ScalarExpression::Empty),
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::SubString {
+                expr: Box::new(ScalarExpression::Empty),
+                for_expr: Some(Box::new(ScalarExpression::Empty)),
+                from_expr: Some(Box::new(ScalarExpression::Empty)),
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::SubString {
+                expr: Box::new(ScalarExpression::Empty),
+                for_expr: None,
+                from_expr: Some(Box::new(ScalarExpression::Empty)),
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::SubString {
+                expr: Box::new(ScalarExpression::Empty),
+                for_expr: None,
+                from_expr: None,
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::Position {
+                expr: Box::new(ScalarExpression::Empty),
+                in_expr: Box::new(ScalarExpression::Empty),
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::Trim {
+                expr: Box::new(ScalarExpression::Empty),
+                trim_what_expr: Some(Box::new(ScalarExpression::Empty)),
+                trim_where: Some(TrimWhereField::Both),
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::Trim {
+                expr: Box::new(ScalarExpression::Empty),
+                trim_what_expr: None,
+                trim_where: Some(TrimWhereField::Both),
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::Trim {
+                expr: Box::new(ScalarExpression::Empty),
+                trim_what_expr: None,
+                trim_where: None,
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::Empty,
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::Tuple(vec![ScalarExpression::Empty]),
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::ScalaFunction(ScalarFunction {
+                args: vec![ScalarExpression::Empty],
+                inner: CurrentDate::new(),
+            }),
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::TableFunction(TableFunction {
+                args: vec![ScalarExpression::Empty],
+                inner: Numbers::new(),
+            }),
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::If {
+                condition: Box::new(ScalarExpression::Empty),
+                left_expr: Box::new(ScalarExpression::Empty),
+                right_expr: Box::new(ScalarExpression::Empty),
+                ty: LogicalType::Integer,
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::IfNull {
+                left_expr: Box::new(ScalarExpression::Empty),
+                right_expr: Box::new(ScalarExpression::Empty),
+                ty: LogicalType::Integer,
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::NullIf {
+                left_expr: Box::new(ScalarExpression::Empty),
+                right_expr: Box::new(ScalarExpression::Empty),
+                ty: LogicalType::Integer,
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::Coalesce {
+                exprs: vec![ScalarExpression::Empty],
+                ty: LogicalType::Integer,
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::CaseWhen {
+                operand_expr: Some(Box::new(ScalarExpression::Empty)),
+                expr_pairs: vec![(ScalarExpression::Empty, ScalarExpression::Empty)],
+                else_expr: Some(Box::new(ScalarExpression::Empty)),
+                ty: LogicalType::Integer,
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::CaseWhen {
+                operand_expr: None,
+                expr_pairs: vec![(ScalarExpression::Empty, ScalarExpression::Empty)],
+                else_expr: Some(Box::new(ScalarExpression::Empty)),
+                ty: LogicalType::Integer,
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+        fn_assert(
+            &mut cursor,
+            ScalarExpression::CaseWhen {
+                operand_expr: None,
+                expr_pairs: vec![(ScalarExpression::Empty, ScalarExpression::Empty)],
+                else_expr: None,
+                ty: LogicalType::Integer,
+            },
+            Some((&transaction, &table_cache)),
+            &mut reference_tables,
+        )?;
+
+        Ok(())
+    }
+}

--- a/src/serdes/scala_expression.rs
+++ b/src/serdes/scala_expression.rs
@@ -566,7 +566,7 @@ pub(crate) mod test {
         build_table(&table_cache, &mut transaction)?;
 
         let mut cursor = Cursor::new(Vec::new());
-        let mut reference_tables = ReferenceTables::single();
+        let mut reference_tables = ReferenceTables::new();
 
         fn_assert(
             &mut cursor,

--- a/src/serdes/scala_function.rs
+++ b/src/serdes/scala_function.rs
@@ -1,0 +1,44 @@
+use crate::errors::DatabaseError;
+use crate::expression::function::scala::{ScalarFunction, ScalarFunctionImpl};
+use crate::expression::ScalarExpression;
+use crate::serdes::{ReferenceSerialization, ReferenceTables, Serialization};
+use crate::storage::{TableCache, Transaction};
+use std::io::{Read, Write};
+use std::sync::Arc;
+
+impl ReferenceSerialization for ScalarFunction {
+    fn encode<W: Write>(
+        &self,
+        writer: &mut W,
+        is_direct: bool,
+        reference_tables: &mut ReferenceTables,
+    ) -> Result<(), DatabaseError> {
+        (self.args.len() as u32).encode(writer)?;
+        for arg in self.args.iter() {
+            arg.encode(writer, is_direct, reference_tables)?
+        }
+        let bytes = bincode::serialize(&self.inner)?;
+        (bytes.len() as u32).encode(writer)?;
+        writer.write_all(&bytes)?;
+
+        Ok(())
+    }
+
+    fn decode<T: Transaction, R: Read>(
+        reader: &mut R,
+        drive: Option<(&T, &TableCache)>,
+        reference_tables: &ReferenceTables,
+    ) -> Result<Self, DatabaseError> {
+        let args_len = u32::decode(reader)? as usize;
+
+        let mut args = Vec::with_capacity(args_len);
+        for _ in 0..args_len {
+            args.push(ScalarExpression::decode(reader, drive, reference_tables)?);
+        }
+        let mut buf = vec![0u8; u32::decode(reader)? as usize];
+        reader.read_exact(&mut buf)?;
+        let inner = bincode::deserialize::<Arc<dyn ScalarFunctionImpl>>(&buf)?;
+
+        Ok(ScalarFunction { args, inner })
+    }
+}

--- a/src/serdes/string.rs
+++ b/src/serdes/string.rs
@@ -1,0 +1,41 @@
+use crate::serdes::Serialization;
+use std::io;
+use std::io::{Read, Write};
+
+impl Serialization for String {
+    type Error = io::Error;
+
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+        (self.len() as u32).encode(writer)?;
+        writer.write_all(self.as_bytes())?;
+
+        Ok(())
+    }
+
+    fn decode<R: Read>(reader: &mut R) -> Result<Self, Self::Error> {
+        let mut buf = vec![0u8; u32::decode(reader)? as usize];
+        reader.read_exact(&mut buf)?;
+
+        Ok(String::from_utf8(buf).unwrap())
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use crate::errors::DatabaseError;
+    use crate::serdes::Serialization;
+    use std::io::{Cursor, Seek, SeekFrom};
+
+    #[test]
+    fn test_serialization() -> Result<(), DatabaseError> {
+        let mut bytes = Vec::new();
+        let mut cursor = Cursor::new(&mut bytes);
+
+        let source = "hello".to_string();
+        source.encode(&mut cursor)?;
+        cursor.seek(SeekFrom::Start(0))?;
+        assert_eq!(String::decode(&mut cursor)?, source);
+
+        Ok(())
+    }
+}

--- a/src/serdes/table_function.rs
+++ b/src/serdes/table_function.rs
@@ -1,0 +1,44 @@
+use crate::errors::DatabaseError;
+use crate::expression::function::table::{TableFunction, TableFunctionImpl};
+use crate::expression::ScalarExpression;
+use crate::serdes::{ReferenceSerialization, ReferenceTables, Serialization};
+use crate::storage::{TableCache, Transaction};
+use std::io::{Read, Write};
+use std::sync::Arc;
+
+impl ReferenceSerialization for TableFunction {
+    fn encode<W: Write>(
+        &self,
+        writer: &mut W,
+        is_direct: bool,
+        reference_tables: &mut ReferenceTables,
+    ) -> Result<(), DatabaseError> {
+        (self.args.len() as u32).encode(writer)?;
+        for arg in self.args.iter() {
+            arg.encode(writer, is_direct, reference_tables)?
+        }
+        let bytes = bincode::serialize(&self.inner)?;
+        (bytes.len() as u32).encode(writer)?;
+        writer.write_all(&bytes)?;
+
+        Ok(())
+    }
+
+    fn decode<T: Transaction, R: Read>(
+        reader: &mut R,
+        drive: Option<(&T, &TableCache)>,
+        reference_tables: &ReferenceTables,
+    ) -> Result<Self, DatabaseError> {
+        let args_len = u32::decode(reader)? as usize;
+
+        let mut args = Vec::with_capacity(args_len);
+        for _ in 0..args_len {
+            args.push(ScalarExpression::decode(reader, drive, reference_tables)?);
+        }
+        let mut buf = vec![0u8; u32::decode(reader)? as usize];
+        reader.read_exact(&mut buf)?;
+        let inner = bincode::deserialize::<Arc<dyn TableFunctionImpl>>(&buf)?;
+
+        Ok(TableFunction { args, inner })
+    }
+}

--- a/src/serdes/trim.rs
+++ b/src/serdes/trim.rs
@@ -1,0 +1,31 @@
+use crate::errors::DatabaseError;
+use crate::serdes::Serialization;
+use sqlparser::ast::TrimWhereField;
+use std::io::{Read, Write};
+
+impl Serialization for TrimWhereField {
+    type Error = DatabaseError;
+
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+        let type_id = match self {
+            TrimWhereField::Both => 0,
+            TrimWhereField::Leading => 1,
+            TrimWhereField::Trailing => 2,
+        };
+        writer.write_all(&[type_id])?;
+
+        Ok(())
+    }
+
+    fn decode<R: Read>(reader: &mut R) -> Result<Self, Self::Error> {
+        let mut one_byte = [0u8; 1];
+        reader.read_exact(&mut one_byte)?;
+
+        Ok(match one_byte[0] {
+            0 => TrimWhereField::Both,
+            1 => TrimWhereField::Leading,
+            2 => TrimWhereField::Trailing,
+            _ => unreachable!(),
+        })
+    }
+}

--- a/src/serdes/unary_operator.rs
+++ b/src/serdes/unary_operator.rs
@@ -1,0 +1,31 @@
+use crate::expression::UnaryOperator;
+use crate::serdes::Serialization;
+use std::io;
+use std::io::{Read, Write};
+
+impl Serialization for UnaryOperator {
+    type Error = io::Error;
+
+    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Self::Error> {
+        let type_id = match self {
+            UnaryOperator::Plus => 0u8,
+            UnaryOperator::Minus => 1u8,
+            UnaryOperator::Not => 2u8,
+        };
+        writer.write_all(&[type_id])?;
+
+        Ok(())
+    }
+
+    fn decode<R: Read>(reader: &mut R) -> Result<Self, Self::Error> {
+        let mut type_bytes = [0u8; 1];
+        reader.read_exact(&mut type_bytes)?;
+
+        Ok(match type_bytes[0] {
+            0 => UnaryOperator::Plus,
+            1 => UnaryOperator::Minus,
+            2 => UnaryOperator::Not,
+            _ => unreachable!(),
+        })
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -5,6 +5,7 @@ use crate::catalog::{ColumnCatalog, ColumnRef, TableCatalog, TableMeta, TableNam
 use crate::errors::DatabaseError;
 use crate::expression::range_detacher::Range;
 use crate::optimizer::core::statistics_meta::{StatisticMetaLoader, StatisticsMeta};
+use crate::serdes::ReferenceTables;
 use crate::storage::table_codec::TableCodec;
 use crate::types::index::{Index, IndexId, IndexMetaRef, IndexType};
 use crate::types::tuple::{Tuple, TupleId};
@@ -14,6 +15,7 @@ use crate::utils::lru::ShardingLruCache;
 use bytes::Bytes;
 use itertools::Itertools;
 use std::collections::{Bound, VecDeque};
+use std::io::Cursor;
 use std::ops::SubAssign;
 use std::sync::Arc;
 use std::{mem, slice};
@@ -239,7 +241,7 @@ pub trait Transaction: Sized {
             }
 
             let column = table.get_column_by_id(&col_id).unwrap();
-            let (key, value) = TableCodec::encode_column(table_name, column)?;
+            let (key, value) = TableCodec::encode_column(column, &mut ReferenceTables::single())?;
             self.set(key, value)?;
             table_cache.remove(table_name);
 
@@ -259,7 +261,7 @@ pub trait Transaction: Sized {
         if let Some(table_catalog) = self.table(table_cache, table_name.clone()).cloned() {
             let column = table_catalog.get_column_by_name(column_name).unwrap();
 
-            let (key, _) = TableCodec::encode_column(table_name, column)?;
+            let (key, _) = TableCodec::encode_column(column, &mut ReferenceTables::single())?;
             self.remove(&key)?;
 
             for index_meta in table_catalog.indexes.iter() {
@@ -305,8 +307,9 @@ pub trait Transaction: Sized {
         self.create_index_meta_from_column(&mut table_catalog)?;
         self.set(table_key, value)?;
 
+        let mut reference_tables = ReferenceTables::single();
         for column in table_catalog.columns() {
-            let (key, value) = TableCodec::encode_column(&table_name, column)?;
+            let (key, value) = TableCodec::encode_column(column, &mut reference_tables)?;
             self.set(key, value)?;
         }
         table_cache.put(table_name.to_string(), table_catalog);
@@ -361,6 +364,7 @@ pub trait Transaction: Sized {
     ) -> Option<&TableCatalog> {
         table_cache
             .get_or_insert(table_name.to_string(), |_| {
+                // `TableCache` is not theoretically used in `table_collect` because ColumnCatalog should not depend on other Column
                 let (columns, indexes) = self.table_collect(table_name.clone())?;
 
                 TableCatalog::reload(table_name.clone(), columns, indexes)
@@ -433,18 +437,24 @@ pub trait Transaction: Sized {
     fn table_collect(
         &self,
         table_name: TableName,
-    ) -> Result<(Vec<ColumnCatalog>, Vec<IndexMetaRef>), DatabaseError> {
+    ) -> Result<(Vec<ColumnRef>, Vec<IndexMetaRef>), DatabaseError> {
         let (table_min, table_max) = TableCodec::table_bound(&table_name);
         let mut column_iter =
             self.range(Bound::Included(&table_min), Bound::Included(&table_max))?;
 
         let mut columns = Vec::new();
         let mut index_metas = Vec::new();
+        let mut reference_tables = ReferenceTables::single();
+        let _ = reference_tables.push_or_replace(&table_name);
 
         // Tips: only `Column`, `IndexMeta`, `TableMeta`
         while let Some((key, value)) = column_iter.try_next().ok().flatten() {
             if key.starts_with(&table_min) {
-                columns.push(TableCodec::decode_column(&value)?);
+                let mut cursor = Cursor::new(value.as_ref());
+                columns.push(TableCodec::decode_column::<Self, _>(
+                    &mut cursor,
+                    &reference_tables,
+                )?);
             } else {
                 index_metas.push(Arc::new(TableCodec::decode_index_meta(&value)?));
             }
@@ -981,7 +991,9 @@ pub trait Iter {
 
 #[cfg(test)]
 mod test {
-    use crate::catalog::{ColumnCatalog, ColumnDesc, ColumnRef, ColumnSummary, TableCatalog};
+    use crate::catalog::{
+        ColumnCatalog, ColumnDesc, ColumnRef, ColumnRelation, ColumnSummary, TableCatalog,
+    };
     use crate::db::test::build_table;
     use crate::errors::DatabaseError;
     use crate::expression::range_detacher::Range;
@@ -1008,7 +1020,7 @@ mod test {
                 Arc::new(ColumnCatalog::new(
                     "c1".to_string(),
                     false,
-                    ColumnDesc::new(LogicalType::Integer, true, false, None),
+                    ColumnDesc::new(LogicalType::Integer, true, false, None).unwrap(),
                 )),
             ),
             (
@@ -1016,7 +1028,7 @@ mod test {
                 Arc::new(ColumnCatalog::new(
                     "c2".to_string(),
                     false,
-                    ColumnDesc::new(LogicalType::Boolean, false, false, None),
+                    ColumnDesc::new(LogicalType::Boolean, false, false, None).unwrap(),
                 )),
             ),
             (
@@ -1024,7 +1036,7 @@ mod test {
                 Arc::new(ColumnCatalog::new(
                     "c3".to_string(),
                     false,
-                    ColumnDesc::new(LogicalType::Integer, false, false, None),
+                    ColumnDesc::new(LogicalType::Integer, false, false, None).unwrap(),
                 )),
             ),
         ]
@@ -1093,14 +1105,16 @@ mod test {
             assert_eq!(
                 c1_column.summary(),
                 &ColumnSummary {
-                    id: Some(0),
                     name: "c1".to_string(),
-                    table_name: Some(Arc::new("t1".to_string())),
+                    relation: ColumnRelation::Table {
+                        column_id: 0,
+                        table_name: Arc::new("t1".to_string())
+                    },
                 }
             );
             assert_eq!(
                 c1_column.desc,
-                ColumnDesc::new(LogicalType::Integer, true, false, None)
+                ColumnDesc::new(LogicalType::Integer, true, false, None)?
             );
 
             let c2_column = column_iter.next().unwrap();
@@ -1108,14 +1122,16 @@ mod test {
             assert_eq!(
                 c2_column.summary(),
                 &ColumnSummary {
-                    id: Some(1),
                     name: "c2".to_string(),
-                    table_name: Some(Arc::new("t1".to_string())),
+                    relation: ColumnRelation::Table {
+                        column_id: 1,
+                        table_name: Arc::new("t1".to_string())
+                    },
                 }
             );
             assert_eq!(
                 c2_column.desc,
-                ColumnDesc::new(LogicalType::Boolean, false, false, None)
+                ColumnDesc::new(LogicalType::Boolean, false, false, None)?
             );
 
             let c3_column = column_iter.next().unwrap();
@@ -1123,14 +1139,16 @@ mod test {
             assert_eq!(
                 c3_column.summary(),
                 &ColumnSummary {
-                    id: Some(2),
                     name: "c3".to_string(),
-                    table_name: Some(Arc::new("t1".to_string())),
+                    relation: ColumnRelation::Table {
+                        column_id: 2,
+                        table_name: Arc::new("t1".to_string())
+                    },
                 }
             );
             assert_eq!(
                 c3_column.desc,
-                ColumnDesc::new(LogicalType::Integer, false, false, None)
+                ColumnDesc::new(LogicalType::Integer, false, false, None)?
             );
 
             Ok(())
@@ -1427,7 +1445,7 @@ mod test {
         let new_column = ColumnCatalog::new(
             "c4".to_string(),
             true,
-            ColumnDesc::new(LogicalType::Integer, false, false, None),
+            ColumnDesc::new(LogicalType::Integer, false, false, None)?,
         );
         let new_column_id =
             transaction.add_column(&table_cache, &table_name, &new_column, false)?;
@@ -1447,10 +1465,12 @@ mod test {
             let mut new_column = ColumnCatalog::new(
                 "c4".to_string(),
                 true,
-                ColumnDesc::new(LogicalType::Integer, false, false, None),
+                ColumnDesc::new(LogicalType::Integer, false, false, None)?,
             );
-            new_column.set_table_name(table_name.clone());
-            new_column.set_id(3);
+            new_column.summary.relation = ColumnRelation::Table {
+                column_id: 3,
+                table_name: table_name.clone(),
+            };
             assert_eq!(table.get_column_by_name("c4"), Some(&Arc::new(new_column)));
         }
         transaction.drop_column(&table_cache, &meta_cache, &table_name, "c4")?;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -241,7 +241,7 @@ pub trait Transaction: Sized {
             }
 
             let column = table.get_column_by_id(&col_id).unwrap();
-            let (key, value) = TableCodec::encode_column(column, &mut ReferenceTables::single())?;
+            let (key, value) = TableCodec::encode_column(column, &mut ReferenceTables::new())?;
             self.set(key, value)?;
             table_cache.remove(table_name);
 
@@ -261,7 +261,7 @@ pub trait Transaction: Sized {
         if let Some(table_catalog) = self.table(table_cache, table_name.clone()).cloned() {
             let column = table_catalog.get_column_by_name(column_name).unwrap();
 
-            let (key, _) = TableCodec::encode_column(column, &mut ReferenceTables::single())?;
+            let (key, _) = TableCodec::encode_column(column, &mut ReferenceTables::new())?;
             self.remove(&key)?;
 
             for index_meta in table_catalog.indexes.iter() {
@@ -307,7 +307,7 @@ pub trait Transaction: Sized {
         self.create_index_meta_from_column(&mut table_catalog)?;
         self.set(table_key, value)?;
 
-        let mut reference_tables = ReferenceTables::single();
+        let mut reference_tables = ReferenceTables::new();
         for column in table_catalog.columns() {
             let (key, value) = TableCodec::encode_column(column, &mut reference_tables)?;
             self.set(key, value)?;
@@ -444,7 +444,7 @@ pub trait Transaction: Sized {
 
         let mut columns = Vec::new();
         let mut index_metas = Vec::new();
-        let mut reference_tables = ReferenceTables::single();
+        let mut reference_tables = ReferenceTables::new();
         let _ = reference_tables.push_or_replace(&table_name);
 
         // Tips: only `Column`, `IndexMeta`, `TableMeta`

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -312,6 +312,7 @@ pub trait Transaction: Sized {
             let (key, value) = TableCodec::encode_column(column, &mut reference_tables)?;
             self.set(key, value)?;
         }
+        debug_assert_eq!(reference_tables.len(), 1);
         table_cache.put(table_name.to_string(), table_catalog);
 
         Ok(table_name)

--- a/src/storage/rocksdb.rs
+++ b/src/storage/rocksdb.rs
@@ -158,12 +158,12 @@ mod test {
             Arc::new(ColumnCatalog::new(
                 "c1".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Integer, true, false, None),
+                ColumnDesc::new(LogicalType::Integer, true, false, None).unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c2".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Boolean, false, false, None),
+                ColumnDesc::new(LogicalType::Boolean, false, false, None).unwrap(),
             )),
         ]);
 

--- a/src/storage/table_codec.rs
+++ b/src/storage/table_codec.rs
@@ -524,7 +524,7 @@ mod tests {
         };
         let col = Arc::new(col);
 
-        let mut reference_tables = ReferenceTables::single();
+        let mut reference_tables = ReferenceTables::new();
 
         let (_, bytes) = TableCodec::encode_column(&col, &mut reference_tables).unwrap();
         let mut cursor = Cursor::new(bytes.as_ref());
@@ -558,7 +558,7 @@ mod tests {
             };
 
             let (key, _) =
-                TableCodec::encode_column(&Arc::new(col), &mut ReferenceTables::single()).unwrap();
+                TableCodec::encode_column(&Arc::new(col), &mut ReferenceTables::new()).unwrap();
             key
         };
 

--- a/src/storage/table_codec.rs
+++ b/src/storage/table_codec.rs
@@ -385,27 +385,22 @@ impl TableCodec {
 #[cfg(test)]
 mod tests {
     use crate::catalog::{ColumnCatalog, ColumnDesc, ColumnRelation, TableCatalog, TableMeta};
-    use crate::db::test::build_table;
     use crate::errors::DatabaseError;
     use crate::serdes::ReferenceTables;
-    use crate::storage::rocksdb::{RocksStorage, RocksTransaction};
+    use crate::storage::rocksdb::RocksTransaction;
     use crate::storage::table_codec::TableCodec;
-    use crate::storage::Storage;
     use crate::types::index::{Index, IndexMeta, IndexType};
     use crate::types::tuple::Tuple;
     use crate::types::value::DataValue;
     use crate::types::LogicalType;
-    use crate::utils::lru::ShardingLruCache;
     use bytes::Bytes;
     use itertools::Itertools;
     use rust_decimal::Decimal;
     use std::collections::BTreeSet;
-    use std::hash::RandomState;
     use std::io::Cursor;
     use std::ops::Bound;
     use std::slice;
     use std::sync::Arc;
-    use tempfile::TempDir;
 
     fn build_table_codec() -> TableCatalog {
         let columns = vec![
@@ -506,13 +501,6 @@ mod tests {
 
     #[test]
     fn test_table_codec_column() -> Result<(), DatabaseError> {
-        let temp_dir = TempDir::new().expect("unable to create temporary working directory");
-        let storage = RocksStorage::new(temp_dir.path())?;
-        let mut transaction = storage.transaction()?;
-        let table_cache = Arc::new(ShardingLruCache::new(4, 1, RandomState::new())?);
-
-        build_table(&table_cache, &mut transaction)?;
-
         let mut col: ColumnCatalog = ColumnCatalog::new(
             "c2".to_string(),
             false,

--- a/src/types/evaluator/mod.rs
+++ b/src/types/evaluator/mod.rs
@@ -52,12 +52,12 @@ use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
-#[typetag::serde(tag = "type")]
+#[typetag::serde(tag = "binary")]
 pub trait BinaryEvaluator: Send + Sync + Debug {
     fn binary_eval(&self, left: &DataValue, right: &DataValue) -> DataValue;
 }
 
-#[typetag::serde(tag = "type")]
+#[typetag::serde(tag = "unary")]
 pub trait UnaryEvaluator: Send + Sync + Debug {
     fn unary_eval(&self, value: &DataValue) -> DataValue;
 }

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -184,12 +184,12 @@ mod tests {
             Arc::new(ColumnCatalog::new(
                 "c1".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Integer, true, false, None),
+                ColumnDesc::new(LogicalType::Integer, true, false, None).unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c2".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::UInteger, false, false, None),
+                ColumnDesc::new(LogicalType::UInteger, false, false, None).unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c3".to_string(),
@@ -199,57 +199,58 @@ mod tests {
                     false,
                     false,
                     None,
-                ),
+                )
+                .unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c4".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Smallint, false, false, None),
+                ColumnDesc::new(LogicalType::Smallint, false, false, None).unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c5".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::USmallint, false, false, None),
+                ColumnDesc::new(LogicalType::USmallint, false, false, None).unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c6".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Float, false, false, None),
+                ColumnDesc::new(LogicalType::Float, false, false, None).unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c7".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Double, false, false, None),
+                ColumnDesc::new(LogicalType::Double, false, false, None).unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c8".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Tinyint, false, false, None),
+                ColumnDesc::new(LogicalType::Tinyint, false, false, None).unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c9".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::UTinyint, false, false, None),
+                ColumnDesc::new(LogicalType::UTinyint, false, false, None).unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c10".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Boolean, false, false, None),
+                ColumnDesc::new(LogicalType::Boolean, false, false, None).unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c11".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::DateTime, false, false, None),
+                ColumnDesc::new(LogicalType::DateTime, false, false, None).unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c12".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Date, false, false, None),
+                ColumnDesc::new(LogicalType::Date, false, false, None).unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c13".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Decimal(None, None), false, false, None),
+                ColumnDesc::new(LogicalType::Decimal(None, None), false, false, None).unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c14".to_string(),
@@ -259,7 +260,8 @@ mod tests {
                     false,
                     false,
                     None,
-                ),
+                )
+                .unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c15".to_string(),
@@ -269,7 +271,8 @@ mod tests {
                     false,
                     false,
                     None,
-                ),
+                )
+                .unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c16".to_string(),
@@ -279,7 +282,8 @@ mod tests {
                     false,
                     false,
                     None,
-                ),
+                )
+                .unwrap(),
             )),
         ]);
 

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -2,7 +2,7 @@ fn main() {}
 
 #[cfg(test)]
 mod test {
-    use fnck_sql::catalog::column::{ColumnCatalog, ColumnDesc};
+    use fnck_sql::catalog::column::{ColumnCatalog, ColumnDesc, ColumnRelation};
     use fnck_sql::errors::DatabaseError;
     use fnck_sql::expression::function::scala::ScalarFunctionImpl;
     use fnck_sql::expression::function::table::TableFunctionImpl;
@@ -23,7 +23,7 @@ mod test {
             Arc::new(ColumnCatalog::new(
                 "c1".to_string(),
                 false,
-                ColumnDesc::new(LogicalType::Integer, true, false, None),
+                ColumnDesc::new(LogicalType::Integer, true, false, None).unwrap(),
             )),
             Arc::new(ColumnCatalog::new(
                 "c2".to_string(),
@@ -33,7 +33,7 @@ mod test {
                     false,
                     false,
                     None,
-                ),
+                ).unwrap(),
             )),
         ]);
         let values = vec![
@@ -174,17 +174,21 @@ mod test {
         let mut c1 = ColumnCatalog::new(
             "c1".to_string(),
             true,
-            ColumnDesc::new(LogicalType::Integer, false, false, None),
+            ColumnDesc::new(LogicalType::Integer, false, false, None)?,
         );
-        c1.set_id(0);
-        c1.set_table_name(table_name.clone());
+        c1.summary.relation = ColumnRelation::Table {
+            column_id: 0,
+            table_name: table_name.clone(),
+        };
         let mut c2 = ColumnCatalog::new(
             "c2".to_string(),
             true,
-            ColumnDesc::new(LogicalType::Integer, false, false, None),
+            ColumnDesc::new(LogicalType::Integer, false, false, None)?,
         );
-        c2.set_id(1);
-        c2.set_table_name(table_name.clone());
+        c2.summary.relation = ColumnRelation::Table {
+            column_id: 1,
+            table_name: table_name.clone(),
+        };
 
         assert_eq!(
             function.output_schema(),


### PR DESCRIPTION
### What problem does this PR solve?

`ReferenceSerialization` is used to unify meta-information such as `ColumnRef` to avoid possible inconsistencies caused by direct serialization after deserialization.

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
