### PR TITLE
Perf/rocksdb

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -34,7 +34,7 @@ use crate::planner::operator::Operator;
 use crate::planner::LogicalPlan;
 use crate::storage::memory::MemoryStorage;
 #[cfg(not(target_arch = "wasm32"))]
-use crate::storage::rocksdb::{OptimisticRocksStorage, RocksDbMetrics, RocksStorage};
+use crate::storage::rocksdb::{OptimisticRocksStorage, RocksStorage, StorageConfig};
 use crate::storage::{StatisticsMetaCache, Storage, TableCache, Transaction, ViewCache};
 use crate::types::tuple::{SchemaRef, Tuple};
 use crate::types::value::DataValue;
@@ -66,6 +66,8 @@ pub struct DataBaseBuilder {
     scala_functions: ScalaFunctions,
     table_functions: TableFunctions,
     histogram_buckets: Option<usize>,
+    #[cfg(not(target_arch = "wasm32"))]
+    storage_config: StorageConfig,
 }
 
 impl DataBaseBuilder {
@@ -75,6 +77,8 @@ impl DataBaseBuilder {
             scala_functions: Default::default(),
             table_functions: Default::default(),
             histogram_buckets: None,
+            #[cfg(not(target_arch = "wasm32"))]
+            storage_config: Default::default(),
         };
         builder = builder.register_scala_function(CharLength::new("char_length".to_lowercase()));
         builder =
@@ -107,6 +111,12 @@ impl DataBaseBuilder {
         self
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn storage_statistics(mut self, enable: bool) -> Self {
+        self.storage_config.enable_statistics = enable;
+        self
+    }
+
     pub fn build_with_storage<T: Storage>(self, storage: T) -> Result<Database<T>, DatabaseError> {
         Self::_build::<T>(
             storage,
@@ -130,7 +140,7 @@ impl DataBaseBuilder {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub fn build(self) -> Result<Database<RocksStorage>, DatabaseError> {
-        let storage = RocksStorage::new(self.path)?;
+        let storage = RocksStorage::with_config(self.path, self.storage_config)?;
 
         Self::_build::<RocksStorage>(
             storage,
@@ -153,7 +163,7 @@ impl DataBaseBuilder {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub fn build_optimistic(self) -> Result<Database<OptimisticRocksStorage>, DatabaseError> {
-        let storage = OptimisticRocksStorage::new(self.path)?;
+        let storage = OptimisticRocksStorage::with_config(self.path, self.storage_config)?;
 
         Self::_build::<OptimisticRocksStorage>(
             storage,
@@ -521,20 +531,9 @@ impl<S: Storage> Database<S> {
             state,
         })
     }
-}
 
-#[cfg(not(target_arch = "wasm32"))]
-impl Database<RocksStorage> {
     #[inline]
-    pub fn rocksdb_metrics(&self) -> RocksDbMetrics {
-        self.storage.metrics()
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl Database<OptimisticRocksStorage> {
-    #[inline]
-    pub fn rocksdb_metrics(&self) -> RocksDbMetrics {
+    pub fn storage_metrics(&self) -> Option<S::Metrics> {
         self.storage.metrics()
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -34,7 +34,7 @@ use crate::planner::operator::Operator;
 use crate::planner::LogicalPlan;
 use crate::storage::memory::MemoryStorage;
 #[cfg(not(target_arch = "wasm32"))]
-use crate::storage::rocksdb::{OptimisticRocksStorage, RocksStorage};
+use crate::storage::rocksdb::{OptimisticRocksStorage, RocksDbMetrics, RocksStorage};
 use crate::storage::{StatisticsMetaCache, Storage, TableCache, Transaction, ViewCache};
 use crate::types::tuple::{SchemaRef, Tuple};
 use crate::types::value::DataValue;
@@ -520,6 +520,22 @@ impl<S: Storage> Database<S> {
             _guard: guard,
             state,
         })
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Database<RocksStorage> {
+    #[inline]
+    pub fn rocksdb_metrics(&self) -> RocksDbMetrics {
+        self.storage.metrics()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Database<OptimisticRocksStorage> {
+    #[inline]
+    pub fn rocksdb_metrics(&self) -> RocksDbMetrics {
+        self.storage.metrics()
     }
 }
 

--- a/src/optimizer/core/histogram.rs
+++ b/src/optimizer/core/histogram.rs
@@ -273,6 +273,10 @@ impl Histogram {
         self.values_len
     }
 
+    pub fn buckets_len(&self) -> usize {
+        self.buckets.len()
+    }
+
     pub fn collect_count(
         &self,
         ranges: &[Range],

--- a/src/storage/memory.rs
+++ b/src/storage/memory.rs
@@ -14,7 +14,7 @@
 
 use crate::errors::DatabaseError;
 use crate::storage::table_codec::{BumpBytes, Bytes, TableCodec};
-use crate::storage::{InnerIter, Storage, Transaction};
+use crate::storage::{EmptyStorageMetrics, InnerIter, Storage, Transaction};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, Bound, VecDeque};
 use std::rc::Rc;
@@ -31,6 +31,8 @@ impl MemoryStorage {
 }
 
 impl Storage for MemoryStorage {
+    type Metrics = EmptyStorageMetrics;
+
     type TransactionType<'a>
         = MemoryTransaction
     where

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -34,6 +34,7 @@ use crate::types::{ColumnId, LogicalType};
 use crate::utils::lru::SharedLruCache;
 use itertools::Itertools;
 use std::collections::{BTreeMap, Bound};
+use std::fmt::{self, Display, Formatter};
 #[cfg(not(target_arch = "wasm32"))]
 use std::fs;
 use std::io::Cursor;
@@ -47,12 +48,27 @@ pub(crate) type StatisticsMetaCache = SharedLruCache<(TableName, IndexId), Stati
 pub(crate) type TableCache = SharedLruCache<TableName, TableCatalog>;
 pub(crate) type ViewCache = SharedLruCache<TableName, View>;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EmptyStorageMetrics;
+
+impl Display for EmptyStorageMetrics {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str("")
+    }
+}
+
 pub trait Storage: Clone {
+    type Metrics: Display;
+
     type TransactionType<'a>: Transaction
     where
         Self: 'a;
 
     fn transaction(&self) -> Result<Self::TransactionType<'_>, DatabaseError>;
+
+    fn metrics(&self) -> Option<Self::Metrics> {
+        None
+    }
 }
 
 /// Optional bounds of the reader, of the form (offset, limit).

--- a/src/storage/rocksdb.rs
+++ b/src/storage/rocksdb.rs
@@ -23,6 +23,35 @@ use std::collections::Bound;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+// Table data keys are `{table_hash(8)}{type_tag(1)}...`, so use hash+type as prefix.
+const ROCKSDB_FIXED_PREFIX_LEN: usize = 9;
+const ROCKSDB_BLOOM_BITS_PER_KEY: f64 = 10.0;
+const ROCKSDB_MEMTABLE_PREFIX_BLOOM_RATIO: f64 = 0.10;
+
+/// A lightweight snapshot of key RocksDB runtime indicators for tuning and diagnostics.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct RocksDbMetrics {
+    pub block_cache_hit: Option<u64>,
+    pub block_cache_miss: Option<u64>,
+    pub stall_micros: Option<u64>,
+    pub compaction_pending_bytes: Option<u64>,
+    pub write_amp: Option<f64>,
+}
+
+impl RocksDbMetrics {
+    #[inline]
+    pub fn block_cache_hit_rate(&self) -> Option<f64> {
+        let hit = self.block_cache_hit?;
+        let miss = self.block_cache_miss?;
+        let total = hit + miss;
+        if total == 0 {
+            return None;
+        }
+
+        Some(hit as f64 / total as f64)
+    }
+}
+
 #[derive(Clone)]
 pub struct OptimisticRocksStorage {
     pub inner: Arc<OptimisticTransactionDB>,
@@ -36,33 +65,110 @@ impl OptimisticRocksStorage {
             inner: Arc::new(storage),
         })
     }
+
+    #[inline]
+    pub fn metrics(&self) -> RocksDbMetrics {
+        collect_metrics(
+            |name| self.inner.property_int_value(name),
+            |name| self.inner.property_value(name),
+        )
+    }
 }
 
 #[derive(Clone)]
 pub struct RocksStorage {
-    pub inner: Arc<TransactionDB>,
+    pub inner: Arc<TransactionDB<rocksdb::MultiThreaded>>,
 }
 
 impl RocksStorage {
     pub fn new(path: impl Into<PathBuf> + Send) -> Result<Self, DatabaseError> {
         let txn_opts = rocksdb::TransactionDBOptions::default();
-        let storage = TransactionDB::open(&default_opts(), &txn_opts, path.into())?;
+        let storage = TransactionDB::<rocksdb::MultiThreaded>::open(
+            &default_opts(),
+            &txn_opts,
+            path.into(),
+        )?;
 
         Ok(RocksStorage {
             inner: Arc::new(storage),
         })
     }
+
+    #[inline]
+    pub fn metrics(&self) -> RocksDbMetrics {
+        collect_metrics(
+            |name| self.inner.property_int_value(name),
+            |name| self.inner.property_value(name),
+        )
+    }
+}
+
+fn collect_metrics(
+    int_property: impl Fn(&str) -> Result<Option<u64>, rocksdb::Error>,
+    str_property: impl Fn(&str) -> Result<Option<String>, rocksdb::Error>,
+) -> RocksDbMetrics {
+    let block_cache_hit = int_property("rocksdb.block-cache-hit").ok().flatten();
+    let block_cache_miss = int_property("rocksdb.block-cache-miss").ok().flatten();
+    let stall_micros = int_property("rocksdb.stall-micros").ok().flatten();
+    let compaction_pending_bytes = int_property("rocksdb.estimate-pending-compaction-bytes")
+        .ok()
+        .flatten();
+    let write_amp = read_write_amp(&str_property);
+
+    RocksDbMetrics {
+        block_cache_hit,
+        block_cache_miss,
+        stall_micros,
+        compaction_pending_bytes,
+        write_amp,
+    }
+}
+
+fn read_write_amp(
+    str_property: &impl Fn(&str) -> Result<Option<String>, rocksdb::Error>,
+) -> Option<f64> {
+    for key in ["rocksdb.write-amp", "rocksdb.write-amplification"] {
+        if let Ok(Some(value)) = str_property(key) {
+            if let Some(number) = parse_last_f64(&value) {
+                return Some(number);
+            }
+        }
+    }
+
+    if let Ok(Some(stats)) = str_property("rocksdb.stats") {
+        for line in stats.lines() {
+            if line.to_ascii_lowercase().contains("write amplification") {
+                if let Some(number) = parse_last_f64(line) {
+                    return Some(number);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn parse_last_f64(input: &str) -> Option<f64> {
+    input
+        .split(|c: char| !(c.is_ascii_digit() || c == '.' || c == '-'))
+        .filter(|token| !token.is_empty() && *token != "." && *token != "-" && *token != "-.")
+        .rev()
+        .find_map(|token| token.parse::<f64>().ok())
 }
 
 fn default_opts() -> Options {
     let mut bb = rocksdb::BlockBasedOptions::default();
     bb.set_block_cache(&rocksdb::Cache::new_lru_cache(40 * 1_024 * 1_024));
+    bb.set_bloom_filter(ROCKSDB_BLOOM_BITS_PER_KEY, true);
     bb.set_whole_key_filtering(false);
 
     let mut opts = rocksdb::Options::default();
     opts.set_block_based_table_factory(&bb);
     opts.create_if_missing(true);
-    opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(4));
+    opts.set_memtable_prefix_bloom_ratio(ROCKSDB_MEMTABLE_PREFIX_BLOOM_RATIO);
+    opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(
+        ROCKSDB_FIXED_PREFIX_LEN,
+    ));
     opts
 }
 
@@ -100,7 +206,7 @@ pub struct OptimisticRocksTransaction<'db> {
 }
 
 pub struct RocksTransaction<'db> {
-    tx: rocksdb::Transaction<'db, TransactionDB>,
+    tx: rocksdb::Transaction<'db, TransactionDB<rocksdb::MultiThreaded>>,
     table_codec: TableCodec,
 }
 
@@ -167,11 +273,12 @@ macro_rules! impl_transaction {
                         .take_while(|(x, y)| x == y)
                         .count();
 
-                    debug_assert!(len > 0);
-                    let mut iter = self.tx.prefix_iterator(&min_bytes[..len]);
-                    iter.set_mode(lower);
+                    if len >= ROCKSDB_FIXED_PREFIX_LEN {
+                        let mut iter = self.tx.prefix_iterator(&min_bytes[..len]);
+                        iter.set_mode(lower);
 
-                    return Ok($iter { upper: max, iter });
+                        return Ok($iter { upper: max, iter });
+                    }
                 }
                 let iter = self.tx.iterator(lower);
 
@@ -206,7 +313,10 @@ impl InnerIter for OptimisticRocksIter<'_, '_> {
 
 pub struct RocksIter<'txn, 'iter> {
     upper: Bound<BumpBytes<'iter>>,
-    iter: DBIteratorWithThreadMode<'iter, rocksdb::Transaction<'txn, TransactionDB>>,
+    iter: DBIteratorWithThreadMode<
+        'iter,
+        rocksdb::Transaction<'txn, TransactionDB<rocksdb::MultiThreaded>>,
+    >,
 }
 
 impl InnerIter for RocksIter<'_, '_> {
@@ -256,6 +366,33 @@ mod test {
     use std::hash::RandomState;
     use std::sync::Arc;
     use tempfile::TempDir;
+
+    #[test]
+    fn test_parse_write_amp_from_stats_line() {
+        assert_eq!(
+            super::parse_last_f64("Cumulative writes: 89 writes, Write Amplification: 1.72"),
+            Some(1.72)
+        );
+        assert_eq!(super::parse_last_f64("no numeric token"), None);
+    }
+
+    #[test]
+    fn test_collect_rocksdb_metrics_snapshot() -> Result<(), DatabaseError> {
+        let temp_dir = TempDir::new().expect("unable to create temporary working directory");
+        let kite_sql = DataBaseBuilder::path(temp_dir.path()).build()?;
+        kite_sql
+            .run("create table t_metrics (a int primary key, b int)")?
+            .done()?;
+        kite_sql
+            .run("insert into t_metrics values (1, 10), (2, 20), (3, 30)")?
+            .done()?;
+        kite_sql.run("select * from t_metrics where a = 2")?.done()?;
+
+        let metrics = kite_sql.rocksdb_metrics();
+        let _ = metrics.block_cache_hit_rate();
+
+        Ok(())
+    }
 
     #[test]
     fn test_in_rocksdb_storage_works_with_data() -> Result<(), DatabaseError> {

--- a/src/storage/rocksdb.rs
+++ b/src/storage/rocksdb.rs
@@ -16,10 +16,12 @@ use crate::errors::DatabaseError;
 use crate::storage::table_codec::{BumpBytes, Bytes, TableCodec};
 use crate::storage::{InnerIter, Storage, Transaction};
 use rocksdb::{
+    statistics::{StatsLevel, Ticker},
     DBIteratorWithThreadMode, Direction, IteratorMode, OptimisticTransactionDB, Options,
     SliceTransform, TransactionDB,
 };
 use std::collections::Bound;
+use std::fmt::{self, Display, Formatter};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -38,6 +40,11 @@ pub struct RocksDbMetrics {
     pub write_amp: Option<f64>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StorageConfig {
+    pub enable_statistics: bool,
+}
+
 impl RocksDbMetrics {
     #[inline]
     pub fn block_cache_hit_rate(&self) -> Option<f64> {
@@ -52,68 +59,96 @@ impl RocksDbMetrics {
     }
 }
 
+impl Display for RocksDbMetrics {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        writeln!(f, "<RocksDB Metrics>")?;
+        writeln!(
+            f,
+            "block_cache_hit={} block_cache_miss={} block_cache_hit_rate={}",
+            format_optional_u64(self.block_cache_hit),
+            format_optional_u64(self.block_cache_miss),
+            format_optional_pct(self.block_cache_hit_rate()),
+        )?;
+        write!(
+            f,
+            "stall_micros={} pending_compaction_bytes={} write_amp={}",
+            format_optional_u64(self.stall_micros),
+            format_optional_u64(self.compaction_pending_bytes),
+            format_optional_f64(self.write_amp),
+        )
+    }
+}
+
 #[derive(Clone)]
 pub struct OptimisticRocksStorage {
     pub inner: Arc<OptimisticTransactionDB>,
+    options: Arc<Options>,
+    config: StorageConfig,
 }
 
 impl OptimisticRocksStorage {
     pub fn new(path: impl Into<PathBuf> + Send) -> Result<Self, DatabaseError> {
-        let storage = OptimisticTransactionDB::open(&default_opts(), path.into())?;
+        Self::with_config(path, StorageConfig::default())
+    }
+
+    pub fn with_config(
+        path: impl Into<PathBuf> + Send,
+        config: StorageConfig,
+    ) -> Result<Self, DatabaseError> {
+        let options = Arc::new(default_opts(config));
+        let storage = OptimisticTransactionDB::open(options.as_ref(), path.into())?;
 
         Ok(OptimisticRocksStorage {
             inner: Arc::new(storage),
+            options,
+            config,
         })
-    }
-
-    #[inline]
-    pub fn metrics(&self) -> RocksDbMetrics {
-        collect_metrics(
-            |name| self.inner.property_int_value(name),
-            |name| self.inner.property_value(name),
-        )
     }
 }
 
 #[derive(Clone)]
 pub struct RocksStorage {
     pub inner: Arc<TransactionDB<rocksdb::MultiThreaded>>,
+    options: Arc<Options>,
+    config: StorageConfig,
 }
 
 impl RocksStorage {
     pub fn new(path: impl Into<PathBuf> + Send) -> Result<Self, DatabaseError> {
+        Self::with_config(path, StorageConfig::default())
+    }
+
+    pub fn with_config(
+        path: impl Into<PathBuf> + Send,
+        config: StorageConfig,
+    ) -> Result<Self, DatabaseError> {
+        let options = Arc::new(default_opts(config));
         let txn_opts = rocksdb::TransactionDBOptions::default();
         let storage = TransactionDB::<rocksdb::MultiThreaded>::open(
-            &default_opts(),
+            options.as_ref(),
             &txn_opts,
             path.into(),
         )?;
 
         Ok(RocksStorage {
             inner: Arc::new(storage),
+            options,
+            config,
         })
-    }
-
-    #[inline]
-    pub fn metrics(&self) -> RocksDbMetrics {
-        collect_metrics(
-            |name| self.inner.property_int_value(name),
-            |name| self.inner.property_value(name),
-        )
     }
 }
 
 fn collect_metrics(
+    options: &Options,
     int_property: impl Fn(&str) -> Result<Option<u64>, rocksdb::Error>,
-    str_property: impl Fn(&str) -> Result<Option<String>, rocksdb::Error>,
 ) -> RocksDbMetrics {
-    let block_cache_hit = int_property("rocksdb.block-cache-hit").ok().flatten();
-    let block_cache_miss = int_property("rocksdb.block-cache-miss").ok().flatten();
-    let stall_micros = int_property("rocksdb.stall-micros").ok().flatten();
+    let block_cache_hit = Some(options.get_ticker_count(Ticker::BlockCacheHit));
+    let block_cache_miss = Some(options.get_ticker_count(Ticker::BlockCacheMiss));
+    let stall_micros = Some(options.get_ticker_count(Ticker::StallMicros));
     let compaction_pending_bytes = int_property("rocksdb.estimate-pending-compaction-bytes")
         .ok()
         .flatten();
-    let write_amp = read_write_amp(&str_property);
+    let write_amp = read_write_amp(options.get_statistics().as_deref());
 
     RocksDbMetrics {
         block_cache_hit,
@@ -124,18 +159,8 @@ fn collect_metrics(
     }
 }
 
-fn read_write_amp(
-    str_property: &impl Fn(&str) -> Result<Option<String>, rocksdb::Error>,
-) -> Option<f64> {
-    for key in ["rocksdb.write-amp", "rocksdb.write-amplification"] {
-        if let Ok(Some(value)) = str_property(key) {
-            if let Some(number) = parse_last_f64(&value) {
-                return Some(number);
-            }
-        }
-    }
-
-    if let Ok(Some(stats)) = str_property("rocksdb.stats") {
+fn read_write_amp(stats: Option<&str>) -> Option<f64> {
+    if let Some(stats) = stats {
         for line in stats.lines() {
             if line.to_ascii_lowercase().contains("write amplification") {
                 if let Some(number) = parse_last_f64(line) {
@@ -156,7 +181,25 @@ fn parse_last_f64(input: &str) -> Option<f64> {
         .find_map(|token| token.parse::<f64>().ok())
 }
 
-fn default_opts() -> Options {
+fn format_optional_u64(value: Option<u64>) -> String {
+    value
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn format_optional_f64(value: Option<f64>) -> String {
+    value
+        .map(|v| format!("{v:.3}"))
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn format_optional_pct(value: Option<f64>) -> String {
+    value
+        .map(|v| format!("{:.2}%", v * 100.0))
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn default_opts(config: StorageConfig) -> Options {
     let mut bb = rocksdb::BlockBasedOptions::default();
     bb.set_block_cache(&rocksdb::Cache::new_lru_cache(40 * 1_024 * 1_024));
     bb.set_bloom_filter(ROCKSDB_BLOOM_BITS_PER_KEY, true);
@@ -165,6 +208,10 @@ fn default_opts() -> Options {
     let mut opts = rocksdb::Options::default();
     opts.set_block_based_table_factory(&bb);
     opts.create_if_missing(true);
+    if config.enable_statistics {
+        opts.enable_statistics();
+        opts.set_statistics_level(StatsLevel::ExceptDetailedTimers);
+    }
     opts.set_memtable_prefix_bloom_ratio(ROCKSDB_MEMTABLE_PREFIX_BLOOM_RATIO);
     opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(
         ROCKSDB_FIXED_PREFIX_LEN,
@@ -173,6 +220,8 @@ fn default_opts() -> Options {
 }
 
 impl Storage for OptimisticRocksStorage {
+    type Metrics = RocksDbMetrics;
+
     type TransactionType<'a>
         = OptimisticRocksTransaction<'a>
     where
@@ -184,9 +233,21 @@ impl Storage for OptimisticRocksStorage {
             table_codec: Default::default(),
         })
     }
+
+    fn metrics(&self) -> Option<Self::Metrics> {
+        if !self.config.enable_statistics {
+            return None;
+        }
+
+        Some(collect_metrics(self.options.as_ref(), |name| {
+            self.inner.property_int_value(name)
+        }))
+    }
 }
 
 impl Storage for RocksStorage {
+    type Metrics = RocksDbMetrics;
+
     type TransactionType<'a>
         = RocksTransaction<'a>
     where
@@ -197,6 +258,16 @@ impl Storage for RocksStorage {
             tx: self.inner.transaction(),
             table_codec: Default::default(),
         })
+    }
+
+    fn metrics(&self) -> Option<Self::Metrics> {
+        if !self.config.enable_statistics {
+            return None;
+        }
+
+        Some(collect_metrics(self.options.as_ref(), |name| {
+            self.inner.property_int_value(name)
+        }))
     }
 }
 
@@ -379,16 +450,20 @@ mod test {
     #[test]
     fn test_collect_rocksdb_metrics_snapshot() -> Result<(), DatabaseError> {
         let temp_dir = TempDir::new().expect("unable to create temporary working directory");
-        let kite_sql = DataBaseBuilder::path(temp_dir.path()).build()?;
+        let kite_sql = DataBaseBuilder::path(temp_dir.path())
+            .storage_statistics(true)
+            .build()?;
         kite_sql
             .run("create table t_metrics (a int primary key, b int)")?
             .done()?;
         kite_sql
             .run("insert into t_metrics values (1, 10), (2, 20), (3, 30)")?
             .done()?;
-        kite_sql.run("select * from t_metrics where a = 2")?.done()?;
+        kite_sql
+            .run("select * from t_metrics where a = 2")?
+            .done()?;
 
-        let metrics = kite_sql.rocksdb_metrics();
+        let metrics = kite_sql.storage_metrics().unwrap();
         let _ = metrics.block_cache_hit_rate();
 
         Ok(())

--- a/src/storage/table_codec.rs
+++ b/src/storage/table_codec.rs
@@ -118,7 +118,7 @@ impl TableCodec {
     ///
     /// Tips:
     /// 1. Root & View & Hash full key = key_prefix
-    /// 2. hash table name makes it 4 as a fixed length, and [prefix_extractor](https://github.com/facebook/rocksdb/wiki/Prefix-Seek#defining-a-prefix) can be enabled in rocksdb
+    /// 2. table-name hash is fixed-width (8 bytes), so [prefix_extractor](https://github.com/facebook/rocksdb/wiki/Prefix-Seek#defining-a-prefix) can be enabled in rocksdb
     fn key_prefix(&self, ty: CodecType, name: &str) -> BumpBytes<'_> {
         let mut table_bytes = BumpBytes::new_in(&self.arena);
         table_bytes.extend_from_slice(Self::hash_bytes(name).as_slice());

--- a/tpcc/src/backend/dual.rs
+++ b/tpcc/src/backend/dual.rs
@@ -30,9 +30,9 @@ pub struct DualBackend {
 }
 
 impl DualBackend {
-    pub fn new(path: &str) -> Result<Self, TpccError> {
+    pub fn new(path: &str, rocksdb_stats: bool) -> Result<Self, TpccError> {
         Ok(Self {
-            kite: KiteBackend::new(path)?,
+            kite: KiteBackend::new(path, rocksdb_stats)?,
             sqlite: SqliteBackend::new_memory()?,
         })
     }
@@ -56,6 +56,10 @@ impl BackendControl for DualBackend {
             kite: self.kite.new_transaction()?,
             sqlite: self.sqlite.new_transaction()?,
         })
+    }
+
+    fn storage_metrics(&self) -> Option<String> {
+        self.kite.storage_metrics()
     }
 }
 

--- a/tpcc/src/backend/kite.rs
+++ b/tpcc/src/backend/kite.rs
@@ -26,9 +26,11 @@ pub struct KiteBackend {
 }
 
 impl KiteBackend {
-    pub fn new(path: &str) -> Result<Self, TpccError> {
+    pub fn new(path: &str, rocksdb_stats: bool) -> Result<Self, TpccError> {
         Ok(Self {
-            database: DataBaseBuilder::path(path).build()?,
+            database: DataBaseBuilder::path(path)
+                .storage_statistics(rocksdb_stats)
+                .build()?,
         })
     }
 
@@ -73,6 +75,12 @@ impl BackendControl for KiteBackend {
 
     fn new_transaction(&self) -> Result<Self::Transaction<'_>, TpccError> {
         self.start_transaction()
+    }
+
+    fn storage_metrics(&self) -> Option<String> {
+        self.database
+            .storage_metrics()
+            .map(|metrics| metrics.to_string())
     }
 }
 

--- a/tpcc/src/backend/mod.rs
+++ b/tpcc/src/backend/mod.rs
@@ -41,6 +41,10 @@ pub trait BackendControl: SimpleExecutor {
     ) -> Result<Vec<Vec<PreparedStatement>>, TpccError>;
 
     fn new_transaction(&self) -> Result<Self::Transaction<'_>, TpccError>;
+
+    fn storage_metrics(&self) -> Option<String> {
+        None
+    }
 }
 
 pub struct QueryResult<'a>(QueryResultKind<'a>);

--- a/tpcc/src/main.rs
+++ b/tpcc/src/main.rs
@@ -105,6 +105,8 @@ struct Args {
     measure_time: u64,
     #[clap(long, default_value = "1")]
     num_ware: usize,
+    #[clap(long, default_value = "false")]
+    rocksdb_stats: bool,
 }
 
 #[derive(Copy, Clone, Debug, ValueEnum)]
@@ -124,7 +126,7 @@ fn main() -> Result<(), TpccError> {
             if db_path.exists() {
                 fs::remove_dir_all(db_path)?;
             }
-            let backend = KiteBackend::new(&args.path)?;
+            let backend = KiteBackend::new(&args.path, args.rocksdb_stats)?;
             run_tpcc(&backend, &args, &mut rng)?;
         }
         BackendKind::Dual => {
@@ -132,7 +134,7 @@ fn main() -> Result<(), TpccError> {
             if db_path.exists() {
                 fs::remove_dir_all(db_path)?;
             }
-            let backend = DualBackend::new(&args.path)?;
+            let backend = DualBackend::new(&args.path, args.rocksdb_stats)?;
             run_tpcc(&backend, &args, &mut rng)?;
         }
     }
@@ -266,6 +268,10 @@ fn run_tpcc<B: BackendControl>(
     println!("<TpmC>");
     let tpmc = ((success[0] + late[0]) as f64 / (actual_tpcc_time.as_secs_f64() / 60.0)).round();
     println!("{} Tpmc", tpmc);
+    if let Some(metrics) = backend.storage_metrics() {
+        println!();
+        println!("{metrics}");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
### What problem does this PR solve?

- Optimize RocksDB prefix iteration by using a fixed-length prefix (table_hash + type_tag) in key layout
- Enable RocksDB prefix-based seek and bloom filtering to reduce unnecessary iterator scanning
- Add a generic storage metrics API to Storage via an associated Metrics type that only needs to implement Display
- Introduce Database::storage_metrics() so metrics can be exposed without hardcoding RocksDB-specific APIs
- Implement RocksDB metrics collection for cache hits/misses, stall time, pending compaction bytes, and related runtime indicators
- Add DataBaseBuilder::storage_statistics(bool) to explicitly control whether storage statistics are enabled
- Add --rocksdb-stats to tpcc so storage metrics can be printed at the end of a benchmark run when needed

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer
