### PR TITLE
chore: supplement decimal’s `memcomparable` encode

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ run `cargo run -p tpcc --release` to run tpcc
 
 - i9-13900HX
 - 32.0 GB
-- YMTC PC411-1024GB-B
+- KIOXIA-EXCERIA PLUS G3 SSD
 - Tips: TPC-C currently only supports single thread
 ```shell
 <90th Percentile RT (MaxRT)>

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -235,7 +235,9 @@ fn encode_tuples<'a>(schema: &Schema, tuples: Vec<Tuple>) -> PgWireResult<QueryR
                 LogicalType::Date => encoder.encode_field(&value.date()),
                 LogicalType::DateTime => encoder.encode_field(&value.datetime()),
                 LogicalType::Time => encoder.encode_field(&value.time()),
-                LogicalType::Decimal(_, _) => todo!(),
+                LogicalType::Decimal(_, _) => {
+                    encoder.encode_field(&value.decimal().map(|decimal| decimal.to_string()))
+                }
                 _ => unreachable!(),
             }?;
         }
@@ -260,7 +262,7 @@ fn into_pg_type(data_type: &LogicalType) -> PgWireResult<Type> {
         LogicalType::Date | LogicalType::DateTime => Type::DATE,
         LogicalType::Char(..) => Type::CHAR,
         LogicalType::Time => Type::TIME,
-        LogicalType::Decimal(_, _) => todo!(),
+        LogicalType::Decimal(_, _) => Type::FLOAT8,
         _ => {
             return Err(PgWireError::UserError(Box::new(ErrorInfo::new(
                 "ERROR".to_owned(),

--- a/src/binder/alter_table.rs
+++ b/src/binder/alter_table.rs
@@ -64,23 +64,12 @@ impl<T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'_, '_, T, A>
                     Childrens::Only(plan),
                 )
             }
-            AlterTableOperation::DropPrimaryKey => todo!(),
-            AlterTableOperation::RenameColumn {
-                old_column_name: _,
-                new_column_name: _,
-            } => todo!(),
-            AlterTableOperation::RenameTable { table_name: _ } => todo!(),
-            AlterTableOperation::ChangeColumn {
-                old_name: _,
-                new_name: _,
-                data_type: _,
-                options: _,
-            } => todo!(),
-            AlterTableOperation::AlterColumn {
-                column_name: _,
-                op: _,
-            } => todo!(),
-            _ => todo!(),
+            op => {
+                return Err(DatabaseError::UnsupportedStmt(format!(
+                    "AlertOperation: {:?}",
+                    op
+                )))
+            }
         };
 
         Ok(plan)

--- a/src/binder/copy.rs
+++ b/src/binder/copy.rs
@@ -88,7 +88,12 @@ impl<T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'_, '_, T, A>
             let ext_source = ExtSource {
                 path: match target {
                     CopyTarget::File { filename } => filename.into(),
-                    t => todo!("unsupported copy target: {:?}", t),
+                    t => {
+                        return Err(DatabaseError::UnsupportedStmt(format!(
+                            "copy target: {:?}",
+                            t
+                        )))
+                    }
                 },
                 format: FileFormat::from_options(options),
             };

--- a/src/binder/create_table.rs
+++ b/src/binder/create_table.rs
@@ -1,8 +1,3 @@
-use itertools::Itertools;
-use sqlparser::ast::{ColumnDef, ColumnOption, ObjectName, TableConstraint};
-use std::collections::HashSet;
-use std::sync::Arc;
-
 use super::{is_valid_identifier, Binder};
 use crate::binder::lower_case_name;
 use crate::catalog::{ColumnCatalog, ColumnDesc};
@@ -14,6 +9,10 @@ use crate::planner::{Childrens, LogicalPlan};
 use crate::storage::Transaction;
 use crate::types::value::DataValue;
 use crate::types::LogicalType;
+use itertools::Itertools;
+use sqlparser::ast::{ColumnDef, ColumnOption, ObjectName, TableConstraint};
+use std::collections::HashSet;
+use std::sync::Arc;
 
 impl<T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'_, '_, T, A> {
     // TODO: TableConstraint
@@ -75,7 +74,12 @@ impl<T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'_, '_, T, A>
                         }
                     }
                 }
-                _ => todo!(),
+                constraint => {
+                    return Err(DatabaseError::UnsupportedStmt(format!(
+                        "`CreateTable` does not currently support this constraint: {:?}",
+                        constraint
+                    )))?
+                }
             }
         }
 
@@ -140,7 +144,12 @@ impl<T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'_, '_, T, A>
                     }
                     column_desc.default = Some(expr);
                 }
-                _ => todo!(),
+                option => {
+                    return Err(DatabaseError::UnsupportedStmt(format!(
+                        "`Column` does not currently support this option: {:?}",
+                        option
+                    )))
+                }
             }
         }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -328,7 +328,7 @@ impl<S: Storage> Database<S> {
     }
 }
 
-pub trait ResultIter: Iterator<Item = Result<Tuple, DatabaseError>> + Sized {
+pub trait ResultIter: Iterator<Item = Result<Tuple, DatabaseError>> {
     fn schema(&self) -> &SchemaRef;
 
     fn done(self) -> Result<(), DatabaseError>;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -73,6 +73,8 @@ pub enum DatabaseError {
     InvalidTable(String),
     #[error("invalid type")]
     InvalidType,
+    #[error("invalid value: {0}")]
+    InvalidValue(String),
     #[error("io: {0}")]
     IO(
         #[source]

--- a/src/planner/operator/mod.rs
+++ b/src/planner/operator/mod.rs
@@ -287,7 +287,7 @@ impl fmt::Display for Operator {
             Operator::DropView(op) => write!(f, "{}", op),
             Operator::Truncate(op) => write!(f, "{}", op),
             Operator::CopyFromFile(op) => write!(f, "{}", op),
-            Operator::CopyToFile(_) => todo!(),
+            Operator::CopyToFile(op) => write!(f, "{}", op),
             Operator::Union(op) => write!(f, "{}", op),
         }
     }

--- a/src/storage/rocksdb.rs
+++ b/src/storage/rocksdb.rs
@@ -139,9 +139,7 @@ impl InnerIter for RocksIter<'_, '_> {
         if let Some(result) = self.iter.by_ref().next() {
             let (key, value) = result?;
             let upper_bound_check = match &self.upper {
-                Bound::Included(ref upper) => {
-                    key.as_ref() <= upper.as_slice() || key.starts_with(upper.as_slice())
-                }
+                Bound::Included(ref upper) => key.as_ref() <= upper.as_slice(),
                 Bound::Excluded(ref upper) => key.as_ref() < upper.as_slice(),
                 Bound::Unbounded => true,
             };

--- a/src/storage/table_codec.rs
+++ b/src/storage/table_codec.rs
@@ -342,6 +342,7 @@ impl TableCodec {
         &self,
         name: &str,
         index: &Index,
+        is_upper: bool,
     ) -> Result<BumpBytes, DatabaseError> {
         let mut key_prefix = self.key_prefix(CodecType::Index, name);
         key_prefix.push(BOUND_MIN_TAG);
@@ -349,6 +350,9 @@ impl TableCodec {
         key_prefix.push(BOUND_MIN_TAG);
 
         index.value.memcomparable_encode(&mut key_prefix)?;
+        if is_upper {
+            key_prefix.push(BOUND_MAX_TAG)
+        }
 
         Ok(key_prefix)
     }
@@ -359,7 +363,7 @@ impl TableCodec {
         index: &Index,
         tuple_id: Option<&TupleId>,
     ) -> Result<BumpBytes, DatabaseError> {
-        let mut key_prefix = self.encode_index_bound_key(name, index)?;
+        let mut key_prefix = self.encode_index_bound_key(name, index, false)?;
 
         if let Some(tuple_id) = tuple_id {
             if matches!(index.ty, IndexType::Normal | IndexType::Composite) {

--- a/tests/slt/where_by_index.slt
+++ b/tests/slt/where_by_index.slt
@@ -174,6 +174,11 @@ select * from t1 where c2 > 0 and c2 < 9;
 3 4 5
 6 7 8
 
+query IIT
+select * from t1 where c2 = 5;
+----
+3 4 5
+
 statement ok
 update t1 set c2 = 9 where c1 = 1
 

--- a/tpcc/README.md
+++ b/tpcc/README.md
@@ -3,7 +3,7 @@ run `cargo run -p tpcc --release` to run tpcc
 
 - i9-13900HX
 - 32.0 GB
-- YMTC PC411-1024GB-B
+- KIOXIA-EXCERIA PLUS G3 SSD
 - Tips: TPCC currently only supports single thread
 ```shell
 |New-Order| sc: 93779  lt: 0  fl: 926


### PR DESCRIPTION
### What problem does this PR solve?

- supplement decimal’s `memcomparable` encode
- todo code returns error

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
