### PR TITLE
Feat/Index Cover

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+# Helper variables (override on invocation if needed).
+CARGO ?= cargo
+WASM_PACK ?= wasm-pack
+SQLLOGIC_PATH ?= tests/slt/**/*.slt
+
+.PHONY: test test-wasm test-slt test-all wasm-build
+
+## Run default Rust tests in the current environment (non-WASM).
+test:
+	$(CARGO) test
+
+## Build the WebAssembly package (artifact goes to ./pkg).
+wasm-build:
+	$(WASM_PACK) build --release --target nodejs
+
+## Execute wasm-bindgen tests under Node.js (wasm32 target).
+test-wasm:
+	$(WASM_PACK) test --node --release
+
+## Run the sqllogictest harness against the configured .slt suite.
+test-slt:
+	$(CARGO) run -p sqllogictest-test -- --path $(SQLLOGIC_PATH)
+
+## Convenience target to run every suite in sequence.
+test-all: test test-wasm test-slt

--- a/src/execution/dql/sort.rs
+++ b/src/execution/dql/sort.rs
@@ -183,13 +183,13 @@ impl SortBy {
                         let mut key = BumpBytes::new_in(arena);
 
                         expr.eval(Some((tuple, schema)))?
-                            .memcomparable_encode(&mut key)?;
-                        if !asc {
-                            for byte in key.iter_mut() {
+                            .memcomparable_encode_with_null_order(&mut key, *nulls_first)?;
+
+                        if !asc && key.len() > 1 {
+                            for byte in key.iter_mut().skip(1) {
                                 *byte ^= 0xFF;
                             }
                         }
-                        key.push(if *nulls_first { u8::MIN } else { u8::MAX });
                         full_key.extend(key);
                     }
                     sort_keys.put((i, full_key))

--- a/src/execution/dql/top_k.rs
+++ b/src/execution/dql/top_k.rs
@@ -48,13 +48,12 @@ fn top_sort<'a>(
     {
         let mut key = BumpBytes::new_in(arena);
         expr.eval(Some((&tuple, &**schema)))?
-            .memcomparable_encode(&mut key)?;
-        if !asc {
-            for byte in key.iter_mut() {
+            .memcomparable_encode_with_null_order(&mut key, *nulls_first)?;
+        if !asc && key.len() > 1 {
+            for byte in key.iter_mut().skip(1) {
                 *byte ^= 0xFF;
             }
         }
-        key.push(if *nulls_first { u8::MIN } else { u8::MAX });
         full_key.extend(key);
     }
 

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -124,9 +124,11 @@ pub fn build_read<'a, T: Transaction + 'a>(
             if let Some(PhysicalOption::IndexScan(IndexInfo {
                 meta,
                 range: Some(range),
+                covered_deserializers,
             })) = plan.physical_option
             {
-                IndexScan::from((op, meta, range)).execute(cache, transaction)
+                IndexScan::from((op, meta, range, covered_deserializers))
+                    .execute(cache, transaction)
             } else {
                 SeqScan::from(op).execute(cache, transaction)
             }

--- a/src/optimizer/core/memo.rs
+++ b/src/optimizer/core/memo.rs
@@ -212,6 +212,7 @@ mod tests {
                         max: Bound::Unbounded,
                     }
                 ])),
+                covered_deserializers: None,
             }))
         );
 

--- a/src/optimizer/rule/implementation/dql/table_scan.rs
+++ b/src/optimizer/rule/implementation/dql/table_scan.rs
@@ -79,7 +79,9 @@ impl<T: Transaction> ImplementationRule<T> for IndexScanImplementation {
                     {
                         let mut row_count = statistics_meta.collect_count(range)?;
 
-                        if !matches!(index_info.meta.ty, IndexType::PrimaryKey { .. }) {
+                        if index_info.covered_deserializers.is_none()
+                            && !matches!(index_info.meta.ty, IndexType::PrimaryKey { .. })
+                        {
                             // need to return table query(non-covering index)
                             row_count *= 2;
                         }

--- a/src/planner/operator/table_scan.rs
+++ b/src/planner/operator/table_scan.rs
@@ -48,6 +48,7 @@ impl TableScanOperator {
             .map(|meta| IndexInfo {
                 meta: meta.clone(),
                 range: None,
+                covered_deserializers: None,
             })
             .collect_vec();
 

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -218,6 +218,7 @@ mod wasm_tests {
                 max: Bound::Included(DataValue::Int32(2)),
             }],
             true,
+            None,
         )?;
 
         let mut result = Vec::new();

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -349,6 +349,7 @@ mod native_tests {
                 max: Bound::Included(DataValue::Int32(2)),
             }],
             true,
+            None,
         )?;
 
         let mut result = Vec::new();

--- a/src/storage/rocksdb.rs
+++ b/src/storage/rocksdb.rs
@@ -230,7 +230,7 @@ mod test {
     use crate::storage::rocksdb::RocksStorage;
     use crate::storage::{
         IndexImplEnum, IndexImplParams, IndexIter, IndexIterState, Iter, PrimaryKeyIndexImpl,
-        Storage, Transaction,
+        PrimaryKeyRemap, Storage, Transaction,
     };
     use crate::types::index::{IndexMeta, IndexType};
     use crate::types::tuple::Tuple;
@@ -358,7 +358,7 @@ mod test {
         let mut iter = IndexIter {
             offset: 0,
             limit: None,
-            remap_pk_indices: Some(vec![0]),
+            remap_pk_indices: PrimaryKeyRemap::Indices(vec![0]),
             params: IndexImplParams {
                 deserializers,
                 index_meta: Arc::new(IndexMeta {
@@ -426,6 +426,7 @@ mod test {
                         max: Bound::Unbounded,
                     }],
                     true,
+                    None,
                 )
                 .unwrap();
 
@@ -451,6 +452,7 @@ mod test {
                         max: Bound::Unbounded,
                     }],
                     true,
+                    None,
                 )
                 .unwrap();
 

--- a/src/storage/table_codec.rs
+++ b/src/storage/table_codec.rs
@@ -19,9 +19,9 @@ pub(crate) const BOUND_MAX_TAG: u8 = u8::MAX;
 pub(crate) const NULL_TAG: u8 = 0u8;
 pub(crate) const NOTNULL_TAG: u8 = 1u8;
 
-static ROOT_BYTES: LazyLock<Vec<u8>> = LazyLock::new(|| b"R".to_vec());
-static VIEW_BYTES: LazyLock<Vec<u8>> = LazyLock::new(|| b"V".to_vec());
-static HASH_BYTES: LazyLock<Vec<u8>> = LazyLock::new(|| b"H".to_vec());
+static ROOT_BYTES: LazyLock<Vec<u8>> = LazyLock::new(|| b"Root".to_vec());
+static VIEW_BYTES: LazyLock<Vec<u8>> = LazyLock::new(|| b"View".to_vec());
+static HASH_BYTES: LazyLock<Vec<u8>> = LazyLock::new(|| b"Hash".to_vec());
 static EMPTY_REFERENCE_TABLES: LazyLock<ReferenceTables> = LazyLock::new(ReferenceTables::new);
 
 pub type Bytes = Vec<u8>;

--- a/src/types/index.rs
+++ b/src/types/index.rs
@@ -82,6 +82,9 @@ impl fmt::Display for IndexInfo {
         } else {
             write!(f, "EMPTY")?;
         }
+        if self.covered_deserializers.is_some() {
+            write!(f, " Covered")?;
+        }
 
         Ok(())
     }

--- a/src/types/index.rs
+++ b/src/types/index.rs
@@ -2,6 +2,7 @@ use crate::catalog::{TableCatalog, TableName};
 use crate::errors::DatabaseError;
 use crate::expression::range_detacher::Range;
 use crate::expression::ScalarExpression;
+use crate::types::serialize::TupleValueSerializableImpl;
 use crate::types::value::DataValue;
 use crate::types::{ColumnId, LogicalType};
 use kite_sql_serde_macros::ReferenceSerialization;
@@ -11,6 +12,8 @@ use std::sync::Arc;
 
 pub type IndexId = u32;
 pub type IndexMetaRef = Arc<IndexMeta>;
+
+pub const INDEX_ID_LEN: usize = 4;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, ReferenceSerialization)]
 pub enum IndexType {
@@ -24,6 +27,7 @@ pub enum IndexType {
 pub struct IndexInfo {
     pub(crate) meta: IndexMetaRef,
     pub(crate) range: Option<Range>,
+    pub(crate) covered_deserializers: Option<Vec<TupleValueSerializableImpl>>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, ReferenceSerialization)]

--- a/src/types/serialize.rs
+++ b/src/types/serialize.rs
@@ -3,6 +3,7 @@ use crate::types::value::{DataValue, Utf8Type};
 use crate::types::LogicalType;
 use bumpalo::collections::Vec;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use kite_sql_serde_macros::ReferenceSerialization;
 use ordered_float::OrderedFloat;
 use rust_decimal::Decimal;
 use sqlparser::ast::CharLengthUnits;
@@ -41,7 +42,7 @@ pub trait TupleValueSerializable: Debug {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, ReferenceSerialization)]
 pub enum TupleValueSerializableImpl {
     Boolean,
     Int8,

--- a/tests/slt/where_by_index.slt
+++ b/tests/slt/where_by_index.slt
@@ -202,6 +202,15 @@ select * from t1 where c2 > 0 and c2 < 10;
 query I rowsort
 select c1 from t1 where c1 < 10;
 ----
+1
+7
+
+# unique covered with primary key projection
+query II rowsort
+select c1, id from t1 where c1 < 10;
+----
+1 0
+7 6
 
 statement ok
 drop index t1.u_c1_index;
@@ -210,15 +219,49 @@ drop index t1.u_c1_index;
 query II rowsort
 select c2 from t1 where c2 < 10 and c2 > 0;
 ----
+8
+9
 
 statement ok
 drop index t1.c2_index;
 
 # composite covered
 query II rowsort
-select c1 c2 from t1 where c1 < 10 and c1 > 0 and c2 >0 and c2 < 10;
+select c1, c2 from t1 where c1 < 10 and c1 > 0 and c2 >0 and c2 < 10;
 ----
+1 9
+7 8
+
+# composite covered projection reorder
+query II rowsort
+select c2, c1 from t1 where c1 < 10 and c1 > 0 and c2 > 0 and c2 < 10;
+----
+8 7
+9 1
 
 
 statement ok
 drop table t1;
+
+statement ok
+create table t_cover(id int primary key, c1 int, c2 int, c3 int);
+
+statement ok
+insert into t_cover values
+    (1, 1, 10, 11),
+    (2, 2, 20, 21),
+    (3, 2, 22, 23),
+    (4, 3, 30, 31);
+
+statement ok
+create index idx_cover on t_cover (c1, c2, c3);
+
+# composite index trailing columns cover (index columns > output columns)
+query II rowsort
+select c2, c3 from t_cover where c1 = 2;
+----
+20 21
+22 23
+
+statement ok
+drop table t_cover;

--- a/tests/slt/where_by_index.slt
+++ b/tests/slt/where_by_index.slt
@@ -198,5 +198,27 @@ select * from t1 where c2 > 0 and c2 < 10;
 0 1 9
 6 7 8
 
+# unique covered
+query I rowsort
+select c1 from t1 where c1 < 10;
+----
+
+statement ok
+drop index t1.u_c1_index;
+
+# normal covered
+query II rowsort
+select c2 from t1 where c2 < 10 and c2 > 0;
+----
+
+statement ok
+drop index t1.c2_index;
+
+# composite covered
+query II rowsort
+select c1 c2 from t1 where c1 < 10 and c1 > 0 and c2 >0 and c2 < 10;
+----
+
+
 statement ok
 drop table t1;


### PR DESCRIPTION
### What problem does this PR solve?

By checking whether the index being used overrides the columns output by the Scan, if so, the required values ​​are returned only from the index itself, avoiding table lookups.

fix:  where is_null scanned extra data during indexing.

### What is changed and how it works?

When performing an index_lookup in CoveredIndexImpl, the value portion of the key is parsed, deserialized, and assembled into a tuple for return.

The `is_null` key lookup is implemented by marking null values ​​before the value to distinguish whether a value is null.

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
