### PR TITLE
fix: use home directory instead of config directory for index paths avoid permission denied

### DIFF
--- a/src/execution/dml/analyze.rs
+++ b/src/execution/dml/analyze.rs
@@ -97,7 +97,7 @@ impl<'a, T: Transaction + 'a> WriteExecutor<'a, T> for Analyze {
                 }
                 drop(coroutine);
                 let mut values = Vec::with_capacity(builders.len());
-                let dir_path = dirs::config_dir()
+                let dir_path = dirs::home_dir()
                     .expect("Your system does not have a Config directory!")
                     .join(DEFAULT_STATISTICS_META_PATH)
                     .join(table_name.as_str());
@@ -184,7 +184,7 @@ mod test {
         }
         let _ = fnck_sql.run("analyze table t1")?;
 
-        let dir_path = dirs::config_dir()
+        let dir_path = dirs::home_dir()
             .expect("Your system does not have a Config directory!")
             .join(DEFAULT_STATISTICS_META_PATH)
             .join("t1");
@@ -227,7 +227,7 @@ mod test {
         }
         let _ = fnck_sql.run("analyze table t1")?;
 
-        let dir_path = dirs::config_dir()
+        let dir_path = dirs::home_dir()
             .expect("Your system does not have a Config directory!")
             .join(DEFAULT_STATISTICS_META_PATH)
             .join("t1");


### PR DESCRIPTION
Changed path directory retrieval from `dirs::config_dir` to `dirs::home_dir` in `analyze.rs`. This ensures the application uses the user's home directory for storing and accessing necessary metadata paths.

### What problem does this PR solve?

Add corresponding issue link with summary if exists -->

Issue link:

### What is changed and how it works?

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
