### PR TITLE
feat: complete ORM query builder and model-driven workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ KiteSQL supports direct SQL execution, typed ORM models, schema migration, and b
 ## Key Features
 - A lightweight embedded SQL database fully rewritten in Rust
 - A Rust-native relational API alongside direct SQL execution
-- Typed ORM models with migrations, CRUD helpers, and a lightweight query builder
+- Typed ORM models with migrations and a lightweight typed query/mutation builder
 - Higher write speed with an application-friendly embedding model
 - All metadata and actual data in KV storage, with no intermediate stateful service layer
 - Extensible storage integration for customized workloads
@@ -43,7 +43,7 @@ KiteSQL supports direct SQL execution, typed ORM models, schema migration, and b
 #### 👉[check more](docs/features.md)
 
 ## ORM
-KiteSQL includes a built-in ORM behind the `orm` feature flag. With `#[derive(Model)]`, you can define typed models and get tuple mapping, CRUD helpers, schema creation, migration support, and builder-style single-table queries.
+KiteSQL includes a built-in ORM behind the `orm` feature flag. With `#[derive(Model)]`, you can define typed models and get tuple mapping, schema creation, migration support, and builder-style single-table queries and mutations.
 
 ### Schema Migration
 Model changes are part of the normal workflow. KiteSQL ORM can help evolve tables for common schema updates, including adding, dropping, renaming, and changing columns, so many migrations can stay close to the Rust model definition instead of being managed as hand-written SQL.
@@ -89,9 +89,17 @@ fn main() -> Result<(), DatabaseError> {
         age: Some(24),
     })?;
 
-    let mut alice = database.get::<User>(&1)?.unwrap();
-    alice.age = Some(19);
-    database.update(&alice)?;
+    database
+        .from::<User>()
+        .eq(User::id(), 1)
+        .update()
+        .set(User::age(), Some(19))
+        .execute()?;
+
+    database
+        .from::<User>()
+        .eq(User::id(), 2)
+        .delete()?;
 
     let users = database
         .from::<User>()
@@ -104,7 +112,7 @@ fn main() -> Result<(), DatabaseError> {
         println!("{:?}", user?);
     }
 
-    // ORM covers common model-centric workflows, while `run(...)` remains available
+    // ORM covers common typed table workflows, while `run(...)` remains available
     // for more advanced SQL that is easier to express directly.
     let top_users = database.run(
         r#"

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ fn main() -> Result<(), DatabaseError> {
     database.update(&alice)?;
 
     let users = database
-        .select::<User>()
+        .from::<User>()
         .and(User::email().like("%@example.com"), User::age().gte(18))
         .asc(User::name())
         .limit(10)

--- a/README.md
+++ b/README.md
@@ -95,9 +95,8 @@ fn main() -> Result<(), DatabaseError> {
 
     let users = database
         .select::<User>()
-        .filter(User::email().like("%@example.com"))
-        .and_filter(User::age().gte(18))
-        .order_by(User::name().asc())
+        .and(User::email().like("%@example.com"), User::age().gte(18))
+        .asc(User::name())
         .limit(10)
         .fetch()?;
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ KiteSQL supports direct SQL execution, typed ORM models, schema migration, and b
 #### 👉[check more](docs/features.md)
 
 ## ORM
-KiteSQL includes a built-in ORM behind the `orm` feature flag. With `#[derive(Model)]`, you can define typed models and get tuple mapping, schema creation, migration support, and builder-style single-table queries and mutations.
+KiteSQL includes a built-in ORM behind the `orm` feature flag. With `#[derive(Model)]`, you can define typed models and get tuple mapping, schema creation, migration support, projections, set queries, and builder-style query/mutation workflows.
 
 ### Schema Migration
 Model changes are part of the normal workflow. KiteSQL ORM can help evolve tables for common schema updates, including adding, dropping, renaming, and changing columns, so many migrations can stay close to the Rust model definition instead of being managed as hand-written SQL.
@@ -55,7 +55,7 @@ For the full ORM guide, see [`src/orm/README.md`](src/orm/README.md).
 ```rust
 use kite_sql::db::DataBaseBuilder;
 use kite_sql::errors::DatabaseError;
-use kite_sql::Model;
+use kite_sql::{Model, Projection};
 
 #[derive(Default, Debug, PartialEq, Model)]
 #[model(table = "users")]
@@ -71,23 +71,32 @@ struct User {
     age: Option<i32>,
 }
 
+#[derive(Default, Debug, PartialEq, Projection)]
+struct UserSummary {
+    id: i32,
+    #[projection(rename = "user_name")]
+    display_name: String,
+}
+
 fn main() -> Result<(), DatabaseError> {
     let database = DataBaseBuilder::path("./data").build()?;
 
     database.migrate::<User>()?;
 
-    database.insert(&User {
-        id: 1,
-        email: "alice@example.com".to_string(),
-        name: "Alice".to_string(),
-        age: Some(18),
-    })?;
-    database.insert(&User {
-        id: 2,
-        email: "bob@example.com".to_string(),
-        name: "Bob".to_string(),
-        age: Some(24),
-    })?;
+    database.insert_many([
+        User {
+            id: 1,
+            email: "alice@example.com".to_string(),
+            name: "Alice".to_string(),
+            age: Some(18),
+        },
+        User {
+            id: 2,
+            email: "bob@example.com".to_string(),
+            name: "Bob".to_string(),
+            age: Some(24),
+        },
+    ])?;
 
     database
         .from::<User>()
@@ -103,7 +112,8 @@ fn main() -> Result<(), DatabaseError> {
 
     let users = database
         .from::<User>()
-        .and(User::email().like("%@example.com"), User::age().gte(18))
+        .gte(User::age(), 18)
+        .project::<UserSummary>()
         .asc(User::name())
         .limit(10)
         .fetch()?;
@@ -112,23 +122,7 @@ fn main() -> Result<(), DatabaseError> {
         println!("{:?}", user?);
     }
 
-    // ORM covers common typed table workflows, while `run(...)` remains available
-    // for more advanced SQL that is easier to express directly.
-    let top_users = database.run(
-        r#"
-        select user_name, count(*) as total
-        from users
-        where age >= 18
-        group by user_name
-        having count(*) > 0
-        order by total desc, user_name asc
-        limit 5
-        "#,
-    )?;
-
-    for row in top_users {
-        println!("aggregated row: {:?}", row?);
-    }
+    // For ad-hoc or more SQL-shaped workloads, `run(...)` is still available.
 
     Ok(())
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -56,10 +56,13 @@ mod app {
             c2: "two".to_string(),
         })?;
 
-        let mut row = database.get::<MyStruct>(&1)?.expect("row should exist");
-        row.c2 = "ONE".to_string();
-        database.update(&row)?;
-        database.delete_by_id::<MyStruct>(&2)?;
+        database
+            .from::<MyStruct>()
+            .eq(MyStruct::c1(), 1)
+            .update()
+            .set(MyStruct::c2(), "ONE")
+            .execute()?;
+        database.from::<MyStruct>().eq(MyStruct::c1(), 2).delete()?;
 
         for row in database.fetch::<MyStruct>()? {
             println!("{:?}", row?);

--- a/kite_sql_serde_macros/src/lib.rs
+++ b/kite_sql_serde_macros/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod orm;
+mod projection;
 mod reference_serialization;
 
 use proc_macro::TokenStream;
@@ -34,6 +35,17 @@ pub fn model(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
 
     let result = orm::handle(ast);
+    match result {
+        Ok(codegen) => codegen.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+#[proc_macro_derive(Projection, attributes(projection))]
+pub fn projection(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+
+    let result = projection::handle(ast);
     match result {
         Ok(codegen) => codegen.into(),
         Err(e) => e.to_compile_error().into(),

--- a/kite_sql_serde_macros/src/orm.rs
+++ b/kite_sql_serde_macros/src/orm.rs
@@ -467,27 +467,6 @@ pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
                 &INSERT_STATEMENT
             }
 
-            fn update_statement() -> &'static ::kite_sql::db::Statement {
-                static UPDATE_STATEMENT: ::std::sync::LazyLock<::kite_sql::db::Statement> = ::std::sync::LazyLock::new(|| {
-                    ::kite_sql::orm::orm_update_statement(
-                        #table_name_lit,
-                        <#struct_name #ty_generics as ::kite_sql::orm::Model>::fields(),
-                        <#struct_name #ty_generics as ::kite_sql::orm::Model>::primary_key_field(),
-                    )
-                });
-                &UPDATE_STATEMENT
-            }
-
-            fn delete_statement() -> &'static ::kite_sql::db::Statement {
-                static DELETE_STATEMENT: ::std::sync::LazyLock<::kite_sql::db::Statement> = ::std::sync::LazyLock::new(|| {
-                    ::kite_sql::orm::orm_delete_statement(
-                        #table_name_lit,
-                        <#struct_name #ty_generics as ::kite_sql::orm::Model>::primary_key_field(),
-                    )
-                });
-                &DELETE_STATEMENT
-            }
-
             fn find_statement() -> &'static ::kite_sql::db::Statement {
                 static FIND_STATEMENT: ::std::sync::LazyLock<::kite_sql::db::Statement> = ::std::sync::LazyLock::new(|| {
                     ::kite_sql::orm::orm_find_statement(

--- a/kite_sql_serde_macros/src/orm.rs
+++ b/kite_sql_serde_macros/src/orm.rs
@@ -73,10 +73,8 @@ pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
     let mut field_getters = Vec::new();
     let mut column_names = Vec::new();
     let mut placeholder_names = Vec::new();
-    let mut update_assignments = Vec::new();
-    let mut ddl_columns = Vec::new();
-    let mut create_index_sqls = Vec::new();
-    let mut create_index_if_not_exists_sqls = Vec::new();
+    let mut create_index_statements = Vec::new();
+    let mut create_index_if_not_exists_statements = Vec::new();
     let mut persisted_columns = Vec::new();
     let mut index_names = BTreeSet::new();
     index_names.insert("pk_index".to_string());
@@ -179,7 +177,6 @@ pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
                 &self.#field_name
             });
         } else {
-            update_assignments.push(format!("{column_name} = {placeholder_name}"));
         }
 
         generics
@@ -220,14 +217,6 @@ pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
             }
         } else {
             quote! { <#field_ty as ::kite_sql::orm::ModelColumnType>::ddl_type() }
-        };
-        let default_clause = if let Some(default_expr) = &default_expr {
-            quote! {
-                column_def.push_str(" default ");
-                column_def.push_str(#default_expr);
-            }
-        } else {
-            quote! {}
         };
         let default_expr_tokens = if let Some(default_expr) = &default_expr {
             quote! { Some(#default_expr) }
@@ -278,50 +267,33 @@ pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
         }
         if is_index {
             let index_name = format!("{table_name}_{column_name}_index");
+            let index_name_lit = LitStr::new(&index_name, Span::call_site());
+            let column_name_for_index = column_name_lit.clone();
             if !index_names.insert(index_name.clone()) {
                 return Err(Error::new_spanned(
                     struct_name,
                     format!("duplicate ORM index name: {}", index_name),
                 ));
             }
-            create_index_sqls.push(LitStr::new(
-                &format!(
-                    "create index {} on {} ({})",
-                    index_name, table_name, column_name
-                ),
-                Span::call_site(),
-            ));
-            create_index_if_not_exists_sqls.push(LitStr::new(
-                &format!(
-                    "create index if not exists {} on {} ({})",
-                    index_name, table_name, column_name
-                ),
-                Span::call_site(),
-            ));
+            create_index_statements.push(quote! {
+                ::kite_sql::orm::orm_create_index_statement(
+                    #table_name_lit,
+                    #index_name_lit,
+                    &[#column_name_for_index],
+                    false,
+                    false,
+                )
+            });
+            create_index_if_not_exists_statements.push(quote! {
+                ::kite_sql::orm::orm_create_index_statement(
+                    #table_name_lit,
+                    #index_name_lit,
+                    &[#column_name_for_index],
+                    false,
+                    true,
+                )
+            });
         }
-
-        ddl_columns.push(quote! {
-            {
-                let ddl_type = #ddl_type;
-                let mut column_def = ::std::format!(
-                    "{} {}",
-                    #column_name_lit,
-                    ddl_type,
-                );
-                if #is_primary_key {
-                    column_def.push_str(" primary key");
-                } else {
-                    if !<#field_ty as ::kite_sql::orm::ModelColumnType>::nullable() {
-                        column_def.push_str(" not null");
-                    }
-                    if #is_unique {
-                        column_def.push_str(" unique");
-                    }
-                }
-                #default_clause
-                column_def
-            }
-        });
     }
 
     for index in orm_opts.indexes {
@@ -382,31 +354,30 @@ pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
             ));
         }
 
-        let index_columns = resolved_columns.join(", ");
-        let create_prefix = if index.unique {
-            "create unique index"
-        } else {
-            "create index"
-        };
-        let create_if_not_exists_prefix = if index.unique {
-            "create unique index if not exists"
-        } else {
-            "create index if not exists"
-        };
-        create_index_sqls.push(LitStr::new(
-            &format!(
-                "{} {} on {} ({})",
-                create_prefix, index.name, table_name, index_columns
-            ),
-            Span::call_site(),
-        ));
-        create_index_if_not_exists_sqls.push(LitStr::new(
-            &format!(
-                "{} {} on {} ({})",
-                create_if_not_exists_prefix, index.name, table_name, index_columns
-            ),
-            Span::call_site(),
-        ));
+        let index_name_lit = LitStr::new(&index.name, Span::call_site());
+        let index_columns = resolved_columns
+            .iter()
+            .map(|column| LitStr::new(column, Span::call_site()))
+            .collect::<Vec<_>>();
+        let is_unique = index.unique;
+        create_index_statements.push(quote! {
+            ::kite_sql::orm::orm_create_index_statement(
+                #table_name_lit,
+                #index_name_lit,
+                &[#(#index_columns),*],
+                #is_unique,
+                false,
+            )
+        });
+        create_index_if_not_exists_statements.push(quote! {
+            ::kite_sql::orm::orm_create_index_statement(
+                #table_name_lit,
+                #index_name_lit,
+                &[#(#index_columns),*],
+                #is_unique,
+                true,
+            )
+        });
     }
 
     if primary_key_count != 1 {
@@ -418,49 +389,8 @@ pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
 
     let primary_key_type = primary_key_type.expect("primary key checked above");
     let primary_key_value = primary_key_value.expect("primary key checked above");
-    let primary_key_column = primary_key_column.expect("primary key checked above");
-    let primary_key_placeholder = primary_key_placeholder.expect("primary key checked above");
-    let select_sql = LitStr::new(
-        &format!("select {} from {}", column_names.join(", "), table_name,),
-        Span::call_site(),
-    );
-    let insert_sql = LitStr::new(
-        &format!(
-            "insert into {} ({}) values ({})",
-            table_name,
-            column_names.join(", "),
-            placeholder_names.join(", "),
-        ),
-        Span::call_site(),
-    );
-    let update_sql = LitStr::new(
-        &format!(
-            "update {} set {} where {} = {}",
-            table_name,
-            update_assignments.join(", "),
-            primary_key_column,
-            primary_key_placeholder,
-        ),
-        Span::call_site(),
-    );
-    let delete_sql = LitStr::new(
-        &format!(
-            "delete from {} where {} = {}",
-            table_name, primary_key_column, primary_key_placeholder,
-        ),
-        Span::call_site(),
-    );
-    let find_sql = LitStr::new(
-        &format!(
-            "select {} from {} where {} = {}",
-            column_names.join(", "),
-            table_name,
-            primary_key_column,
-            primary_key_placeholder,
-        ),
-        Span::call_site(),
-    );
-    let analyze_sql = LitStr::new(&format!("analyze table {}", table_name), Span::call_site());
+    let _primary_key_column = primary_key_column.expect("primary key checked above");
+    let _primary_key_placeholder = primary_key_placeholder.expect("primary key checked above");
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     Ok(quote! {
@@ -519,59 +449,76 @@ pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
 
             fn select_statement() -> &'static ::kite_sql::db::Statement {
                 static SELECT_STATEMENT: ::std::sync::LazyLock<::kite_sql::db::Statement> = ::std::sync::LazyLock::new(|| {
-                    ::kite_sql::db::prepare(#select_sql).expect("failed to prepare ORM select statement")
+                    ::kite_sql::orm::orm_select_statement(
+                        #table_name_lit,
+                        <#struct_name #ty_generics as ::kite_sql::orm::Model>::fields(),
+                    )
                 });
                 &SELECT_STATEMENT
             }
 
             fn insert_statement() -> &'static ::kite_sql::db::Statement {
                 static INSERT_STATEMENT: ::std::sync::LazyLock<::kite_sql::db::Statement> = ::std::sync::LazyLock::new(|| {
-                    ::kite_sql::db::prepare(#insert_sql).expect("failed to prepare ORM insert statement")
+                    ::kite_sql::orm::orm_insert_statement(
+                        #table_name_lit,
+                        <#struct_name #ty_generics as ::kite_sql::orm::Model>::fields(),
+                    )
                 });
                 &INSERT_STATEMENT
             }
 
             fn update_statement() -> &'static ::kite_sql::db::Statement {
                 static UPDATE_STATEMENT: ::std::sync::LazyLock<::kite_sql::db::Statement> = ::std::sync::LazyLock::new(|| {
-                    ::kite_sql::db::prepare(#update_sql).expect("failed to prepare ORM update statement")
+                    ::kite_sql::orm::orm_update_statement(
+                        #table_name_lit,
+                        <#struct_name #ty_generics as ::kite_sql::orm::Model>::fields(),
+                        <#struct_name #ty_generics as ::kite_sql::orm::Model>::primary_key_field(),
+                    )
                 });
                 &UPDATE_STATEMENT
             }
 
             fn delete_statement() -> &'static ::kite_sql::db::Statement {
                 static DELETE_STATEMENT: ::std::sync::LazyLock<::kite_sql::db::Statement> = ::std::sync::LazyLock::new(|| {
-                    ::kite_sql::db::prepare(#delete_sql).expect("failed to prepare ORM delete statement")
+                    ::kite_sql::orm::orm_delete_statement(
+                        #table_name_lit,
+                        <#struct_name #ty_generics as ::kite_sql::orm::Model>::primary_key_field(),
+                    )
                 });
                 &DELETE_STATEMENT
             }
 
             fn find_statement() -> &'static ::kite_sql::db::Statement {
                 static FIND_STATEMENT: ::std::sync::LazyLock<::kite_sql::db::Statement> = ::std::sync::LazyLock::new(|| {
-                    ::kite_sql::db::prepare(#find_sql).expect("failed to prepare ORM find statement")
+                    ::kite_sql::orm::orm_find_statement(
+                        #table_name_lit,
+                        <#struct_name #ty_generics as ::kite_sql::orm::Model>::fields(),
+                        <#struct_name #ty_generics as ::kite_sql::orm::Model>::primary_key_field(),
+                    )
                 });
                 &FIND_STATEMENT
             }
 
             fn create_table_statement() -> &'static ::kite_sql::db::Statement {
                 static CREATE_TABLE_STATEMENT: ::std::sync::LazyLock<::kite_sql::db::Statement> = ::std::sync::LazyLock::new(|| {
-                    let sql = ::std::format!(
-                        "create table {} ({})",
+                    ::kite_sql::orm::orm_create_table_statement(
                         #table_name_lit,
-                        vec![#(#ddl_columns),*].join(", ")
-                    );
-                    ::kite_sql::db::prepare(&sql).expect("failed to prepare ORM create table statement")
+                        <#struct_name #ty_generics as ::kite_sql::orm::Model>::columns(),
+                        false,
+                    )
+                        .expect("failed to build ORM create table statement")
                 });
                 &CREATE_TABLE_STATEMENT
             }
 
             fn create_table_if_not_exists_statement() -> &'static ::kite_sql::db::Statement {
                 static CREATE_TABLE_IF_NOT_EXISTS_STATEMENT: ::std::sync::LazyLock<::kite_sql::db::Statement> = ::std::sync::LazyLock::new(|| {
-                    let sql = ::std::format!(
-                        "create table if not exists {} ({})",
+                    ::kite_sql::orm::orm_create_table_statement(
                         #table_name_lit,
-                        vec![#(#ddl_columns),*].join(", ")
-                    );
-                    ::kite_sql::db::prepare(&sql).expect("failed to prepare ORM create table if not exists statement")
+                        <#struct_name #ty_generics as ::kite_sql::orm::Model>::columns(),
+                        true,
+                    )
+                        .expect("failed to build ORM create table if not exists statement")
                 });
                 &CREATE_TABLE_IF_NOT_EXISTS_STATEMENT
             }
@@ -579,10 +526,7 @@ pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
             fn create_index_statements() -> &'static [::kite_sql::db::Statement] {
                 static CREATE_INDEX_STATEMENTS: ::std::sync::LazyLock<::std::vec::Vec<::kite_sql::db::Statement>> = ::std::sync::LazyLock::new(|| {
                     vec![
-                        #(
-                            ::kite_sql::db::prepare(#create_index_sqls)
-                                .expect("failed to prepare ORM create index statement")
-                        ),*
+                        #(#create_index_statements),*
                     ]
                 });
                 CREATE_INDEX_STATEMENTS.as_slice()
@@ -591,10 +535,7 @@ pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
             fn create_index_if_not_exists_statements() -> &'static [::kite_sql::db::Statement] {
                 static CREATE_INDEX_IF_NOT_EXISTS_STATEMENTS: ::std::sync::LazyLock<::std::vec::Vec<::kite_sql::db::Statement>> = ::std::sync::LazyLock::new(|| {
                     vec![
-                        #(
-                            ::kite_sql::db::prepare(#create_index_if_not_exists_sqls)
-                                .expect("failed to prepare ORM create index if not exists statement")
-                        ),*
+                        #(#create_index_if_not_exists_statements),*
                     ]
                 });
                 CREATE_INDEX_IF_NOT_EXISTS_STATEMENTS.as_slice()
@@ -602,23 +543,21 @@ pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
 
             fn drop_table_statement() -> &'static ::kite_sql::db::Statement {
                 static DROP_TABLE_STATEMENT: ::std::sync::LazyLock<::kite_sql::db::Statement> = ::std::sync::LazyLock::new(|| {
-                    let sql = ::std::format!("drop table {}", #table_name_lit);
-                    ::kite_sql::db::prepare(&sql).expect("failed to prepare ORM drop table statement")
+                    ::kite_sql::orm::orm_drop_table_statement(#table_name_lit, false)
                 });
                 &DROP_TABLE_STATEMENT
             }
 
             fn drop_table_if_exists_statement() -> &'static ::kite_sql::db::Statement {
                 static DROP_TABLE_IF_EXISTS_STATEMENT: ::std::sync::LazyLock<::kite_sql::db::Statement> = ::std::sync::LazyLock::new(|| {
-                    let sql = ::std::format!("drop table if exists {}", #table_name_lit);
-                    ::kite_sql::db::prepare(&sql).expect("failed to prepare ORM drop table if exists statement")
+                    ::kite_sql::orm::orm_drop_table_statement(#table_name_lit, true)
                 });
                 &DROP_TABLE_IF_EXISTS_STATEMENT
             }
 
             fn analyze_statement() -> &'static ::kite_sql::db::Statement {
                 static ANALYZE_STATEMENT: ::std::sync::LazyLock<::kite_sql::db::Statement> = ::std::sync::LazyLock::new(|| {
-                    ::kite_sql::db::prepare(#analyze_sql).expect("failed to prepare ORM analyze statement")
+                    ::kite_sql::orm::orm_analyze_statement(#table_name_lit)
                 });
                 &ANALYZE_STATEMENT
             }

--- a/kite_sql_serde_macros/src/projection.rs
+++ b/kite_sql_serde_macros/src/projection.rs
@@ -56,11 +56,11 @@ pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
 
         projected_values.push(if rename.is_some() {
             quote! {
-                ::kite_sql::orm::projection_value::<M>(#source_name_lit, #field_name_lit)
+                ::kite_sql::orm::projection_value(#source_name_lit, relation, #field_name_lit)
             }
         } else {
             quote! {
-                ::kite_sql::orm::projection_column::<M>(#source_name_lit)
+                ::kite_sql::orm::projection_column(#source_name_lit, relation)
             }
         });
         assignments.push(quote! {
@@ -76,7 +76,7 @@ pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
         impl #impl_generics ::kite_sql::orm::Projection for #struct_name #ty_generics
         #where_clause
         {
-            fn projected_values<M: ::kite_sql::orm::Model>() -> ::std::vec::Vec<::kite_sql::orm::ProjectedValue> {
+            fn projected_values<M: ::kite_sql::orm::Model>(relation: &str) -> ::std::vec::Vec<::kite_sql::orm::ProjectedValue> {
                 vec![#(#projected_values),*]
             }
         }

--- a/kite_sql_serde_macros/src/projection.rs
+++ b/kite_sql_serde_macros/src/projection.rs
@@ -1,0 +1,94 @@
+use darling::ast::Data;
+use darling::{FromDeriveInput, FromField};
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{parse_quote, DeriveInput, Error, Generics, Ident, LitStr, Type};
+
+#[derive(Debug, FromDeriveInput)]
+#[darling(attributes(projection), supports(struct_named))]
+struct ProjectionOpts {
+    ident: Ident,
+    generics: Generics,
+    data: Data<(), ProjectionFieldOpts>,
+}
+
+#[derive(Debug, FromField)]
+#[darling(attributes(projection))]
+struct ProjectionFieldOpts {
+    ident: Option<Ident>,
+    ty: Type,
+    rename: Option<String>,
+}
+
+pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
+    let projection_opts = ProjectionOpts::from_derive_input(&ast)?;
+    let struct_name = &projection_opts.ident;
+    let mut generics = projection_opts.generics.clone();
+
+    let Data::Struct(data_struct) = projection_opts.data else {
+        return Err(Error::new_spanned(
+            struct_name,
+            "Projection only supports structs with named fields",
+        ));
+    };
+
+    let mut projected_values = Vec::new();
+    let mut assignments = Vec::new();
+
+    for field in data_struct.fields {
+        let ProjectionFieldOpts {
+            ident,
+            ty: field_ty,
+            rename,
+        } = field;
+        let field_name = ident.ok_or_else(|| {
+            Error::new_spanned(struct_name, "Projection only supports named struct fields")
+        })?;
+        let field_name_string = field_name.to_string();
+        let source_name = rename.clone().unwrap_or_else(|| field_name_string.clone());
+        let source_name_lit = LitStr::new(&source_name, Span::call_site());
+        let field_name_lit = LitStr::new(&field_name_string, Span::call_site());
+
+        generics
+            .make_where_clause()
+            .predicates
+            .push(parse_quote!(#field_ty : ::kite_sql::orm::FromDataValue));
+
+        projected_values.push(if rename.is_some() {
+            quote! {
+                ::kite_sql::orm::projection_value::<M>(#source_name_lit, #field_name_lit)
+            }
+        } else {
+            quote! {
+                ::kite_sql::orm::projection_column::<M>(#source_name_lit)
+            }
+        });
+        assignments.push(quote! {
+            if let Some(value) = ::kite_sql::orm::try_get::<#field_ty>(&mut tuple, schema, #field_name_lit) {
+                struct_instance.#field_name = value;
+            }
+        });
+    }
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    Ok(quote! {
+        impl #impl_generics ::kite_sql::orm::Projection for #struct_name #ty_generics
+        #where_clause
+        {
+            fn projected_values<M: ::kite_sql::orm::Model>() -> ::std::vec::Vec<::kite_sql::orm::ProjectedValue> {
+                vec![#(#projected_values),*]
+            }
+        }
+
+        impl #impl_generics From<(&::kite_sql::types::tuple::SchemaRef, ::kite_sql::types::tuple::Tuple)> for #struct_name #ty_generics
+        #where_clause
+        {
+            fn from((schema, mut tuple): (&::kite_sql::types::tuple::SchemaRef, ::kite_sql::types::tuple::Tuple)) -> Self {
+                let mut struct_instance = <Self as ::std::default::Default>::default();
+                #(#assignments)*
+                struct_instance
+            }
+        }
+    })
+}

--- a/kite_sql_serde_macros/src/projection.rs
+++ b/kite_sql_serde_macros/src/projection.rs
@@ -18,6 +18,7 @@ struct ProjectionFieldOpts {
     ident: Option<Ident>,
     ty: Type,
     rename: Option<String>,
+    from: Option<String>,
 }
 
 pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
@@ -40,6 +41,7 @@ pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
             ident,
             ty: field_ty,
             rename,
+            from,
         } = field;
         let field_name = ident.ok_or_else(|| {
             Error::new_spanned(struct_name, "Projection only supports named struct fields")
@@ -48,6 +50,12 @@ pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
         let source_name = rename.clone().unwrap_or_else(|| field_name_string.clone());
         let source_name_lit = LitStr::new(&source_name, Span::call_site());
         let field_name_lit = LitStr::new(&field_name_string, Span::call_site());
+        let relation_expr = if let Some(source_relation) = from {
+            let relation_lit = LitStr::new(&source_relation, Span::call_site());
+            quote!(#relation_lit)
+        } else {
+            quote!(relation)
+        };
 
         generics
             .make_where_clause()
@@ -56,11 +64,11 @@ pub(crate) fn handle(ast: DeriveInput) -> Result<TokenStream, Error> {
 
         projected_values.push(if rename.is_some() {
             quote! {
-                ::kite_sql::orm::projection_value(#source_name_lit, relation, #field_name_lit)
+                ::kite_sql::orm::projection_value(#source_name_lit, #relation_expr, #field_name_lit)
             }
         } else {
             quote! {
-                ::kite_sql::orm::projection_column(#source_name_lit, relation)
+                ::kite_sql::orm::projection_column(#source_name_lit, #relation_expr)
             }
         });
         assignments.push(quote! {

--- a/src/binder/expr.rs
+++ b/src/binder/expr.rs
@@ -197,24 +197,30 @@ impl<'a, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'a, '_, T
                 })
             }
             Expr::Exists { subquery, negated } => {
-                let (sub_query, column) = self.bind_subquery(None, subquery)?;
+                let (sub_query, column, correlated) = self.bind_subquery(None, subquery)?;
                 let (_, sub_query) = if !self.context.is_step(&QueryBindStep::Where) {
                     self.bind_temp_table(column, sub_query)?
                 } else {
                     (column, sub_query)
                 };
-                self.context
-                    .sub_query(SubQueryType::ExistsSubQuery(*negated, sub_query));
+                self.context.sub_query(SubQueryType::ExistsSubQuery {
+                    negated: *negated,
+                    plan: sub_query,
+                    correlated,
+                });
                 Ok(ScalarExpression::Constant(DataValue::Boolean(true)))
             }
             Expr::Subquery(subquery) => {
-                let (sub_query, column) = self.bind_subquery(None, subquery)?;
+                let (sub_query, column, correlated) = self.bind_subquery(None, subquery)?;
                 let (expr, sub_query) = if !self.context.is_step(&QueryBindStep::Where) {
                     self.bind_temp_table(column, sub_query)?
                 } else {
                     (column, sub_query)
                 };
-                self.context.sub_query(SubQueryType::SubQuery(sub_query));
+                self.context.sub_query(SubQueryType::SubQuery {
+                    plan: sub_query,
+                    correlated,
+                });
                 Ok(expr)
             }
             Expr::InSubquery {
@@ -223,7 +229,7 @@ impl<'a, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'a, '_, T
                 negated,
             } => {
                 let left_expr = Box::new(self.bind_expr(expr)?);
-                let (sub_query, column) =
+                let (sub_query, column, correlated) =
                     self.bind_subquery(Some(left_expr.return_type()), subquery)?;
 
                 if !self.context.is_step(&QueryBindStep::Where) {
@@ -233,8 +239,11 @@ impl<'a, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'a, '_, T
                 }
 
                 let (alias_expr, sub_query) = self.bind_temp_table(column, sub_query)?;
-                self.context
-                    .sub_query(SubQueryType::InSubQuery(*negated, sub_query));
+                self.context.sub_query(SubQueryType::InSubQuery {
+                    negated: *negated,
+                    plan: sub_query,
+                    correlated,
+                });
 
                 Ok(ScalarExpression::Binary {
                     op: expression::BinaryOperator::Eq,
@@ -325,7 +334,7 @@ impl<'a, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'a, '_, T
         &mut self,
         in_ty: Option<LogicalType>,
         subquery: &Query,
-    ) -> Result<(LogicalPlan, ScalarExpression), DatabaseError> {
+    ) -> Result<(LogicalPlan, ScalarExpression, bool), DatabaseError> {
         let BinderContext {
             table_cache,
             view_cache,
@@ -348,6 +357,7 @@ impl<'a, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'a, '_, T
             Some(self),
         );
         let mut sub_query = binder.bind_query(subquery)?;
+        let correlated = binder.context.has_outer_refs();
         let sub_query_schema = sub_query.output_schema();
 
         let fn_check = |len: usize| {
@@ -373,7 +383,7 @@ impl<'a, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'a, '_, T
 
             ScalarExpression::column_expr(sub_query_schema[0].clone())
         };
-        Ok((sub_query, expr))
+        Ok((sub_query, expr, correlated))
     }
 
     pub fn bind_like(
@@ -426,13 +436,27 @@ impl<'a, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'a, '_, T
             try_default!(&full_name.0, full_name.1);
         }
         if let Some(table) = full_name.0.or(bind_table_name) {
-            let source = self.context.bind_source(&table).map_err(|err| {
-                if let [table_ident, _] = idents {
-                    attach_span_from_sqlparser_span_if_absent(err, table_ident.span)
-                } else {
-                    err
+            let source = match self.context.bind_source(&table) {
+                Ok(source) => source,
+                Err(err) => {
+                    if let Some(parent) = self.parent {
+                        self.context.mark_outer_ref();
+                        parent.context.bind_source(&table).map_err(|_| {
+                            if let [table_ident, _] = idents {
+                                attach_span_from_sqlparser_span_if_absent(err, table_ident.span)
+                            } else {
+                                err
+                            }
+                        })?
+                    } else {
+                        return Err(if let [table_ident, _] = idents {
+                            attach_span_from_sqlparser_span_if_absent(err, table_ident.span)
+                        } else {
+                            err
+                        });
+                    }
                 }
-            })?;
+            };
             let schema_buf = self.table_schema_buf.entry(table.into()).or_default();
 
             Ok(ScalarExpression::column_expr(
@@ -454,7 +478,7 @@ impl<'a, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'a, '_, T
                             break;
                         }
                         if let Some(alias) = alias {
-                            *got_column = self.context.expr_aliases.iter().find_map(
+                            *got_column = context.expr_aliases.iter().find_map(
                                 |((alias_table, alias_column), expr)| {
                                     matches!(
                                         alias_table
@@ -479,8 +503,11 @@ impl<'a, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'a, '_, T
             let mut got_column = None;
 
             op(&mut got_column, &self.context, &mut self.table_schema_buf);
-            if let Some(parent) = self.parent {
-                op(&mut got_column, &parent.context, &mut self.table_schema_buf);
+            if got_column.is_none() {
+                if let Some(parent) = self.parent {
+                    self.context.mark_outer_ref();
+                    op(&mut got_column, &parent.context, &mut self.table_schema_buf);
+                }
             }
             match got_column {
                 Some(column) => Ok(column),

--- a/src/binder/insert.rs
+++ b/src/binder/insert.rs
@@ -16,6 +16,7 @@ use crate::binder::{attach_span_if_absent, lower_case_name, Binder};
 use crate::errors::DatabaseError;
 use crate::expression::simplify::ConstantCalculator;
 use crate::expression::visitor_mut::VisitorMut;
+use crate::expression::AliasType;
 use crate::expression::ScalarExpression;
 use crate::planner::operator::insert::InsertOperator;
 use crate::planner::operator::values::ValuesOperator;
@@ -24,7 +25,7 @@ use crate::planner::{Childrens, LogicalPlan};
 use crate::storage::Transaction;
 use crate::types::tuple::SchemaRef;
 use crate::types::value::DataValue;
-use sqlparser::ast::{Expr, Ident, ObjectName};
+use sqlparser::ast::{Expr, Ident, ObjectName, Query};
 use std::slice;
 use std::sync::Arc;
 
@@ -132,6 +133,74 @@ impl<T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'_, '_, T, A>
                 is_mapping_by_name,
             }),
             Childrens::Only(Box::new(values_plan)),
+        ))
+    }
+
+    pub(crate) fn bind_insert_query(
+        &mut self,
+        name: &ObjectName,
+        idents: &[Ident],
+        query: &Query,
+        is_overwrite: bool,
+    ) -> Result<LogicalPlan, DatabaseError> {
+        let table_name: Arc<str> = lower_case_name(name)?.into();
+        let source = self
+            .context
+            .source_and_bind(table_name.clone(), None, None, false)?
+            .ok_or(DatabaseError::TableNotFound)?;
+        let mut schema_buf = None;
+        let table_schema = source.schema_ref(&mut schema_buf);
+
+        let mut input_plan = self.bind_query(query)?;
+        let input_schema = input_plan.output_schema().clone();
+        let input_len = input_schema.len();
+
+        let target_columns = if idents.is_empty() {
+            if input_len > table_schema.len() {
+                return Err(DatabaseError::ValuesLenMismatch(
+                    table_schema.len(),
+                    input_len,
+                ));
+            }
+            table_schema
+                .iter()
+                .take(input_len)
+                .cloned()
+                .collect::<Vec<_>>()
+        } else {
+            let mut columns = Vec::with_capacity(idents.len());
+            for ident in idents {
+                match self.bind_column_ref_from_identifiers(
+                    slice::from_ref(ident),
+                    Some(table_name.to_string()),
+                )? {
+                    ScalarExpression::ColumnRef { column, .. } => columns.push(column),
+                    _ => return Err(DatabaseError::UnsupportedStmt(ident.to_string())),
+                }
+            }
+            if input_len != columns.len() {
+                return Err(DatabaseError::ValuesLenMismatch(columns.len(), input_len));
+            }
+            columns
+        };
+
+        let projection = input_schema
+            .iter()
+            .zip(target_columns.iter())
+            .map(|(input_column, target_column)| ScalarExpression::Alias {
+                expr: Box::new(ScalarExpression::column_expr(input_column.clone())),
+                alias: AliasType::Name(target_column.name().to_string()),
+            })
+            .collect::<Vec<_>>();
+        input_plan = self.bind_project(input_plan, projection)?;
+
+        Ok(LogicalPlan::new(
+            Operator::Insert(InsertOperator {
+                table_name,
+                is_overwrite,
+                is_mapping_by_name: true,
+            }),
+            Childrens::Only(Box::new(input_plan)),
         ))
     }
 

--- a/src/binder/mod.rs
+++ b/src/binder/mod.rs
@@ -497,20 +497,20 @@ impl<'a, 'b, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'a, '
                         "insert without source is not supported".to_string(),
                     )
                 })?;
-                // TODO: support body on Insert
-                if let SetExpr::Values(values) = source.body.as_ref() {
-                    self.bind_insert(
+                match source.body.as_ref() {
+                    SetExpr::Values(values) => self.bind_insert(
                         table_name,
                         &insert.columns,
                         &values.rows,
                         insert.overwrite,
                         false,
-                    )?
-                } else {
-                    return Err(DatabaseError::UnsupportedStmt(format!(
-                        "insert body: {:#?}",
-                        source.body
-                    )));
+                    )?,
+                    _ => self.bind_insert_query(
+                        table_name,
+                        &insert.columns,
+                        source,
+                        insert.overwrite,
+                    )?,
                 }
             }
             Statement::Update(update) => {

--- a/src/binder/mod.rs
+++ b/src/binder/mod.rs
@@ -147,9 +147,20 @@ pub enum QueryBindStep {
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub enum SubQueryType {
-    SubQuery(LogicalPlan),
-    ExistsSubQuery(bool, LogicalPlan),
-    InSubQuery(bool, LogicalPlan),
+    SubQuery {
+        plan: LogicalPlan,
+        correlated: bool,
+    },
+    ExistsSubQuery {
+        negated: bool,
+        plan: LogicalPlan,
+        correlated: bool,
+    },
+    InSubQuery {
+        negated: bool,
+        plan: LogicalPlan,
+        correlated: bool,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -178,6 +189,7 @@ pub struct BinderContext<'a, T: Transaction> {
 
     bind_step: QueryBindStep,
     sub_queries: HashMap<QueryBindStep, Vec<SubQueryType>>,
+    has_outer_refs: bool,
 
     temp_table_id: Arc<AtomicUsize>,
     pub(crate) allow_default: bool,
@@ -249,6 +261,7 @@ impl<'a, T: Transaction> BinderContext<'a, T> {
             using: Default::default(),
             bind_step: QueryBindStep::From,
             sub_queries: Default::default(),
+            has_outer_refs: false,
             temp_table_id,
             allow_default: false,
         }
@@ -283,6 +296,14 @@ impl<'a, T: Transaction> BinderContext<'a, T> {
 
     pub fn sub_queries_at_now(&mut self) -> Option<Vec<SubQueryType>> {
         self.sub_queries.remove(&self.bind_step)
+    }
+
+    pub fn mark_outer_ref(&mut self) {
+        self.has_outer_refs = true;
+    }
+
+    pub fn has_outer_refs(&self) -> bool {
+        self.has_outer_refs
     }
 
     pub fn table(&self, table_name: TableName) -> Result<Option<&TableCatalog>, DatabaseError> {

--- a/src/binder/select.rs
+++ b/src/binder/select.rs
@@ -864,60 +864,21 @@ impl<'a: 'b, 'b, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'
                 let mut filter = vec![];
 
                 let (mut plan, join_ty) = match sub_query {
-                    SubQueryType::SubQuery(plan) => (plan, JoinType::Inner),
-                    SubQueryType::ExistsSubQuery(is_not, plan) => {
-                        let limit = LimitOperator::build(None, Some(1), plan);
-                        let mut agg = AggregateOperator::build(
-                            limit,
-                            vec![ScalarExpression::AggCall {
-                                distinct: false,
-                                kind: AggKind::Count,
-                                args: vec![ScalarExpression::Constant(DataValue::Utf8 {
-                                    value: "*".to_string(),
-                                    ty: Utf8Type::Fixed(1),
-                                    unit: CharLengthUnits::Characters,
-                                })],
-                                ty: LogicalType::Integer,
-                            }],
-                            vec![],
-                            false,
-                        );
-                        let filter = FilterOperator::build(
-                            ScalarExpression::Binary {
-                                op: if is_not {
-                                    BinaryOperator::NotEq
-                                } else {
-                                    BinaryOperator::Eq
-                                },
-                                left_expr: Box::new(ScalarExpression::column_expr(
-                                    agg.output_schema()[0].clone(),
-                                )),
-                                right_expr: Box::new(ScalarExpression::Constant(DataValue::Int32(
-                                    1,
-                                ))),
-                                evaluator: None,
-                                ty: LogicalType::Boolean,
-                            },
-                            agg,
-                            false,
-                        );
-                        let projection = ProjectOperator {
-                            exprs: vec![ScalarExpression::Constant(DataValue::Int32(1))],
+                    SubQueryType::SubQuery { plan, .. } => (plan, JoinType::Inner),
+                    SubQueryType::ExistsSubQuery {
+                        negated,
+                        plan,
+                        correlated,
+                    } => {
+                        children = if correlated {
+                            Self::bind_correlated_exists(children, plan, negated)?
+                        } else {
+                            Self::bind_uncorrelated_exists(children, plan, negated)
                         };
-                        let plan = LogicalPlan::new(
-                            Operator::Project(projection),
-                            Childrens::Only(Box::new(filter)),
-                        );
-                        children = LJoinOperator::build(
-                            children,
-                            plan,
-                            JoinCondition::None,
-                            JoinType::Cross,
-                        );
                         continue;
                     }
-                    SubQueryType::InSubQuery(is_not, plan) => {
-                        let join_ty = if is_not {
+                    SubQueryType::InSubQuery { negated, plan, .. } => {
+                        let join_ty = if negated {
                             JoinType::LeftAnti
                         } else {
                             JoinType::LeftSemi
@@ -935,15 +896,7 @@ impl<'a: 'b, 'b, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'
                 )?;
 
                 // combine multiple filter exprs into one BinaryExpr
-                let join_filter = filter
-                    .into_iter()
-                    .reduce(|acc, expr| ScalarExpression::Binary {
-                        op: BinaryOperator::And,
-                        left_expr: Box::new(acc),
-                        right_expr: Box::new(expr),
-                        evaluator: None,
-                        ty: LogicalType::Boolean,
-                    });
+                let join_filter = Self::combine_conjuncts(filter);
 
                 children = LJoinOperator::build(
                     children,
@@ -958,6 +911,224 @@ impl<'a: 'b, 'b, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'
             return Ok(children);
         }
         Ok(FilterOperator::build(predicate, children, false))
+    }
+
+    fn bind_correlated_exists(
+        mut children: LogicalPlan,
+        plan: LogicalPlan,
+        negated: bool,
+    ) -> Result<LogicalPlan, DatabaseError> {
+        let mut on_keys: Vec<(ScalarExpression, ScalarExpression)> = vec![];
+        let mut filter = vec![];
+        let join_ty = if negated {
+            JoinType::LeftAnti
+        } else {
+            JoinType::LeftSemi
+        };
+        let (mut plan, correlated_filters) =
+            Self::prepare_correlated_exists_plan(plan, children.output_schema())?;
+
+        for expr in correlated_filters {
+            Self::extract_join_keys(
+                expr,
+                &mut on_keys,
+                &mut filter,
+                children.output_schema(),
+                plan.output_schema(),
+            )?;
+        }
+
+        children = LJoinOperator::build(
+            children,
+            plan,
+            JoinCondition::On {
+                on: on_keys,
+                filter: Self::combine_conjuncts(filter),
+            },
+            join_ty,
+        );
+        Ok(children)
+    }
+
+    fn bind_uncorrelated_exists(
+        children: LogicalPlan,
+        plan: LogicalPlan,
+        negated: bool,
+    ) -> LogicalPlan {
+        let limit = LimitOperator::build(None, Some(1), plan);
+        let mut agg = AggregateOperator::build(
+            limit,
+            vec![ScalarExpression::AggCall {
+                distinct: false,
+                kind: AggKind::Count,
+                args: vec![ScalarExpression::Constant(DataValue::Utf8 {
+                    value: "*".to_string(),
+                    ty: Utf8Type::Fixed(1),
+                    unit: CharLengthUnits::Characters,
+                })],
+                ty: LogicalType::Integer,
+            }],
+            vec![],
+            false,
+        );
+        let filter = FilterOperator::build(
+            ScalarExpression::Binary {
+                op: if negated {
+                    BinaryOperator::NotEq
+                } else {
+                    BinaryOperator::Eq
+                },
+                left_expr: Box::new(ScalarExpression::column_expr(
+                    agg.output_schema()[0].clone(),
+                )),
+                right_expr: Box::new(ScalarExpression::Constant(DataValue::Int32(1))),
+                evaluator: None,
+                ty: LogicalType::Boolean,
+            },
+            agg,
+            false,
+        );
+        let projection = ProjectOperator {
+            exprs: vec![ScalarExpression::Constant(DataValue::Int32(1))],
+        };
+        let plan = LogicalPlan::new(
+            Operator::Project(projection),
+            Childrens::Only(Box::new(filter)),
+        );
+
+        LJoinOperator::build(children, plan, JoinCondition::None, JoinType::Cross)
+    }
+
+    fn plan_has_correlated_refs(plan: &LogicalPlan, left_schema: &Schema) -> bool {
+        let contains = |column: &ColumnRef| {
+            left_schema
+                .iter()
+                .any(|left| left.summary() == column.summary())
+        };
+
+        if plan.operator.referenced_columns(true).iter().any(contains) {
+            return true;
+        }
+
+        match plan.childrens.as_ref() {
+            Childrens::Only(child) => Self::plan_has_correlated_refs(child, left_schema),
+            Childrens::Twins { left, right } => {
+                Self::plan_has_correlated_refs(left, left_schema)
+                    || Self::plan_has_correlated_refs(right, left_schema)
+            }
+            Childrens::None => false,
+        }
+    }
+
+    fn expr_has_correlated_refs(expr: &ScalarExpression, left_schema: &Schema) -> bool {
+        expr.referenced_columns(true).iter().any(|column| {
+            left_schema
+                .iter()
+                .any(|left| left.summary() == column.summary())
+        })
+    }
+
+    fn split_conjuncts(expr: ScalarExpression, exprs: &mut Vec<ScalarExpression>) {
+        match expr.unpack_alias() {
+            ScalarExpression::Binary {
+                op: BinaryOperator::And,
+                left_expr,
+                right_expr,
+                ..
+            } => {
+                Self::split_conjuncts(*left_expr, exprs);
+                Self::split_conjuncts(*right_expr, exprs);
+            }
+            expr => exprs.push(expr),
+        }
+    }
+
+    fn combine_conjuncts(exprs: Vec<ScalarExpression>) -> Option<ScalarExpression> {
+        exprs
+            .into_iter()
+            .reduce(|acc, expr| ScalarExpression::Binary {
+                op: BinaryOperator::And,
+                left_expr: Box::new(acc),
+                right_expr: Box::new(expr),
+                evaluator: None,
+                ty: LogicalType::Boolean,
+            })
+    }
+
+    fn prepare_correlated_exists_plan(
+        plan: LogicalPlan,
+        left_schema: &Schema,
+    ) -> Result<(LogicalPlan, Vec<ScalarExpression>), DatabaseError> {
+        match plan.childrens.as_ref() {
+            Childrens::Only(_) => {}
+            Childrens::Twins { .. } => {
+                if Self::plan_has_correlated_refs(&plan, left_schema) {
+                    return Err(DatabaseError::UnsupportedStmt(
+                        "correlated EXISTS/NOT EXISTS does not support set or join subqueries"
+                            .to_string(),
+                    ));
+                }
+            }
+            Childrens::None => {}
+        }
+
+        match plan {
+            LogicalPlan {
+                operator: Operator::Filter(op),
+                childrens,
+                ..
+            } => {
+                let child = childrens.pop_only();
+                let (child, mut correlated_filters) =
+                    Self::prepare_correlated_exists_plan(child, left_schema)?;
+                let mut local_filters = Vec::new();
+                let mut predicates = Vec::new();
+                Self::split_conjuncts(op.predicate, &mut predicates);
+                for predicate in predicates {
+                    if Self::expr_has_correlated_refs(&predicate, left_schema) {
+                        correlated_filters.push(predicate);
+                    } else {
+                        local_filters.push(predicate);
+                    }
+                }
+                let plan = if let Some(predicate) = Self::combine_conjuncts(local_filters) {
+                    FilterOperator::build(predicate, child, op.having)
+                } else {
+                    child
+                };
+                Ok((plan, correlated_filters))
+            }
+            LogicalPlan {
+                operator: Operator::Project(_),
+                childrens,
+                ..
+            }
+            | LogicalPlan {
+                operator: Operator::Sort(_),
+                childrens,
+                ..
+            }
+            | LogicalPlan {
+                operator: Operator::Limit(_),
+                childrens,
+                ..
+            }
+            | LogicalPlan {
+                operator: Operator::TopK(_),
+                childrens,
+                ..
+            } => Self::prepare_correlated_exists_plan(childrens.pop_only(), left_schema),
+            plan => {
+                if Self::plan_has_correlated_refs(&plan, left_schema) {
+                    Err(DatabaseError::UnsupportedStmt(
+                        "correlated EXISTS/NOT EXISTS only supports filter-based subqueries"
+                            .to_string(),
+                    ))
+                } else {
+                    Ok((plan, vec![]))
+                }
+            }
+        }
     }
 
     fn bind_having(

--- a/src/binder/select.rs
+++ b/src/binder/select.rs
@@ -877,7 +877,20 @@ impl<'a: 'b, 'b, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'
                         };
                         continue;
                     }
-                    SubQueryType::InSubQuery { negated, plan, .. } => {
+                    SubQueryType::InSubQuery {
+                        negated,
+                        plan,
+                        correlated,
+                    } => {
+                        if correlated {
+                            children = Self::bind_correlated_in_subquery(
+                                children,
+                                plan,
+                                negated,
+                                predicate.clone(),
+                            )?;
+                            continue;
+                        }
                         let join_ty = if negated {
                             JoinType::LeftAnti
                         } else {
@@ -997,6 +1010,80 @@ impl<'a: 'b, 'b, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'
         );
 
         LJoinOperator::build(children, plan, JoinCondition::None, JoinType::Cross)
+    }
+
+    fn bind_correlated_in_subquery(
+        mut children: LogicalPlan,
+        plan: LogicalPlan,
+        negated: bool,
+        predicate: ScalarExpression,
+    ) -> Result<LogicalPlan, DatabaseError> {
+        let mut on_keys: Vec<(ScalarExpression, ScalarExpression)> = vec![];
+        let mut filter = vec![];
+        let join_ty = if negated {
+            JoinType::LeftAnti
+        } else {
+            JoinType::LeftSemi
+        };
+        let (mut plan, correlated_filters) =
+            Self::prepare_correlated_exists_plan(plan, children.output_schema())?;
+        let predicate = Self::rewrite_correlated_in_predicate(predicate);
+
+        Self::extract_join_keys(
+            predicate,
+            &mut on_keys,
+            &mut filter,
+            children.output_schema(),
+            plan.output_schema(),
+        )?;
+
+        for expr in correlated_filters {
+            Self::extract_join_keys(
+                expr,
+                &mut on_keys,
+                &mut filter,
+                children.output_schema(),
+                plan.output_schema(),
+            )?;
+        }
+
+        children = LJoinOperator::build(
+            children,
+            plan,
+            JoinCondition::On {
+                on: on_keys,
+                filter: Self::combine_conjuncts(filter),
+            },
+            join_ty,
+        );
+        Ok(children)
+    }
+
+    fn rewrite_correlated_in_predicate(predicate: ScalarExpression) -> ScalarExpression {
+        let strip_projection_alias = |expr: Box<ScalarExpression>| match *expr {
+            ScalarExpression::Alias {
+                expr,
+                alias: AliasType::Expr(_),
+            } => expr,
+            expr => Box::new(expr),
+        };
+
+        match predicate {
+            ScalarExpression::Binary {
+                op,
+                left_expr,
+                right_expr,
+                ty,
+                ..
+            } if op == BinaryOperator::Eq => ScalarExpression::Binary {
+                op,
+                left_expr: strip_projection_alias(left_expr),
+                right_expr: strip_projection_alias(right_expr),
+                evaluator: None,
+                ty,
+            },
+            predicate => predicate,
+        }
     }
 
     fn plan_has_correlated_refs(plan: &LogicalPlan, left_schema: &Schema) -> bool {

--- a/src/binder/select.rs
+++ b/src/binder/select.rs
@@ -79,6 +79,7 @@ impl<'a: 'b, 'b, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'
         } else {
             None
         };
+        let is_plain_select = matches!(query.body.borrow(), SetExpr::Select(_));
         let mut plan = match query.body.borrow() {
             SetExpr::Select(select) => self.bind_select(select, order_by_exprs),
             SetExpr::Query(query) => self.bind_query(query),
@@ -96,12 +97,41 @@ impl<'a: 'b, 'b, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'
             }
         }?;
 
+        if !is_plain_select {
+            if let Some(order_by_exprs) = order_by_exprs {
+                plan = self.bind_top_level_orderby(plan, order_by_exprs)?;
+            }
+        }
+
         if let Some(limit_clause) = query.limit_clause.clone() {
             plan = self.bind_limit(plan, limit_clause)?;
         }
 
         self.context.step(origin_step);
         Ok(plan)
+    }
+
+    fn bind_top_level_orderby(
+        &mut self,
+        mut plan: LogicalPlan,
+        orderbys: &[OrderByExpr],
+    ) -> Result<LogicalPlan, DatabaseError> {
+        let saved_aliases = self.context.expr_aliases.clone();
+        for column in plan.output_schema().iter() {
+            self.context.add_alias(
+                None,
+                column.name().to_string(),
+                ScalarExpression::column_expr(column.clone()),
+            );
+        }
+
+        let sort_fields = self.extract_having_orderby_aggregate(&None, orderbys)?.1;
+        self.context.expr_aliases = saved_aliases;
+
+        Ok(match sort_fields {
+            Some(sort_fields) => self.bind_sort(plan, sort_fields),
+            None => plan,
+        })
     }
 
     pub(crate) fn bind_select(
@@ -318,8 +348,42 @@ impl<'a: 'b, 'b, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'
                 ))
             }
         };
-        let mut left_plan = self.bind_set_expr(left)?;
-        let mut right_plan = self.bind_set_expr(right)?;
+        let BinderContext {
+            table_cache,
+            view_cache,
+            transaction,
+            scala_functions,
+            table_functions,
+            temp_table_id,
+            ..
+        } = &self.context;
+        let mut left_binder = Binder::new(
+            BinderContext::new(
+                table_cache,
+                view_cache,
+                *transaction,
+                scala_functions,
+                table_functions,
+                temp_table_id.clone(),
+            ),
+            self.args,
+            Some(self),
+        );
+        let mut right_binder = Binder::new(
+            BinderContext::new(
+                table_cache,
+                view_cache,
+                *transaction,
+                scala_functions,
+                table_functions,
+                temp_table_id.clone(),
+            ),
+            self.args,
+            Some(self),
+        );
+
+        let mut left_plan = left_binder.bind_set_expr(left)?;
+        let mut right_plan = right_binder.bind_set_expr(right)?;
 
         let mut left_schema = left_plan.output_schema();
         let mut right_schema = right_plan.output_schema();

--- a/src/binder/select.rs
+++ b/src/binder/select.rs
@@ -385,26 +385,27 @@ impl<'a: 'b, 'b, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'
                         right_plan,
                     ))
                 } else {
-                    let distinct_exprs = left_schema
+                    let left_distinct_exprs = left_schema
+                        .iter()
+                        .cloned()
+                        .map(ScalarExpression::column_expr)
+                        .collect_vec();
+                    let right_distinct_exprs = right_schema
                         .iter()
                         .cloned()
                         .map(ScalarExpression::column_expr)
                         .collect_vec();
 
-                    let except_op = Operator::Except(ExceptOperator {
-                        left_schema_ref: left_schema.clone(),
-                        _right_schema_ref: right_schema.clone(),
-                    });
+                    left_plan = self.bind_distinct(left_plan, left_distinct_exprs);
+                    right_plan = self.bind_distinct(right_plan, right_distinct_exprs);
+                    left_schema = left_plan.output_schema();
+                    right_schema = right_plan.output_schema();
 
-                    Ok(self.bind_distinct(
-                        LogicalPlan::new(
-                            except_op,
-                            Childrens::Twins {
-                                left: Box::new(left_plan),
-                                right: Box::new(right_plan),
-                            },
-                        ),
-                        distinct_exprs,
+                    Ok(ExceptOperator::build(
+                        left_schema.clone(),
+                        right_schema.clone(),
+                        left_plan,
+                        right_plan,
                     ))
                 }
             }

--- a/src/execution/dml/insert.rs
+++ b/src/execution/dml/insert.rs
@@ -89,22 +89,16 @@ impl<'a, T: Transaction + 'a> WriteExecutor<'a, T> for Insert {
 
             let schema = input.output_schema().clone();
 
-            let primary_keys = schema
-                .iter()
-                .filter_map(|column| column.desc().primary().map(|i| (i, column)))
-                .sorted_by_key(|(i, _)| *i)
-                .map(|(_, col)| col.key(is_mapping_by_name))
-                .collect_vec();
-            if primary_keys.is_empty() {
-                throw!(co, Err(DatabaseError::not_null()))
-            }
-
             if let Some(table_catalog) = throw!(
                 co,
                 unsafe { &mut (*transaction) }.table(cache.0, table_name.clone())
             )
             .cloned()
             {
+                if table_catalog.primary_keys().is_empty() {
+                    throw!(co, Err(DatabaseError::not_null()))
+                }
+
                 // Index values must be projected from the full table schema, because
                 // omitted input columns may be filled by defaults before index maintenance.
                 let table_schema = table_catalog.schema_ref();
@@ -140,7 +134,7 @@ impl<'a, T: Transaction + 'a> WriteExecutor<'a, T> for Insert {
                     let mut values = Vec::with_capacity(table_catalog.columns_len());
 
                     for col in table_catalog.columns() {
-                        let value = {
+                        let mut value = {
                             let mut value = tuple_map.remove(&col.key(is_mapping_by_name));
 
                             if value.is_none() {
@@ -148,6 +142,10 @@ impl<'a, T: Transaction + 'a> WriteExecutor<'a, T> for Insert {
                             }
                             value.unwrap_or(DataValue::Null)
                         };
+                        if !value.is_null() && &value.logical_type() != col.datatype() {
+                            value = throw!(co, value.cast(col.datatype()));
+                        }
+                        throw!(co, value.check_len(col.datatype()));
                         if value.is_null() && !col.nullable() {
                             co.yield_(Err(DatabaseError::not_null_column(col.name().to_string())))
                                 .await;

--- a/src/execution/dql/except.rs
+++ b/src/execution/dql/except.rs
@@ -16,7 +16,7 @@ use crate::execution::{build_read, spawn_executor, Executor, ReadExecutor};
 use crate::planner::LogicalPlan;
 use crate::storage::{StatisticsMetaCache, TableCache, Transaction, ViewCache};
 use crate::throw;
-use ahash::{HashSet, HashSetExt};
+use ahash::{HashMap, HashMapExt};
 pub struct Except {
     left_input: LogicalPlan,
     right_input: LogicalPlan,
@@ -45,20 +45,24 @@ impl<'a, T: Transaction + 'a> ReadExecutor<'a, T> for Except {
 
             let mut coroutine = build_read(right_input, cache, transaction);
 
-            let mut except_col = HashSet::new();
+            let mut except_col = HashMap::new();
 
             for tuple in coroutine.by_ref() {
                 let tuple = throw!(co, tuple);
-                except_col.insert(tuple);
+                *except_col.entry(tuple).or_insert(0usize) += 1;
             }
 
             let coroutine = build_read(left_input, cache, transaction);
 
             for tuple in coroutine {
                 let tuple = throw!(co, tuple);
-                if !except_col.contains(&tuple) {
-                    co.yield_(Ok(tuple)).await;
+                if let Some(count) = except_col.get_mut(&tuple) {
+                    if *count > 0 {
+                        *count -= 1;
+                        continue;
+                    }
                 }
+                co.yield_(Ok(tuple)).await;
             }
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,3 +113,5 @@ pub mod wasm;
 
 #[cfg(feature = "orm")]
 pub use kite_sql_serde_macros::Model;
+#[cfg(feature = "orm")]
+pub use kite_sql_serde_macros::Projection;

--- a/src/optimizer/rule/normalization/compilation_in_advance.rs
+++ b/src/optimizer/rule/normalization/compilation_in_advance.rs
@@ -191,7 +191,10 @@ impl EvaluatorBind {
             Childrens::Only(child) => Self::_apply(child)?,
             Childrens::Twins { left, right } => {
                 Self::_apply(left)?;
-                if matches!(plan.operator, Operator::Join(_)) {
+                if matches!(
+                    plan.operator,
+                    Operator::Join(_) | Operator::Union(_) | Operator::Except(_)
+                ) {
                     Self::_apply(right)?;
                 }
             }

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -270,6 +270,12 @@ back to the DTO field name.
 If you need expression-based outputs, prefer `project_value(...)` or
 `project_tuple(...)` and assign explicit names with `.alias(...)`.
 
+Use `project::<P>()` when:
+
+- you want a DTO-style result type instead of full `M`
+- selected outputs are plain columns, optionally with renamed field mapping
+- you want field-name-based decoding instead of positional tuple decoding
+
 ### Single-value queries
 
 Use `Database::from::<M>().project_value(expr)` or
@@ -280,12 +286,31 @@ ordering, and subquery composition, and returns typed values via
 
 This is also the intended entry point for scalar subqueries.
 
+Use `project_value(...)` when:
+
+- the query returns exactly one value per row
+- you want scalar decoding such as `i32`, `String`, or `Option<T>`
+- you are building scalar subqueries such as `IN (subquery)`
+- the output is an expression or aggregate rather than a DTO field mapping
+
 ### Tuple queries
 
 Use `Database::from::<M>().project_tuple(values)` or
 `DBTransaction::from::<M>().project_tuple(values)` to project multiple
 expressions and decode them positionally into a Rust tuple via
 `fetch::<(T1, T2, ...)>()` and `get::<(T1, T2, ...)>()`.
+
+Use `project_tuple(...)` when:
+
+- you need multiple outputs but do not want to define a DTO type
+- the projection contains expressions, aggregates, or custom aliases
+- positional decoding is acceptable
+
+In practice:
+
+- `project::<P>()`: named-field DTO mapping
+- `project_value(...)`: one expression, one decoded value
+- `project_tuple(...)`: multiple expressions, positional decoding
 
 ### Example
 

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -150,8 +150,8 @@ The query flow is:
 
 - start with `from::<M>()`
 - optionally add filters, grouping, ordering, and limits
-- either fetch full `M` rows, or switch into a projection with `project_value(...)`
-  or `project_tuple(...)`
+- either fetch full `M` rows, or switch into a projection with `project::<P>()`,
+  `project_value(...)`, or `project_tuple(...)`
 
 ### Field expressions
 
@@ -219,8 +219,8 @@ not expose yet.
 ### Shared builder methods
 
 `FromBuilder` supports the following methods, and the same chainable query
-methods remain available after calling `project_value(...)` or
-`project_tuple(...)`:
+methods remain available after calling `project::<P>()`, `project_value(...)`,
+or `project_tuple(...)`:
 
 - `filter(expr)`
 - `and(left, right)`
@@ -256,6 +256,20 @@ methods remain available after calling `project_value(...)` or
 - `exists()`
 - `count()`
 
+### Struct projections
+
+Use `Database::from::<M>().project::<P>()` or
+`DBTransaction::from::<M>().project::<P>()` to project rows into a dedicated
+DTO-like struct. `P` is typically a `#[derive(Projection)]` type whose field
+names match the projected output names.
+
+Field-level renaming is supported with `#[projection(rename = "...")]`, which
+maps a DTO field to a different source column while still aliasing the result
+back to the DTO field name.
+
+If you need expression-based outputs, prefer `project_value(...)` or
+`project_tuple(...)` and assign explicit names with `.alias(...)`.
+
 ### Single-value queries
 
 Use `Database::from::<M>().project_value(expr)` or
@@ -276,8 +290,17 @@ expressions and decode them positionally into a Rust tuple via
 ### Example
 
 ```rust
+use kite_sql::Projection;
 use kite_sql::orm::{case_when, count_all, func, sum, QueryExpr, QueryValue};
 use sqlparser::ast::{BinaryOperator, Expr};
+
+#[derive(Default, Projection)]
+struct UserSummary {
+    id: i32,
+    #[projection(rename = "user_name")]
+    display_name: String,
+    age: Option<i32>,
+}
 
 let exists = database
     .from::<User>()
@@ -315,6 +338,12 @@ let typed = database
     .from::<User>()
     .eq(User::id().cast("BIGINT")?, 1_i64)
     .get()?;
+
+let summaries = database
+    .from::<User>()
+    .project::<UserSummary>()
+    .asc(User::id())
+    .fetch()?;
 
 let ids = database
     .from::<User>()
@@ -357,6 +386,16 @@ let grouped_ids = database
     .project_tuple((User::age(), sum(User::id()).alias("total_ids")))
     .group_by(User::age())
     .fetch::<(Option<i32>, i32)>()?;
+
+let grouped_stats = database
+    .from::<EventLog>()
+    .project_tuple((
+        EventLog::category(),
+        sum(EventLog::score()).alias("total_score"),
+        count_all().alias("total_count"),
+    ))
+    .group_by(EventLog::category())
+    .fetch::<(String, i32, i32)>()?;
 
 let raw_ast = database
     .from::<User>()
@@ -460,8 +499,8 @@ Helpers:
 
 ### `ProjectedValue`
 
-A projected select-list item used by `project_value(...)` and `project_tuple(...)`,
-optionally carrying an alias.
+A projected select-list item used by `project::<P>()`, `project_value(...)`,
+and `project_tuple(...)`, optionally carrying an alias.
 
 ### `CompareOp`
 
@@ -499,8 +538,9 @@ A lightweight single-table ORM query builder.
 `FromBuilder` is the public entry point for ORM DQL construction.
 
 By default it selects full model rows and supports `fetch()` / `get()` into `M`.
-Calling `project_value(...)` or `project_tuple(...)` keeps the same query chain
-but changes the final decoding shape to a scalar or tuple result.
+Calling `project::<P>()`, `project_value(...)`, or `project_tuple(...)` keeps
+the same query chain but changes the final decoding shape to a struct, scalar,
+or tuple result.
 
 ## Public traits
 
@@ -519,6 +559,16 @@ Important associated items:
 - cached statement getters such as `select_statement()` and `insert_statement()`
 
 In most cases, you should derive this trait instead of implementing it manually.
+
+### `Projection`
+
+The DTO projection trait implemented by `#[derive(Projection)]`.
+
+It powers `Database::from::<M>().project::<P>()` and
+`DBTransaction::from::<M>().project::<P>()`.
+
+Derived projections declare their source model with
+matching field names, and may use `rename` on fields.
 
 ### `FromDataValue`
 

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -226,12 +226,18 @@ not expose yet.
 - `desc(value)`
 - `limit(n)`
 - `offset(n)`
-- `into_query()`
 - `raw()`
 - `fetch()`
 - `get()`
 - `exists()`
 - `count()`
+
+### Single-value queries
+
+Use `Database::project_value::<M>(expr)` or `DBTransaction::project_value::<M>(expr)`
+to start a single-value projection builder. It supports the same filtering,
+ordering, and subquery composition, and returns typed values via `fetch::<T>()`
+and `get::<T>()`.
 
 ### Example
 
@@ -276,10 +282,10 @@ let typed = database
     .eq(User::id().cast("BIGINT")?, 1_i64)
     .get()?;
 
-let query_ast = database
-    .select::<User>()
-    .eq(User::id(), 1)
-    .into_query();
+let ids = database
+    .project_value::<User, _>(User::id())
+    .asc(User::id())
+    .fetch::<i32>()?;
 
 let raw_ast = database
     .select::<User>()
@@ -290,22 +296,21 @@ let raw_ast = database
     }))
     .get()?;
 
-let mut parser = sqlparser::parser::Parser::new(&sqlparser::dialect::PostgreSqlDialect {})
-    .try_with_sql("select id from users where id = 1")?;
-let exists_subquery = match parser.parse_statement()? {
-    sqlparser::ast::Statement::Query(query) => *query,
-    _ => unreachable!(),
-};
 let uncorrelated = database
     .select::<User>()
-    .where_exists(exists_subquery)
+    .where_exists(
+        database
+            .project_value::<User, _>(User::id())
+            .eq(User::id(), 1),
+    )
     .get()?;
 # Ok::<(), kite_sql::errors::DatabaseError>(())
 ```
 
-`into_query()` exports the current model-select AST, including the default full-row
-projection. For scalar subqueries such as `IN (subquery)` and `EXISTS (subquery)`,
-use a single-column `Query` today if the binder expects one expression to be returned.
+For scalar subqueries such as `IN (subquery)` and `EXISTS (subquery)`,
+use `Database::project_value::<M>(...)` or `DBTransaction::project_value::<M>(...)`
+to build a single-column subquery directly when the binder expects one expression
+to be returned.
 
 ## Public structs and enums
 
@@ -393,6 +398,10 @@ Methods:
 ### `SelectBuilder<Q, M>`
 
 A lightweight single-table ORM query builder.
+
+Use `Database::project_value::<M>(expr)` or `DBTransaction::project_value::<M>(expr)`
+to create the matching single-value projection builder. It still supports filters,
+ordering, subquery composition, and typed `fetch::<T>()` / `get::<T>()`.
 
 ## Public traits
 

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -104,6 +104,11 @@ The following ORM helpers are available on `Database`.
 - `create_table::<M>()`: creates the table and any declared secondary indexes
 - `create_table_if_not_exists::<M>()`: idempotent table and index creation
 - `migrate::<M>()`: aligns an existing table with the current model definition
+- `truncate::<M>()`
+- `create_view(name, query_builder)`
+- `create_or_replace_view(name, query_builder)`
+- `drop_view(name)`
+- `drop_view_if_exists(name)`
 - `drop_index::<M>(index_name)`
 - `drop_index_if_exists::<M>(index_name)`
 - `drop_table::<M>()`
@@ -116,6 +121,7 @@ The following ORM helpers are available on `Database`.
 ### DML
 
 - `insert::<M>(&model)`
+- `insert_many::<M>(models)`
 - `from::<M>()...insert::<Target>()`
 - `from::<M>()...project_...().insert_into::<Target>(...)`
 - `from::<M>()...overwrite::<Target>()`
@@ -140,6 +146,7 @@ The following ORM helpers are available on `DBTransaction`.
 ### DML
 
 - `insert::<M>(&model)`
+- `insert_many::<M>(models)`
 - `from::<M>()...insert::<Target>()`
 - `from::<M>()...project_...().insert_into::<Target>(...)`
 - `from::<M>()...overwrite::<Target>()`
@@ -234,8 +241,8 @@ Call `.all()` after `union(...)` or `except(...)` when you want multiset
 semantics instead of the default distinct result.
 
 After a set query is formed, you can still apply result-level methods such as
-`asc(...)`, `desc(...)`, `limit(...)`, `offset(...)`, `fetch()`, `get()`,
-`exists()`, and `count()`.
+`asc(...)`, `desc(...)`, `nulls_first()`, `nulls_last()`, `limit(...)`,
+`offset(...)`, `fetch()`, `get()`, `exists()`, and `count()`.
 
 ```rust
 let user_ids = database

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -252,10 +252,16 @@ to start a single-value projection builder. It supports the same filtering,
 grouping, ordering, and subquery composition, and returns typed values via
 `fetch::<T>()` and `get::<T>()`.
 
+### Tuple queries
+
+Use `Database::project_tuple::<M>(values)` or `DBTransaction::project_tuple::<M>(values)`
+to project multiple expressions and decode them positionally into a Rust tuple via
+`fetch::<(T1, T2, ...)>()` and `get::<(T1, T2, ...)>()`.
+
 ### Example
 
 ```rust
-use kite_sql::orm::{case_when, count_all, func, QueryExpr, QueryValue};
+use kite_sql::orm::{case_when, count_all, func, sum, QueryExpr, QueryValue};
 use sqlparser::ast::{BinaryOperator, Expr};
 
 let exists = database
@@ -315,11 +321,21 @@ let total_users = database
     .project_value::<User, _>(count_all().alias("total_users"))
     .get::<i32>()?;
 
+let rows = database
+    .project_tuple::<User, _>((User::id(), User::name()))
+    .asc(User::id())
+    .fetch::<(i32, String)>()?;
+
 let repeated_ages = database
     .project_value::<User, _>(User::age())
     .group_by(User::age())
     .having(count_all().gt(1))
     .fetch::<Option<i32>>()?;
+
+let grouped_ids = database
+    .project_tuple::<User, _>((User::age(), sum(User::id()).alias("total_ids")))
+    .group_by(User::age())
+    .fetch::<(Option<i32>, i32)>()?;
 
 let raw_ast = database
     .select::<User>()

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -150,8 +150,10 @@ If you need an explicit relation alias, call `.alias("name")` on a source or
 pending join, and re-qualify fields with `Field::qualify("name")` where needed.
 
 For ordinary multi-table queries, `inner_join::<N>().on(...)`,
-`left_join::<N>().on(...)`, and `using(...)` cover most cases. Aliases are
-mainly useful for self-joins or when you want explicit qualification.
+`left_join::<N>().on(...)`, `right_join::<N>().on(...)`,
+`full_join::<N>().on(...)`, `cross_join::<N>()`, and `using(...)` cover most
+cases. Aliases are mainly useful for self-joins or when you want explicit
+qualification.
 
 The query flow is:
 
@@ -229,6 +231,11 @@ or `project_tuple(...)`:
 - `inner_join::<N>().using(columns)`
 - `left_join::<N>().on(expr)`
 - `left_join::<N>().using(columns)`
+- `right_join::<N>().on(expr)`
+- `right_join::<N>().using(columns)`
+- `full_join::<N>().on(expr)`
+- `full_join::<N>().using(columns)`
+- `cross_join::<N>()`
 - `distinct()`
 - `and(left, right)`
 - `or(left, right)`

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -116,6 +116,10 @@ The following ORM helpers are available on `Database`.
 ### DML
 
 - `insert::<M>(&model)`
+- `from::<M>()...insert::<Target>()`
+- `from::<M>()...project_...().insert_into::<Target>(...)`
+- `from::<M>()...overwrite::<Target>()`
+- `from::<M>()...project_...().overwrite_into::<Target>(...)`
 - `from::<M>()...update().set(...).execute()`
 - `from::<M>()...delete()`
 
@@ -136,6 +140,10 @@ The following ORM helpers are available on `DBTransaction`.
 ### DML
 
 - `insert::<M>(&model)`
+- `from::<M>()...insert::<Target>()`
+- `from::<M>()...project_...().insert_into::<Target>(...)`
+- `from::<M>()...overwrite::<Target>()`
+- `from::<M>()...project_...().overwrite_into::<Target>(...)`
 - `from::<M>()...update().set(...).execute()`
 - `from::<M>()...delete()`
 
@@ -171,9 +179,21 @@ The usual flow is:
   `except(...)`, and optional `.all()`
 
 For native single-table mutations, reuse the same filtered `from::<M>()`
-entrypoint and then switch into `update()` or `delete()`:
+entrypoint and then finish with `insert::<Target>()`, `insert_into(...)`,
+`overwrite::<Target>()`, `overwrite_into(...)`, `update()`, or `delete()`.
+Here `overwrite*` follows the engine's `INSERT OVERWRITE` semantics, meaning
+conflicting target rows are replaced rather than the whole table being cleared:
 
 ```rust
+database.from::<ArchivedUser>().insert::<User>()?;
+
+database
+    .from::<ArchivedUser>()
+    .project_tuple((ArchivedUser::id(), ArchivedUser::name()))
+    .insert_into::<UserNameSnapshot, _>((UserNameSnapshot::id(), UserNameSnapshot::name()))?;
+
+database.from::<ArchivedUser>().eq(ArchivedUser::id(), 2).overwrite::<User>()?;
+
 database
     .from::<User>()
     .eq(User::id(), 1)

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -109,9 +109,12 @@ The following ORM helpers are available on `Database`.
 - `drop_table::<M>()`
 - `drop_table_if_exists::<M>()`
 
-### DML
+### Maintenance
 
 - `analyze::<M>()`: refreshes optimizer statistics for the model table
+
+### DML
+
 - `insert::<M>(&model)`
 - `update::<M>(&model)`
 - `delete_by_id::<M>(&key)`
@@ -126,9 +129,12 @@ The following ORM helpers are available on `Database`.
 
 The following ORM helpers are available on `DBTransaction`.
 
-### DML
+### Maintenance
 
 - `analyze::<M>()`
+
+### DML
+
 - `insert::<M>(&model)`
 - `update::<M>(&model)`
 - `delete_by_id::<M>(&key)`
@@ -152,78 +158,33 @@ pending join, and re-qualify fields with `Field::qualify("name")` where needed.
 For ordinary multi-table queries, `inner_join::<N>().on(...)`,
 `left_join::<N>().on(...)`, `right_join::<N>().on(...)`,
 `full_join::<N>().on(...)`, `cross_join::<N>()`, and `using(...)` cover most
-cases. Aliases are mainly useful for self-joins or when you want explicit
-qualification.
+cases. Aliases are mainly useful for self-joins or when explicit qualification
+helps readability.
 
-The query flow is:
+The usual flow is:
 
 - start with `from::<M>()`
-- optionally add `distinct`, filters, grouping, ordering, and limits
-- either fetch full `M` rows, or switch into a projection with `project::<P>()`,
+- add filters, joins, grouping, ordering, and limits as needed
+- keep full-model output, or switch into `project::<P>()`,
   `project_value(...)`, or `project_tuple(...)`
-- once the output shape is fixed, you can build set queries with `union(...)`,
+- once the output shape is fixed, compose set queries with `union(...)`,
   `except(...)`, and optional `.all()`
 
-### Field expressions
+Most expression building starts from generated fields such as `User::id()` and
+`User::name()`. Field values support arithmetic, comparison, null checks,
+pattern matching, range checks, casts, aliases, and subquery predicates. For
+computed expressions, use `QueryValue` helpers such as `func`, `count`,
+`count_all`, `sum`, `avg`, `min`, `max`, `case_when`, and `case_value`.
 
-Generated field accessors return `Field<M, T>`. A field supports:
+Boolean composition lives on `QueryExpr` through `and`, `or`, `not`, `exists`,
+and `not_exists`.
 
-- `add(value)`
-- `sub(value)`
-- `mul(value)`
-- `div(value)`
-- `modulo(value)`
-- `neg()`
-- `eq(value)`
-- `ne(value)`
-- `gt(value)`
-- `gte(value)`
-- `lt(value)`
-- `lte(value)`
-- `is_null()`
-- `is_not_null()`
-- `like(pattern)`
-- `not_like(pattern)`
-- `in_list(values)`
-- `not_in_list(values)`
-- `between(low, high)`
-- `not_between(low, high)`
-- `cast("type")`
-- `cast_to(DataType)`
-- `alias(name)`
-- `qualify(relation)`
-- `in_subquery(query)`
-- `not_in_subquery(query)`
-
-### Function calls
-
-Use `func(name, args)` to build scalar function calls, including registered UDFs.
-Function calls can be used anywhere a `QueryValue` is accepted, such as filters and sorting.
-
-Built-in helpers are also available for common expression shapes:
-
-- `count(expr)`
-- `count_all()`
-- `sum(expr)`
-- `avg(expr)`
-- `min(expr)`
-- `max(expr)`
-- `case_when([(cond, value), ...], else_value)`
-- `case_value(expr, [(when, value), ...], else_value)`
-
-### Boolean composition
-
-`QueryExpr` supports:
-
-- `and(rhs)`
-- `or(rhs)`
-- `not()`
-- `exists(query)`
-- `not_exists(query)`
+Detailed method-by-method examples live in the rustdoc for `Field`,
+`QueryValue`, `QueryExpr`, `FromBuilder`, and `SetQueryBuilder`.
 
 ### Set queries
 
-Set operations are available after the query output shape is fixed.
+Set operations are available after the output shape is fixed:
 
 - model rows: `from::<User>().union(...)`
 - single values: `project_value(...).union(...)`
@@ -236,10 +197,6 @@ semantics instead of the default distinct result.
 After a set query is formed, you can still apply result-level methods such as
 `asc(...)`, `desc(...)`, `limit(...)`, `offset(...)`, `fetch()`, `get()`,
 `exists()`, and `count()`.
-
-For set-query ordering, field inputs are interpreted by their output column
-name, so `asc(User::id())` orders by the projected `id` column of the set
-result.
 
 ```rust
 let user_ids = database
@@ -256,78 +213,10 @@ let total_ids = database
     .asc(User::id())
     .limit(3)
     .count()?;
-
-let users_without_orders = database
-    .from::<User>()
-    .in_subquery(
-        User::id(),
-        database
-            .from::<User>()
-            .project_value(User::id())
-            .except(database.from::<Order>().project_value(Order::user_id())),
-    )
-    .fetch()?;
 # let _ = user_ids;
 # let _ = total_ids;
-# let _ = users_without_orders;
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
-
-### Shared builder methods
-
-`FromBuilder` supports the following methods, and the same chainable query
-methods remain available after calling `project::<P>()`, `project_value(...)`,
-or `project_tuple(...)`:
-
-- `filter(expr)`
-- `alias(name)`
-- `inner_join::<N>().on(expr)`
-- `inner_join::<N>().using(columns)`
-- `left_join::<N>().on(expr)`
-- `left_join::<N>().using(columns)`
-- `right_join::<N>().on(expr)`
-- `right_join::<N>().using(columns)`
-- `full_join::<N>().on(expr)`
-- `full_join::<N>().using(columns)`
-- `cross_join::<N>()`
-- `distinct()`
-- `and(left, right)`
-- `or(left, right)`
-- `not(expr)`
-- `eq(left, right)`
-- `ne(left, right)`
-- `gt(left, right)`
-- `gte(left, right)`
-- `lt(left, right)`
-- `lte(left, right)`
-- `is_null(value)`
-- `is_not_null(value)`
-- `like(value, pattern)`
-- `not_like(value, pattern)`
-- `in_list(value, values)`
-- `not_in_list(value, values)`
-- `between(value, low, high)`
-- `not_between(value, low, high)`
-- `in_subquery(value, query)`
-- `not_in_subquery(value, query)`
-- `where_exists(query)`
-- `where_not_exists(query)`
-- `group_by(value)`
-- `having(expr)`
-- `asc(value)`
-- `desc(value)`
-- `limit(n)`
-- `offset(n)`
-- `raw()`
-- `fetch()`
-- `get()`
-- `exists()`
-- `count()`
-
-After `union(...)` or `except(...)`, the resulting set-query builder keeps the
-result-level subset of this API: `all()`, `asc(...)`, `desc(...)`, `limit(...)`,
-`offset(...)`, `raw()`, `fetch()`, `get()`, `exists()`, `count()`,
-`union(...)`, and `except(...)`.
 
 ### Struct projections
 
@@ -345,40 +234,6 @@ with `#[projection(from = "...")]`.
 
 If you need expression-based outputs, prefer `project_value(...)` or
 `project_tuple(...)` and assign explicit names with `.alias(...)`.
-
-### Join example
-
-```rust
-let rows = database
-    .from::<User>()
-    .inner_join::<Order>()
-    .on(User::id().eq(Order::user_id()))
-    .project_tuple((User::name(), Order::amount()))
-    .fetch::<(String, i32)>()?;
-# let _ = rows;
-# Ok::<(), kite_sql::errors::DatabaseError>(())
-```
-
-Join DTOs can still use `project::<P>()` when fields declare their source:
-
-```rust
-#[derive(Default, Debug, PartialEq, kite_sql::Projection)]
-struct UserOrderSummary {
-    #[projection(from = "users", rename = "user_name")]
-    display_name: String,
-    #[projection(from = "orders")]
-    amount: i32,
-}
-
-let rows = database
-    .from::<User>()
-    .inner_join::<Order>()
-    .on(User::id().eq(Order::user_id()))
-    .project::<UserOrderSummary>()
-    .fetch()?;
-# let _ = rows;
-# Ok::<(), kite_sql::errors::DatabaseError>(())
-```
 
 Use `project::<P>()` when:
 
@@ -400,7 +255,7 @@ Use `project_value(...)` when:
 
 - the query returns exactly one value per row
 - you want scalar decoding such as `i32`, `String`, or `Option<T>`
-- you are building scalar subqueries such as `IN (subquery)`
+- you are building scalar subqueries
 - the output is an expression or aggregate rather than a DTO field mapping
 
 ### Tuple queries
@@ -425,28 +280,23 @@ In practice:
 Result helpers:
 
 - `fetch()`: iterate over all matching rows
-- `get()`: fetch at most one row or value
+- `get()`: fetch at most one row or value with `LIMIT 1` semantics
 - `raw()`: access the underlying tuple/schema iterator directly
 
-Minimal examples:
+### Representative examples
+
+Join with tuple projection:
 
 ```rust
-let first_user = database.from::<User>().asc(User::id()).get()?;
-
-let first_id = database
+let rows = database
     .from::<User>()
-    .project_value(User::id())
-    .asc(User::id())
-    .get::<i32>()?;
-
-let raw_rows = database.from::<User>().limit(1).raw()?;
-# raw_rows.done()?;
-# let _ = first_user;
-# let _ = first_id;
-# Ok::<(), Box<dyn std::error::Error>>(())
+    .inner_join::<Order>()
+    .on(User::id().eq(Order::user_id()))
+    .project_tuple((User::name(), Order::amount()))
+    .fetch::<(String, i32)>()?;
+# let _ = rows;
+# Ok::<(), kite_sql::errors::DatabaseError>(())
 ```
-
-### Example
 
 Struct projection:
 
@@ -468,7 +318,7 @@ let summaries = database
 # Ok::<(), kite_sql::errors::DatabaseError>(())
 ```
 
-Single-value projection:
+Value projection with expression:
 
 ```rust
 use kite_sql::orm::{case_when, count_all};
@@ -488,6 +338,8 @@ let age_bucket = database
         .alias("age_bucket"),
     )
     .fetch::<String>()?;
+# let _ = total_users;
+# let _ = age_bucket;
 # Ok::<(), kite_sql::errors::DatabaseError>(())
 ```
 
@@ -505,35 +357,23 @@ let grouped_stats = database
     ))
     .group_by(EventLog::category())
     .fetch::<(String, i32, i32)>()?;
+# let _ = grouped_stats;
 # Ok::<(), kite_sql::errors::DatabaseError>(())
 ```
 
-Subqueries:
+Scalar subquery:
 
 ```rust
-use kite_sql::orm::{func, QueryValue};
-
-let normalized = database
+let users = database
     .from::<User>()
-    .eq(func("add_one", [QueryValue::from(User::id())]), 2)
-    .get()?;
-
-let uncorrelated = database
-    .from::<User>()
-    .where_exists(
-        database
-            .from::<User>()
-            .project_value(User::id())
-            .eq(User::id(), 1),
+    .in_subquery(
+        User::id(),
+        database.from::<Order>().project_value(Order::user_id()),
     )
-    .get()?;
+    .fetch()?;
+# let _ = users;
 # Ok::<(), kite_sql::errors::DatabaseError>(())
 ```
-
-For scalar subqueries such as `IN (subquery)` and `EXISTS (subquery)`, use
-`Database::from::<M>().project_value(...)` or
-`DBTransaction::from::<M>().project_value(...)` to build a single-column
-subquery directly when the binder expects one expression to be returned.
 
 ## Key types
 
@@ -550,6 +390,8 @@ You usually use it to build expressions:
 - `cast`, `cast_to`
 - `alias`
 - subquery predicates such as `in_subquery`
+
+See the rustdoc on `Field` for the full method surface and minimal examples.
 
 ### `QueryValue`
 
@@ -571,6 +413,8 @@ predicates when you need to keep composing expressions.
 It also supports arithmetic composition such as `add`, `sub`, `mul`, `div`,
 `modulo`, and unary `neg`.
 
+See the rustdoc on `QueryValue` for the full method surface and minimal examples.
+
 ### `QueryExpr`
 
 The boolean expression type used for filtering and `HAVING`.
@@ -583,6 +427,8 @@ Common helpers:
 - `exists(query)`
 - `not_exists(query)`
 
+See the rustdoc on `QueryExpr` for minimal examples.
+
 ### `FromBuilder<Q, M>`
 
 The main single-table ORM query builder returned by `from::<M>()`.
@@ -592,6 +438,16 @@ It starts in full-model mode and can later switch into:
 - `project::<P>()` for DTO structs
 - `project_value(...)` for scalar results
 - `project_tuple(...)` for tuple results
+
+See the rustdoc on `FromBuilder` and `SetQueryBuilder` for the full chainable API.
+
+### `SetQueryBuilder<Q, M>`
+
+The result-level builder produced by `union(...)` and `except(...)`.
+
+It keeps the projection shape of the queries you combine, and supports
+result-level operations such as `all()`, `asc(...)`, `desc(...)`, `limit(...)`,
+`offset(...)`, `fetch()`, `get()`, `exists()`, and `count()`.
 
 ## Key traits
 

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -173,6 +173,17 @@ Generated field accessors return `Field<M, T>`. A field supports:
 Use `func(name, args)` to build scalar function calls, including registered UDFs.
 Function calls can be used anywhere a `QueryValue` is accepted, such as filters and sorting.
 
+Built-in helpers are also available for common expression shapes:
+
+- `count(expr)`
+- `count_all()`
+- `sum(expr)`
+- `avg(expr)`
+- `min(expr)`
+- `max(expr)`
+- `case_when([(cond, value), ...], else_value)`
+- `case_value(expr, [(when, value), ...], else_value)`
+
 ### AST access
 
 `QueryValue` and `QueryExpr` are lightweight wrappers around `sqlparser::ast::Expr`.
@@ -242,7 +253,7 @@ and `get::<T>()`.
 ### Example
 
 ```rust
-use kite_sql::orm::{func, QueryExpr, QueryValue};
+use kite_sql::orm::{case_when, count_all, func, QueryExpr, QueryValue};
 use sqlparser::ast::{BinaryOperator, Expr};
 
 let exists = database
@@ -286,6 +297,21 @@ let ids = database
     .project_value::<User, _>(User::id())
     .asc(User::id())
     .fetch::<i32>()?;
+
+let age_bucket = database
+    .project_value::<User, _>(
+        case_when(
+            [(User::age().is_null(), "unknown"), (User::age().lt(20), "minor")],
+            "adult",
+        )
+        .alias("age_bucket"),
+    )
+    .asc(User::id())
+    .fetch::<String>()?;
+
+let total_users = database
+    .project_value::<User, _>(count_all().alias("total_users"))
+    .get::<i32>()?;
 
 let raw_ast = database
     .select::<User>()
@@ -353,18 +379,31 @@ A query-side wrapper around `sqlparser::ast::Expr` for value-producing expressio
 Helpers:
 
 - `func(name, args)`
+- `count(expr)`
+- `count_all()`
+- `sum(expr)`
+- `avg(expr)`
+- `min(expr)`
+- `max(expr)`
+- `case_when([(cond, value), ...], else_value)`
+- `case_value(expr, [(when, value), ...], else_value)`
 - `in_list(values)`
 - `not_in_list(values)`
 - `between(low, high)`
 - `not_between(low, high)`
 - `cast("type") -> Result<QueryValue, DatabaseError>`
 - `cast_to(DataType)`
+- `alias(name)`
 - `subquery(query)`
 - `in_subquery(query)`
 - `not_in_subquery(query)`
 - `from_ast(expr)`
 - `as_ast()`
 - `into_ast()`
+
+### `ProjectedValue`
+
+A single projected expression for `project_value`, optionally carrying an alias.
 
 ### `CompareOp`
 

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -64,16 +64,16 @@ for user in adults {
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-## Derive macro
+## Model derive
 
 `#[derive(Model)]` is the intended entry point for ORM models.
 
-### Struct attributes
+Struct attributes:
 
 - `#[model(table = "users")]`: sets the backing table name
 - `#[model(index(name = "idx", columns = "a, b"))]`: declares a secondary index at the model level
 
-### Field attributes
+Field attributes:
 
 - `#[model(primary_key)]`
 - `#[model(unique)]`
@@ -85,142 +85,30 @@ for user in adults {
 - `#[model(decimal_precision = 10, decimal_scale = 2)]`
 - `#[model(skip)]`
 
-### Generated helpers
+The derive macro generates the `Model` implementation, tuple decoding, cached
+read/insert/DDL statements, migration metadata, and typed field getters such as
+`User::id()` and `User::name()`.
 
-The derive macro generates:
-
-- the `Model` trait implementation
-- tuple mapping from query results into the Rust struct
-- cached statements for model reads, inserts, and DDL
-- static column metadata for migrations
-- typed field getters such as `User::id()` and `User::name()`
-
-## Database ORM APIs
-
-The following ORM helpers are available on `Database`.
-
-### DDL
-
-- `create_table::<M>()`: creates the table and any declared secondary indexes
-- `create_table_if_not_exists::<M>()`: idempotent table and index creation
-- `migrate::<M>()`: aligns an existing table with the current model definition
-- `truncate::<M>()`
-- `create_view(name, query_builder)`
-- `create_or_replace_view(name, query_builder)`
-- `drop_view(name)`
-- `drop_view_if_exists(name)`
-- `drop_index::<M>(index_name)`
-- `drop_index_if_exists::<M>(index_name)`
-- `drop_table::<M>()`
-- `drop_table_if_exists::<M>()`
-
-### Maintenance
-
-- `analyze::<M>()`: refreshes optimizer statistics for the model table
-
-### DML
-
-- `insert::<M>(&model)`
-- `insert_many::<M>(models)`
-- `from::<M>()...insert::<Target>()`
-- `from::<M>()...project_...().insert_into::<Target>(...)`
-- `from::<M>()...overwrite::<Target>()`
-- `from::<M>()...project_...().overwrite_into::<Target>(...)`
-- `from::<M>()...update().set(...).execute()`
-- `from::<M>()...delete()`
-
-### DQL
-
-- `get::<M>(&key) -> Result<Option<M>, DatabaseError>`
-- `fetch::<M>() -> Result<OrmIter<...>, DatabaseError>`
-- `show_tables() -> Result<ProjectValueIter<..., String>, DatabaseError>`
-- `show_views() -> Result<ProjectValueIter<..., String>, DatabaseError>`
-- `describe::<M>() -> Result<OrmIter<..., DescribeColumn>, DatabaseError>`
-- `from::<M>() -> FromBuilder<...>`
-
-## Transaction ORM APIs
-
-The following ORM helpers are available on `DBTransaction`.
-
-### Maintenance
-
-- `analyze::<M>()`
-
-### DML
-
-- `insert::<M>(&model)`
-- `insert_many::<M>(models)`
-- `from::<M>()...insert::<Target>()`
-- `from::<M>()...project_...().insert_into::<Target>(...)`
-- `from::<M>()...overwrite::<Target>()`
-- `from::<M>()...project_...().overwrite_into::<Target>(...)`
-- `from::<M>()...update().set(...).execute()`
-- `from::<M>()...delete()`
-
-### DQL
-
-- `get::<M>(&key) -> Result<Option<M>, DatabaseError>`
-- `fetch::<M>() -> Result<OrmIter<...>, DatabaseError>`
-- `show_tables() -> Result<ProjectValueIter<..., String>, DatabaseError>`
-- `show_views() -> Result<ProjectValueIter<..., String>, DatabaseError>`
-- `describe::<M>() -> Result<OrmIter<..., DescribeColumn>, DatabaseError>`
-- `from::<M>() -> FromBuilder<...>`
-
-`DBTransaction` does not currently expose the ORM DDL convenience methods.
-
-## Query builder API
+## Query Builder
 
 `Database::from::<M>()` and `DBTransaction::from::<M>()` start a typed query
 from one ORM model table.
 
-If you need an explicit relation alias, call `.alias("name")` on a source or
-pending join, and re-qualify fields with `Field::qualify("name")` where needed.
-
-For ordinary multi-table queries, `inner_join::<N>().on(...)`,
-`left_join::<N>().on(...)`, `right_join::<N>().on(...)`,
-`full_join::<N>().on(...)`, `cross_join::<N>()`, and `using(...)` cover most
-cases. Aliases are mainly useful for self-joins or when explicit qualification
-helps readability.
-
 The usual flow is:
 
 - start with `from::<M>()`
-- add filters, joins, grouping, ordering, and limits as needed
+- add filters, joins, grouping, ordering, and limits
 - keep full-model output, or switch into `project::<P>()`,
   `project_value(...)`, or `project_tuple(...)`
 - once the output shape is fixed, compose set queries with `union(...)`,
   `except(...)`, and optional `.all()`
 
-For native single-table mutations, reuse the same filtered `from::<M>()`
-entrypoint and then finish with `insert::<Target>()`, `insert_into(...)`,
-`overwrite::<Target>()`, `overwrite_into(...)`, `update()`, or `delete()`.
-Here `overwrite*` follows the engine's `INSERT OVERWRITE` semantics, meaning
-conflicting target rows are replaced rather than the whole table being cleared:
-
-```rust
-database.from::<ArchivedUser>().insert::<User>()?;
-
-database
-    .from::<ArchivedUser>()
-    .project_tuple((ArchivedUser::id(), ArchivedUser::name()))
-    .insert_into::<UserNameSnapshot, _>((UserNameSnapshot::id(), UserNameSnapshot::name()))?;
-
-database.from::<ArchivedUser>().eq(ArchivedUser::id(), 2).overwrite::<User>()?;
-
-database
-    .from::<User>()
-    .eq(User::id(), 1)
-    .update()
-    .set(User::name(), "Bob")
-    .set(User::age(), Some(20))
-    .execute()?;
-
-database
-    .from::<User>()
-    .eq(User::id(), 2)
-    .delete()?;
-# Ok::<(), Box<dyn std::error::Error>>(())
-```
+If you need an explicit relation alias, call `.alias("name")` on a source or
+pending join, and re-qualify fields with `Field::qualify("name")` where
+needed. For ordinary multi-table queries, `inner_join::<N>().on(...)`,
+`left_join::<N>().on(...)`, `right_join::<N>().on(...)`,
+`full_join::<N>().on(...)`, `cross_join::<N>()`, and `using(...)` cover most
+cases.
 
 Most expression building starts from generated fields such as `User::id()` and
 `User::name()`. Field values support arithmetic, comparison, null checks,
@@ -231,8 +119,22 @@ computed expressions, use `QueryValue` helpers such as `func`, `count`,
 Boolean composition lives on `QueryExpr` through `and`, `or`, `not`, `exists`,
 and `not_exists`.
 
-Detailed method-by-method examples live in the rustdoc for `Field`,
-`QueryValue`, `QueryExpr`, `FromBuilder`, and `SetQueryBuilder`.
+### Projections
+
+Use full-model fetches when the query still matches `M`, or switch to one of
+the projection modes:
+
+- `project::<P>()`: decode rows into a DTO-style struct
+- `project_value(...)`: decode one expression per row into a scalar type
+- `project_tuple(...)`: decode multiple expressions positionally into a tuple
+
+For `project::<P>()`, `P` is typically a `#[derive(Projection)]` type whose
+field names match the output names. Use `#[projection(rename = "...")]` to map
+DTO fields to differently named source columns, and `#[projection(from = "...")]`
+for join projections that need an explicit source relation.
+
+If the output is expression-based, prefer `project_value(...)` or
+`project_tuple(...)` and assign explicit names with `.alias(...)`.
 
 ### Set queries
 
@@ -250,336 +152,96 @@ After a set query is formed, you can still apply result-level methods such as
 `asc(...)`, `desc(...)`, `nulls_first()`, `nulls_last()`, `limit(...)`,
 `offset(...)`, `fetch()`, `get()`, `exists()`, `count()`, and `explain()`.
 
-```rust
-let user_ids = database
-    .from::<User>()
-    .project_value(User::id())
-    .union(database.from::<Order>().project_value(Order::user_id()))
-    .fetch::<i32>()?;
+Tips: `nulls_first()` and `nulls_last()` only affect the most recently added
+sort key from `asc(...)` or `desc(...)`.
 
-let total_ids = database
-    .from::<User>()
-    .project_value(User::id())
-    .union(database.from::<Order>().project_value(Order::user_id()))
-    .all()
-    .asc(User::id())
-    .limit(3)
-    .count()?;
-# let _ = user_ids;
-# let _ = total_ids;
-# Ok::<(), Box<dyn std::error::Error>>(())
-```
-
-### Struct projections
-
-Use `Database::from::<M>().project::<P>()` or
-`DBTransaction::from::<M>().project::<P>()` to project rows into a dedicated
-DTO-like struct. `P` is typically a `#[derive(Projection)]` type whose field
-names match the projected output names.
-
-Field-level renaming is supported with `#[projection(rename = "...")]`, which
-maps a DTO field to a different source column while still aliasing the result
-back to the DTO field name.
-
-For join projections, you can also pin a field to a specific relation or alias
-with `#[projection(from = "...")]`.
-
-If you need expression-based outputs, prefer `project_value(...)` or
-`project_tuple(...)` and assign explicit names with `.alias(...)`.
-
-Use `project::<P>()` when:
-
-- you want a DTO-style result type instead of full `M`
-- selected outputs are plain columns, optionally with renamed field mapping
-- you want field-name-based decoding instead of positional tuple decoding
-
-### Single-value queries
-
-Use `Database::from::<M>().project_value(expr)` or
-`DBTransaction::from::<M>().project_value(expr)` to project a single
-expression. The resulting query still supports the same filtering, grouping,
-ordering, and subquery composition, and returns typed values via
-`fetch::<T>()` and `get::<T>()`.
-
-This is also the intended entry point for scalar subqueries.
-
-Use `project_value(...)` when:
-
-- the query returns exactly one value per row
-- you want scalar decoding such as `i32`, `String`, or `Option<T>`
-- you are building scalar subqueries
-- the output is an expression or aggregate rather than a DTO field mapping
-
-### Tuple queries
-
-Use `Database::from::<M>().project_tuple(values)` or
-`DBTransaction::from::<M>().project_tuple(values)` to project multiple
-expressions and decode them positionally into a Rust tuple via
-`fetch::<(T1, T2, ...)>()` and `get::<(T1, T2, ...)>()`.
-
-Use `project_tuple(...)` when:
-
-- you need multiple outputs but do not want to define a DTO type
-- the projection contains expressions, aggregates, or custom aliases
-- positional decoding is acceptable
-
-In practice:
-
-- `project::<P>()`: named-field DTO mapping
-- `project_value(...)`: one expression, one decoded value
-- `project_tuple(...)`: multiple expressions, positional decoding
-
-Result helpers:
-
-- `fetch()`: iterate over all matching rows
-- `get()`: fetch at most one row or value with `LIMIT 1` semantics
-- `raw()`: access the underlying tuple/schema iterator directly
-
-### Representative examples
-
-Join with tuple projection:
-
-```rust
-let rows = database
-    .from::<User>()
-    .inner_join::<Order>()
-    .on(User::id().eq(Order::user_id()))
-    .project_tuple((User::name(), Order::amount()))
-    .fetch::<(String, i32)>()?;
-# let _ = rows;
-# Ok::<(), kite_sql::errors::DatabaseError>(())
-```
-
-Struct projection:
-
-```rust
-use kite_sql::Projection;
-
-#[derive(Default, Projection)]
-struct UserSummary {
-    id: i32,
-    #[projection(rename = "user_name")]
-    display_name: String,
-}
-
-let summaries = database
-    .from::<User>()
-    .project::<UserSummary>()
-    .asc(User::id())
-    .fetch()?;
-# Ok::<(), kite_sql::errors::DatabaseError>(())
-```
-
-Value projection with expression:
-
-```rust
-use kite_sql::orm::{case_when, count_all};
-
-let total_users = database
-    .from::<User>()
-    .project_value(count_all().alias("total_users"))
-    .get::<i32>()?;
-
-let age_bucket = database
-    .from::<User>()
-    .project_value(
-        case_when(
-            [(User::age().is_null(), "unknown"), (User::age().lt(20), "minor")],
-            "adult",
-        )
-        .alias("age_bucket"),
-    )
-    .fetch::<String>()?;
-# let _ = total_users;
-# let _ = age_bucket;
-# Ok::<(), kite_sql::errors::DatabaseError>(())
-```
+For richer combinations such as join projections, grouping, scalar subqueries,
+and set queries, prefer the rustdoc on `FromBuilder`, `SetQueryBuilder`,
+`Field`, `QueryValue`, and `QueryExpr`.
 
-Tuple projection with aggregates:
+## Change Operations
 
-```rust
-use kite_sql::orm::{count_all, sum};
+The ORM supports both schema changes and data changes.
 
-let grouped_stats = database
-    .from::<EventLog>()
-    .project_tuple((
-        EventLog::category(),
-        sum(EventLog::score()).alias("total_score"),
-        count_all().alias("total_count"),
-    ))
-    .group_by(EventLog::category())
-    .fetch::<(String, i32, i32)>()?;
-# let _ = grouped_stats;
-# Ok::<(), kite_sql::errors::DatabaseError>(())
-```
+### Schema changes
 
-Scalar subquery:
+On `Database`:
 
-```rust
-let users = database
-    .from::<User>()
-    .in_subquery(
-        User::id(),
-        database.from::<Order>().project_value(Order::user_id()),
-    )
-    .fetch()?;
-# let _ = users;
-# Ok::<(), kite_sql::errors::DatabaseError>(())
-```
+- `create_table::<M>()`
+- `create_table_if_not_exists::<M>()`
+- `migrate::<M>()`
+- `drop_index::<M>(index_name)`
+- `drop_index_if_exists::<M>(index_name)`
+- `drop_table::<M>()`
+- `drop_table_if_exists::<M>()`
+- `truncate::<M>()`
+- `create_view(name, query_builder)`
+- `create_or_replace_view(name, query_builder)`
+- `drop_view(name)`
+- `drop_view_if_exists(name)`
 
-## Key types
+`DBTransaction` does not currently expose the ORM DDL convenience methods.
 
-### `Field<M, T>`
+Typical schema maintenance uses the same model types and query builders:
+create tables from `Model`, truncate by model, and create or replace views from
+ORM queries.
 
-The typed column handle returned by generated accessors such as `User::id()`.
+### Data changes
 
-You usually use it to build expressions:
+For common model-oriented writes:
 
-- comparisons such as `eq`, `gt`, `lt`
-- null checks such as `is_null`
-- pattern matching such as `like`
-- range and membership checks such as `between` and `in_list`
-- `cast`, `cast_to`
-- `alias`
-- subquery predicates such as `in_subquery`
+- `insert::<M>(&model)`
+- `insert_many::<M>(models)`
 
-See the rustdoc on `Field` for the full method surface and minimal examples.
+For query-driven writes, reuse the same filtered `from::<M>()` entrypoint and
+finish with:
 
-### `QueryValue`
+- `insert::<Target>()`
+- `insert_into::<Target>(...)`
+- `overwrite::<Target>()`
+- `overwrite_into::<Target>(...)`
+- `update().set(...).execute()`
+- `delete()`
 
-The value expression type used throughout ORM query building.
+Here `overwrite*` follows the engine's `INSERT OVERWRITE` semantics, meaning
+conflicting target rows are replaced rather than the whole table being cleared.
 
-Use it for:
+For model-oriented writes, use `insert` and `insert_many`. For query-driven
+writes, compose from `from::<M>()` and finish with `insert`, `overwrite`,
+`update`, or `delete`.
 
-- function calls such as `func(name, args)`
-- aggregates such as `count`, `sum`, `avg`, `min`, `max`
-- `CASE` expressions
-- casts
-- aliased projection expressions
-- scalar subqueries
+Query-driven writes are intentionally shaped like read queries first, so the
+same filters, joins, and projections can flow into the final write operation.
 
-`QueryValue` also supports comparison and predicate helpers such as `eq`,
-`ne`, `gt`, `gte`, `lt`, `lte`, `like`, `in_list`, `between`, and subquery
-predicates when you need to keep composing expressions.
+## Introspection / Maintenance
 
-It also supports arithmetic composition such as `add`, `sub`, `mul`, `div`,
-`modulo`, and unary `neg`.
+The ORM also exposes light-weight introspection and maintenance helpers.
 
-See the rustdoc on `QueryValue` for the full method surface and minimal examples.
+On `Database`:
 
-### `QueryExpr`
+- `show_tables()`
+- `show_views()`
+- `describe::<M>()`
+- `from::<M>()...explain()`
+- `analyze::<M>()`
 
-The boolean expression type used for filtering and `HAVING`.
+On `DBTransaction`:
 
-Common helpers:
+- `show_tables()`
+- `show_views()`
+- `describe::<M>()`
 
-- `and(rhs)`
-- `or(rhs)`
-- `not()`
-- `exists(query)`
-- `not_exists(query)`
+These helpers are intended for light-weight inspection around ORM-managed
+tables, without dropping down to raw SQL for common metadata queries.
 
-See the rustdoc on `QueryExpr` for minimal examples.
+## Further reading
 
-### `FromBuilder<Q, M>`
+Detailed method-by-method examples live in the rustdoc for:
 
-The main single-table ORM query builder returned by `from::<M>()`.
-
-It starts in full-model mode and can later switch into:
-
-- `project::<P>()` for DTO structs
-- `project_value(...)` for scalar results
-- `project_tuple(...)` for tuple results
-
-See the rustdoc on `FromBuilder` and `SetQueryBuilder` for the full chainable API.
-
-### `SetQueryBuilder<Q, M>`
-
-The result-level builder produced by `union(...)` and `except(...)`.
-
-It keeps the projection shape of the queries you combine, and supports
-result-level operations such as `all()`, `asc(...)`, `desc(...)`, `limit(...)`,
-`offset(...)`, `fetch()`, `get()`, `exists()`, and `count()`.
-
-## Key traits
-
-### `Model`
-
-The core ORM trait implemented by `#[derive(Model)]`.
-
-Important associated items:
-
-- `type PrimaryKey`
-- `table_name()`
-- `fields()`
-- `columns()`
-- `params(&self)`
-- `primary_key(&self)`
-- cached statement getters such as `select_statement()` and `insert_statement()`
-
-In most cases, you should derive this trait instead of implementing it manually.
-
-### `Projection`
-
-The DTO projection trait implemented by `#[derive(Projection)]`.
-
-It powers `Database::from::<M>().project::<P>()` and
-`DBTransaction::from::<M>().project::<P>()`.
-
-Derived projections declare their source model with
-matching field names, and may use `rename` on fields.
-
-## Extension traits
-
-### `FromDataValue`
-
-Converts a `DataValue` into a Rust value during ORM mapping.
-
-### `ToDataValue`
-
-Converts a Rust value into a `DataValue` for ORM parameters and query expressions.
-
-### `ModelColumnType`
-
-Maps a Rust type to the SQL DDL type used by ORM table creation and migration.
-
-### `StringType`
-
-Marker trait for string-like fields that support `#[model(varchar = N)]` and `#[model(char = N)]`.
-
-### `DecimalType`
-
-Marker trait for decimal-like fields that support precision and scale annotations.
-
-## Migration behavior
-
-`migrate::<M>()` is intended to preserve existing data whenever possible.
-
-Current behavior:
-
-- creates the table if it does not exist
-- adds missing columns
-- drops removed columns
-- applies supported `CHANGE COLUMN` updates for compatible existing columns
-- can infer safe renames in straightforward cases
-- can update type, default, and nullability when supported by the engine
-
-Current limitations:
-
-- primary key changes are rejected
-- unique-constraint changes are rejected
-- the primary-key index is managed by the table and cannot be dropped independently
-- changing the type of an indexed column is intentionally conservative
-
-## Related APIs outside `crate::orm`
-
-ORM models can also be created from arbitrary query results through `ResultIter::orm::<M>()`:
-
-```rust
-let iter = database.run("select id, user_name, age from users")?;
-let users = iter.orm::<User>();
-# let _ = users;
-# Ok::<(), kite_sql::errors::DatabaseError>(())
-```
-
-If you need custom tuple-to-struct mapping without `#[derive(Model)]`, use the lower-level `from_tuple!` macro with `features = ["macros"]`.
+- `Field<M, T>`
+- `QueryValue`
+- `QueryExpr`
+- `FromBuilder<Q, M>`
+- `SetQueryBuilder<Q, M>`
+- `Projection`
+- `Model`

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -133,6 +133,9 @@ The following ORM helpers are available on `Database`.
 
 - `get::<M>(&key) -> Result<Option<M>, DatabaseError>`
 - `fetch::<M>() -> Result<OrmIter<...>, DatabaseError>`
+- `show_tables() -> Result<ProjectValueIter<..., String>, DatabaseError>`
+- `show_views() -> Result<ProjectValueIter<..., String>, DatabaseError>`
+- `describe::<M>() -> Result<OrmIter<..., DescribeColumn>, DatabaseError>`
 - `from::<M>() -> FromBuilder<...>`
 
 ## Transaction ORM APIs
@@ -158,6 +161,9 @@ The following ORM helpers are available on `DBTransaction`.
 
 - `get::<M>(&key) -> Result<Option<M>, DatabaseError>`
 - `fetch::<M>() -> Result<OrmIter<...>, DatabaseError>`
+- `show_tables() -> Result<ProjectValueIter<..., String>, DatabaseError>`
+- `show_views() -> Result<ProjectValueIter<..., String>, DatabaseError>`
+- `describe::<M>() -> Result<OrmIter<..., DescribeColumn>, DatabaseError>`
 - `from::<M>() -> FromBuilder<...>`
 
 `DBTransaction` does not currently expose the ORM DDL convenience methods.
@@ -242,7 +248,7 @@ semantics instead of the default distinct result.
 
 After a set query is formed, you can still apply result-level methods such as
 `asc(...)`, `desc(...)`, `nulls_first()`, `nulls_last()`, `limit(...)`,
-`offset(...)`, `fetch()`, `get()`, `exists()`, and `count()`.
+`offset(...)`, `fetch()`, `get()`, `exists()`, `count()`, and `explain()`.
 
 ```rust
 let user_ids = database

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -161,6 +161,8 @@ The query flow is:
 - optionally add `distinct`, filters, grouping, ordering, and limits
 - either fetch full `M` rows, or switch into a projection with `project::<P>()`,
   `project_value(...)`, or `project_tuple(...)`
+- once the output shape is fixed, you can build set queries with `union(...)`,
+  `except(...)`, and optional `.all()`
 
 ### Field expressions
 
@@ -218,6 +220,18 @@ Built-in helpers are also available for common expression shapes:
 - `not()`
 - `exists(query)`
 - `not_exists(query)`
+
+### Set queries
+
+Set operations are available after the query output shape is fixed.
+
+- model rows: `from::<User>().union(...)`
+- single values: `project_value(...).union(...)`
+- tuples: `project_tuple(...).except(...)`
+- struct projections: `project::<P>().union(...)`
+
+Call `.all()` after `union(...)` or `except(...)` when you want multiset
+semantics instead of the default distinct result.
 
 ### Shared builder methods
 

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -54,8 +54,8 @@ assert_eq!(user.name, "Alice");
 
 let adults = database
     .select::<User>()
-    .filter(User::age().gte(18))
-    .order_by(User::name().asc())
+    .gte(User::age(), 18)
+    .asc(User::name())
     .fetch()?;
 
 for user in adults {
@@ -159,8 +159,11 @@ Generated field accessors return `Field<M, T>`. A field supports:
 - `is_not_null()`
 - `like(pattern)`
 - `not_like(pattern)`
-- `asc()`
-- `desc()`
+
+### Function calls
+
+Use `func(name, args)` to build scalar function calls, including registered UDFs.
+Function calls can be used anywhere a `QueryValue` is accepted, such as filters and sorting.
 
 ### Boolean composition
 
@@ -175,8 +178,21 @@ Generated field accessors return `Field<M, T>`. A field supports:
 `SelectBuilder` supports:
 
 - `filter(expr)`
-- `and_filter(expr)`
-- `order_by(order)`
+- `and(left, right)`
+- `or(left, right)`
+- `not(expr)`
+- `eq(left, right)`
+- `ne(left, right)`
+- `gt(left, right)`
+- `gte(left, right)`
+- `lt(left, right)`
+- `lte(left, right)`
+- `is_null(value)`
+- `is_not_null(value)`
+- `like(value, pattern)`
+- `not_like(value, pattern)`
+- `asc(value)`
+- `desc(value)`
 - `limit(n)`
 - `offset(n)`
 - `raw()`
@@ -188,16 +204,34 @@ Generated field accessors return `Field<M, T>`. A field supports:
 ### Example
 
 ```rust
+use kite_sql::orm::{func, QueryValue};
+
 let exists = database
     .select::<User>()
-    .filter(User::name().like("A%"))
-    .and_filter(User::age().gte(18))
+    .and(User::name().like("A%"), User::age().gte(18))
     .exists()?;
 
 let count = database
     .select::<User>()
-    .filter(User::age().is_not_null())
+    .is_not_null(User::age())
     .count()?;
+
+let top = database
+    .select::<User>()
+    .or(User::id().eq(1), User::id().eq(2))
+    .desc(User::age())
+    .get()?;
+
+let normalized = database
+    .select::<User>()
+    .eq(
+        func(
+            "add_one",
+            [QueryValue::from(User::id())],
+        ),
+        2,
+    )
+    .get()?;
 # Ok::<(), kite_sql::errors::DatabaseError>(())
 ```
 
@@ -243,6 +277,11 @@ Variants:
 
 - `Column { table, column }`
 - `Param(DataValue)`
+- `Function { name, args }`
+
+Helpers:
+
+- `func(name, args)`
 
 ### `CompareOp`
 
@@ -275,10 +314,6 @@ Methods:
 - `and(rhs)`
 - `or(rhs)`
 - `not()`
-
-### `OrderBy`
-
-A typed `ORDER BY` item created from `Field::asc()` or `Field::desc()`.
 
 ### `SelectBuilder<Q, M>`
 

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -193,19 +193,6 @@ Built-in helpers are also available for common expression shapes:
 - `case_when([(cond, value), ...], else_value)`
 - `case_value(expr, [(when, value), ...], else_value)`
 
-### AST access
-
-`QueryValue` and `QueryExpr` are lightweight wrappers around `sqlparser::ast::Expr`.
-They support:
-
-- `from_ast(expr)`
-- `as_ast()`
-- `into_ast()`
-
-This lets you mix the typed ORM helpers with lower-level AST construction when
-KiteSQL already supports an expression shape that the high-level ORM helpers do
-not expose yet.
-
 ### Boolean composition
 
 `QueryExpr` supports:
@@ -314,67 +301,35 @@ In practice:
 
 ### Example
 
+Struct projection:
+
 ```rust
 use kite_sql::Projection;
-use kite_sql::orm::{case_when, count_all, func, sum, QueryExpr, QueryValue};
-use sqlparser::ast::{BinaryOperator, Expr};
 
 #[derive(Default, Projection)]
 struct UserSummary {
     id: i32,
     #[projection(rename = "user_name")]
     display_name: String,
-    age: Option<i32>,
 }
-
-let exists = database
-    .from::<User>()
-    .and(User::name().like("A%"), User::age().gte(18))
-    .exists()?;
-
-let count = database
-    .from::<User>()
-    .is_not_null(User::age())
-    .count()?;
-
-let top = database
-    .from::<User>()
-    .or(User::id().eq(1), User::id().eq(2))
-    .desc(User::age())
-    .get()?;
-
-let normalized = database
-    .from::<User>()
-    .eq(
-        func(
-            "add_one",
-            [QueryValue::from(User::id())],
-        ),
-        2,
-    )
-    .get()?;
-
-let ranged = database
-    .from::<User>()
-    .between(User::id(), 1, 2)
-    .fetch()?;
-
-let typed = database
-    .from::<User>()
-    .eq(User::id().cast("BIGINT")?, 1_i64)
-    .get()?;
 
 let summaries = database
     .from::<User>()
     .project::<UserSummary>()
     .asc(User::id())
     .fetch()?;
+# Ok::<(), kite_sql::errors::DatabaseError>(())
+```
 
-let ids = database
+Single-value projection:
+
+```rust
+use kite_sql::orm::{case_when, count_all};
+
+let total_users = database
     .from::<User>()
-    .project_value(User::id())
-    .asc(User::id())
-    .fetch::<i32>()?;
+    .project_value(count_all().alias("total_users"))
+    .get::<i32>()?;
 
 let age_bucket = database
     .from::<User>()
@@ -385,32 +340,14 @@ let age_bucket = database
         )
         .alias("age_bucket"),
     )
-    .asc(User::id())
     .fetch::<String>()?;
+# Ok::<(), kite_sql::errors::DatabaseError>(())
+```
 
-let total_users = database
-    .from::<User>()
-    .project_value(count_all().alias("total_users"))
-    .get::<i32>()?;
+Tuple projection with aggregates:
 
-let rows = database
-    .from::<User>()
-    .project_tuple((User::id(), User::name()))
-    .asc(User::id())
-    .fetch::<(i32, String)>()?;
-
-let repeated_ages = database
-    .from::<User>()
-    .project_value(User::age())
-    .group_by(User::age())
-    .having(count_all().gt(1))
-    .fetch::<Option<i32>>()?;
-
-let grouped_ids = database
-    .from::<User>()
-    .project_tuple((User::age(), sum(User::id()).alias("total_ids")))
-    .group_by(User::age())
-    .fetch::<(Option<i32>, i32)>()?;
+```rust
+use kite_sql::orm::{count_all, sum};
 
 let grouped_stats = database
     .from::<EventLog>()
@@ -421,14 +358,17 @@ let grouped_stats = database
     ))
     .group_by(EventLog::category())
     .fetch::<(String, i32, i32)>()?;
+# Ok::<(), kite_sql::errors::DatabaseError>(())
+```
 
-let raw_ast = database
+Subqueries:
+
+```rust
+use kite_sql::orm::{func, QueryValue};
+
+let normalized = database
     .from::<User>()
-    .filter(QueryExpr::from_ast(Expr::BinaryOp {
-        left: Box::new(QueryValue::from(User::id()).into_ast()),
-        op: BinaryOperator::Eq,
-        right: Box::new(QueryValue::from(1).into_ast()),
-    }))
+    .eq(func("add_one", [QueryValue::from(User::id())]), 2)
     .get()?;
 
 let uncorrelated = database
@@ -448,41 +388,13 @@ For scalar subqueries such as `IN (subquery)` and `EXISTS (subquery)`, use
 `DBTransaction::from::<M>().project_value(...)` to build a single-column
 subquery directly when the binder expects one expression to be returned.
 
-## Public structs and enums
-
-### `OrmField`
-
-Static metadata for one persisted field.
-
-Fields:
-
-- `column`
-- `placeholder`
-- `primary_key`
-- `unique`
-
-### `OrmColumn`
-
-Static metadata for one persisted column used by table creation and migration.
-
-Fields:
-
-- `name`
-- `ddl_type`
-- `nullable`
-- `primary_key`
-- `unique`
-- `default_expr`
-
-Methods:
-
-- `definition_sql()`
+## Key types
 
 ### `Field<M, T>`
 
-A typed model field handle used by the query builder.
+The typed column handle returned by generated accessors such as `User::id()`.
 
-Common methods:
+You usually use it to build expressions:
 
 - comparisons such as `eq`, `gt`, `lt`
 - null checks such as `is_null`
@@ -494,80 +406,44 @@ Common methods:
 
 ### `QueryValue`
 
-A query-side wrapper around `sqlparser::ast::Expr` for value-producing expressions.
+The value expression type used throughout ORM query building.
 
-Helpers:
+Use it for:
 
-- comparisons such as `eq`, `gt`, `lt`
-- `func(name, args)`
-- `count(expr)`
-- `count_all()`
-- `sum(expr)`
-- `avg(expr)`
-- `min(expr)`
-- `max(expr)`
-- `case_when([(cond, value), ...], else_value)`
-- `case_value(expr, [(when, value), ...], else_value)`
-- `in_list(values)`
-- `not_in_list(values)`
-- `between(low, high)`
-- `not_between(low, high)`
-- `cast("type") -> Result<QueryValue, DatabaseError>`
-- `cast_to(DataType)`
-- `alias(name)`
-- `subquery(query)`
-- `in_subquery(query)`
-- `not_in_subquery(query)`
-- `from_ast(expr)`
-- `as_ast()`
-- `into_ast()`
+- function calls such as `func(name, args)`
+- aggregates such as `count`, `sum`, `avg`, `min`, `max`
+- `CASE` expressions
+- casts
+- aliased projection expressions
+- scalar subqueries
 
-### `ProjectedValue`
-
-A projected select-list item used by `project::<P>()`, `project_value(...)`,
-and `project_tuple(...)`, optionally carrying an alias.
-
-### `CompareOp`
-
-Comparison operator used by `QueryExpr`.
-
-Variants:
-
-- `Eq`
-- `Ne`
-- `Gt`
-- `Gte`
-- `Lt`
-- `Lte`
+`QueryValue` also supports comparison and predicate helpers such as `eq`,
+`ne`, `gt`, `gte`, `lt`, `lte`, `like`, `in_list`, `between`, and subquery
+predicates when you need to keep composing expressions.
 
 ### `QueryExpr`
 
-Boolean-oriented wrapper around `sqlparser::ast::Expr`, typically used in `where`
-clauses and builder filters.
+The boolean expression type used for filtering and `HAVING`.
 
-Methods:
+Common helpers:
 
 - `and(rhs)`
 - `or(rhs)`
 - `not()`
 - `exists(query)`
 - `not_exists(query)`
-- `from_ast(expr)`
-- `as_ast()`
-- `into_ast()`
 
 ### `FromBuilder<Q, M>`
 
-A lightweight single-table ORM query builder.
+The main single-table ORM query builder returned by `from::<M>()`.
 
-`FromBuilder` is the public entry point for ORM DQL construction.
+It starts in full-model mode and can later switch into:
 
-By default it selects full model rows and supports `fetch()` / `get()` into `M`.
-Calling `project::<P>()`, `project_value(...)`, or `project_tuple(...)` keeps
-the same query chain but changes the final decoding shape to a struct, scalar,
-or tuple result.
+- `project::<P>()` for DTO structs
+- `project_value(...)` for scalar results
+- `project_tuple(...)` for tuple results
 
-## Public traits
+## Key traits
 
 ### `Model`
 
@@ -595,6 +471,8 @@ It powers `Database::from::<M>().project::<P>()` and
 Derived projections declare their source model with
 matching field names, and may use `rename` on fields.
 
+## Extension traits
+
 ### `FromDataValue`
 
 Converts a `DataValue` into a Rust value during ORM mapping.
@@ -614,18 +492,6 @@ Marker trait for string-like fields that support `#[model(varchar = N)]` and `#[
 ### `DecimalType`
 
 Marker trait for decimal-like fields that support precision and scale annotations.
-
-### `StatementSource`
-
-Execution abstraction shared by `Database` and `DBTransaction` for prepared ORM statements.
-This is mostly framework infrastructure.
-
-## Public helper function
-
-### `try_get`
-
-`try_get` extracts a named field from a tuple and converts it into a Rust value.
-It is primarily intended for derive-generated code and low-level integrations.
 
 ## Migration behavior
 

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -149,7 +149,7 @@ from one ORM model table.
 The query flow is:
 
 - start with `from::<M>()`
-- optionally add filters, grouping, ordering, and limits
+- optionally add `distinct`, filters, grouping, ordering, and limits
 - either fetch full `M` rows, or switch into a projection with `project::<P>()`,
   `project_value(...)`, or `project_tuple(...)`
 
@@ -210,6 +210,7 @@ methods remain available after calling `project::<P>()`, `project_value(...)`,
 or `project_tuple(...)`:
 
 - `filter(expr)`
+- `distinct()`
 - `and(left, right)`
 - `or(left, right)`
 - `not(expr)`

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -157,6 +157,12 @@ The query flow is:
 
 Generated field accessors return `Field<M, T>`. A field supports:
 
+- `add(value)`
+- `sub(value)`
+- `mul(value)`
+- `div(value)`
+- `modulo(value)`
+- `neg()`
 - `eq(value)`
 - `ne(value)`
 - `gt(value)`
@@ -421,6 +427,9 @@ Use it for:
 `QueryValue` also supports comparison and predicate helpers such as `eq`,
 `ne`, `gt`, `gte`, `lt`, `lte`, `like`, `in_list`, `between`, and subquery
 predicates when you need to keep composing expressions.
+
+It also supports arithmetic composition such as `add`, `sub`, `mul`, `div`,
+`modulo`, and unary `neg`.
 
 ### `QueryExpr`
 

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -121,7 +121,6 @@ The following ORM helpers are available on `Database`.
 - `get::<M>(&key) -> Result<Option<M>, DatabaseError>`
 - `fetch::<M>() -> Result<OrmIter<...>, DatabaseError>`
 - `from::<M>() -> FromBuilder<...>`
-- `from_alias::<M>(alias) -> FromBuilder<...>`
 
 ## Transaction ORM APIs
 
@@ -139,7 +138,6 @@ The following ORM helpers are available on `DBTransaction`.
 - `get::<M>(&key) -> Result<Option<M>, DatabaseError>`
 - `fetch::<M>() -> Result<OrmIter<...>, DatabaseError>`
 - `from::<M>() -> FromBuilder<...>`
-- `from_alias::<M>(alias) -> FromBuilder<...>`
 
 `DBTransaction` does not currently expose the ORM DDL convenience methods.
 
@@ -148,8 +146,12 @@ The following ORM helpers are available on `DBTransaction`.
 `Database::from::<M>()` and `DBTransaction::from::<M>()` start a typed query
 from one ORM model table.
 
-If you need an explicit table alias, use `from_alias::<M>("alias")` and
-re-qualify fields with `Field::qualify("alias")` where needed.
+If you need an explicit relation alias, call `.alias("name")` on a source or
+pending join, and re-qualify fields with `Field::qualify("name")` where needed.
+
+For ordinary multi-table queries, `inner_join::<N>().on(...)` and
+`left_join::<N>().on(...)` are enough. Aliases are mainly useful for self-joins
+or when you want explicit qualification.
 
 The query flow is:
 
@@ -222,6 +224,9 @@ methods remain available after calling `project::<P>()`, `project_value(...)`,
 or `project_tuple(...)`:
 
 - `filter(expr)`
+- `alias(name)`
+- `inner_join::<N>().on(expr)`
+- `left_join::<N>().on(expr)`
 - `distinct()`
 - `and(left, right)`
 - `or(left, right)`
@@ -269,6 +274,19 @@ back to the DTO field name.
 
 If you need expression-based outputs, prefer `project_value(...)` or
 `project_tuple(...)` and assign explicit names with `.alias(...)`.
+
+### Join example
+
+```rust
+let rows = database
+    .from::<User>()
+    .inner_join::<Order>()
+    .on(User::id().eq(Order::user_id()))
+    .project_tuple((User::name(), Order::amount()))
+    .fetch::<(String, i32)>()?;
+# let _ = rows;
+# Ok::<(), kite_sql::errors::DatabaseError>(())
+```
 
 Use `project::<P>()` when:
 

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -121,6 +121,7 @@ The following ORM helpers are available on `Database`.
 - `get::<M>(&key) -> Result<Option<M>, DatabaseError>`
 - `fetch::<M>() -> Result<OrmIter<...>, DatabaseError>`
 - `from::<M>() -> FromBuilder<...>`
+- `from_alias::<M>(alias) -> FromBuilder<...>`
 
 ## Transaction ORM APIs
 
@@ -138,6 +139,7 @@ The following ORM helpers are available on `DBTransaction`.
 - `get::<M>(&key) -> Result<Option<M>, DatabaseError>`
 - `fetch::<M>() -> Result<OrmIter<...>, DatabaseError>`
 - `from::<M>() -> FromBuilder<...>`
+- `from_alias::<M>(alias) -> FromBuilder<...>`
 
 `DBTransaction` does not currently expose the ORM DDL convenience methods.
 
@@ -145,6 +147,9 @@ The following ORM helpers are available on `DBTransaction`.
 
 `Database::from::<M>()` and `DBTransaction::from::<M>()` start a typed query
 from one ORM model table.
+
+If you need an explicit table alias, use `from_alias::<M>("alias")` and
+re-qualify fields with `Field::qualify("alias")` where needed.
 
 The query flow is:
 
@@ -180,6 +185,7 @@ Generated field accessors return `Field<M, T>`. A field supports:
 - `cast("type")`
 - `cast_to(DataType)`
 - `alias(name)`
+- `qualify(relation)`
 - `in_subquery(query)`
 - `not_in_subquery(query)`
 

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -319,16 +319,6 @@ Methods:
 
 A lightweight single-table ORM query builder.
 
-### `DatabaseSelectSource<'a, S>`
-
-Internal source adapter used by `Database::select::<M>()`.
-This type is public for generic completeness, but it is not usually used directly.
-
-### `TransactionSelectSource<'a, 'tx, S>`
-
-Internal source adapter used by `DBTransaction::select::<M>()`.
-This type is public for generic completeness, but it is not usually used directly.
-
 ## Public traits
 
 ### `Model`
@@ -370,11 +360,6 @@ Marker trait for decimal-like fields that support precision and scale annotation
 ### `StatementSource`
 
 Execution abstraction shared by `Database` and `DBTransaction` for prepared ORM statements.
-This is mostly framework infrastructure.
-
-### `SelectSource`
-
-Execution abstraction used by `SelectBuilder`.
 This is mostly framework infrastructure.
 
 ## Public helper function

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -422,6 +422,30 @@ In practice:
 - `project_value(...)`: one expression, one decoded value
 - `project_tuple(...)`: multiple expressions, positional decoding
 
+Result helpers:
+
+- `fetch()`: iterate over all matching rows
+- `get()`: fetch at most one row or value
+- `raw()`: access the underlying tuple/schema iterator directly
+
+Minimal examples:
+
+```rust
+let first_user = database.from::<User>().asc(User::id()).get()?;
+
+let first_id = database
+    .from::<User>()
+    .project_value(User::id())
+    .asc(User::id())
+    .get::<i32>()?;
+
+let raw_rows = database.from::<User>().limit(1).raw()?;
+# raw_rows.done()?;
+# let _ = first_user;
+# let _ = first_id;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
 ### Example
 
 Struct projection:

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -233,6 +233,14 @@ Set operations are available after the query output shape is fixed.
 Call `.all()` after `union(...)` or `except(...)` when you want multiset
 semantics instead of the default distinct result.
 
+After a set query is formed, you can still apply result-level methods such as
+`asc(...)`, `desc(...)`, `limit(...)`, `offset(...)`, `fetch()`, `get()`,
+`exists()`, and `count()`.
+
+For set-query ordering, field inputs are interpreted by their output column
+name, so `asc(User::id())` orders by the projected `id` column of the set
+result.
+
 ```rust
 let user_ids = database
     .from::<User>()
@@ -245,6 +253,8 @@ let total_ids = database
     .project_value(User::id())
     .union(database.from::<Order>().project_value(Order::user_id()))
     .all()
+    .asc(User::id())
+    .limit(3)
     .count()?;
 
 let users_without_orders = database
@@ -313,6 +323,11 @@ or `project_tuple(...)`:
 - `get()`
 - `exists()`
 - `count()`
+
+After `union(...)` or `except(...)`, the resulting set-query builder keeps the
+result-level subset of this API: `all()`, `asc(...)`, `desc(...)`, `limit(...)`,
+`offset(...)`, `raw()`, `fetch()`, `get()`, `exists()`, `count()`,
+`union(...)`, and `except(...)`.
 
 ### Struct projections
 

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -233,6 +233,36 @@ Set operations are available after the query output shape is fixed.
 Call `.all()` after `union(...)` or `except(...)` when you want multiset
 semantics instead of the default distinct result.
 
+```rust
+let user_ids = database
+    .from::<User>()
+    .project_value(User::id())
+    .union(database.from::<Order>().project_value(Order::user_id()))
+    .fetch::<i32>()?;
+
+let total_ids = database
+    .from::<User>()
+    .project_value(User::id())
+    .union(database.from::<Order>().project_value(Order::user_id()))
+    .all()
+    .count()?;
+
+let users_without_orders = database
+    .from::<User>()
+    .in_subquery(
+        User::id(),
+        database
+            .from::<User>()
+            .project_value(User::id())
+            .except(database.from::<Order>().project_value(Order::user_id())),
+    )
+    .fetch()?;
+# let _ = user_ids;
+# let _ = total_ids;
+# let _ = users_without_orders;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
 ### Shared builder methods
 
 `FromBuilder` supports the following methods, and the same chainable query

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -53,7 +53,7 @@ let user = database.get::<User>(&1)?.unwrap();
 assert_eq!(user.name, "Alice");
 
 let adults = database
-    .select::<User>()
+    .from::<User>()
     .gte(User::age(), 18)
     .asc(User::name())
     .fetch()?;
@@ -120,7 +120,7 @@ The following ORM helpers are available on `Database`.
 
 - `get::<M>(&key) -> Result<Option<M>, DatabaseError>`
 - `fetch::<M>() -> Result<OrmIter<...>, DatabaseError>`
-- `select::<M>() -> SelectBuilder<...>`
+- `from::<M>() -> FromBuilder<...>`
 
 ## Transaction ORM APIs
 
@@ -137,13 +137,21 @@ The following ORM helpers are available on `DBTransaction`.
 
 - `get::<M>(&key) -> Result<Option<M>, DatabaseError>`
 - `fetch::<M>() -> Result<OrmIter<...>, DatabaseError>`
-- `select::<M>() -> SelectBuilder<...>`
+- `from::<M>() -> FromBuilder<...>`
 
 `DBTransaction` does not currently expose the ORM DDL convenience methods.
 
 ## Query builder API
 
-`Database::select::<M>()` and `DBTransaction::select::<M>()` return a typed `SelectBuilder`.
+`Database::from::<M>()` and `DBTransaction::from::<M>()` start a typed query
+from one ORM model table.
+
+The query flow is:
+
+- start with `from::<M>()`
+- optionally add filters, grouping, ordering, and limits
+- either fetch full `M` rows, or switch into a projection with `project_value(...)`
+  or `project_tuple(...)`
 
 ### Field expressions
 
@@ -165,6 +173,7 @@ Generated field accessors return `Field<M, T>`. A field supports:
 - `not_between(low, high)`
 - `cast("type")`
 - `cast_to(DataType)`
+- `alias(name)`
 - `in_subquery(query)`
 - `not_in_subquery(query)`
 
@@ -207,9 +216,11 @@ not expose yet.
 - `exists(query)`
 - `not_exists(query)`
 
-### Builder methods
+### Shared builder methods
 
-`SelectBuilder` supports:
+`FromBuilder` supports the following methods, and the same chainable query
+methods remain available after calling `project_value(...)` or
+`project_tuple(...)`:
 
 - `filter(expr)`
 - `and(left, right)`
@@ -247,15 +258,19 @@ not expose yet.
 
 ### Single-value queries
 
-Use `Database::project_value::<M>(expr)` or `DBTransaction::project_value::<M>(expr)`
-to start a single-value projection builder. It supports the same filtering,
-grouping, ordering, and subquery composition, and returns typed values via
+Use `Database::from::<M>().project_value(expr)` or
+`DBTransaction::from::<M>().project_value(expr)` to project a single
+expression. The resulting query still supports the same filtering, grouping,
+ordering, and subquery composition, and returns typed values via
 `fetch::<T>()` and `get::<T>()`.
+
+This is also the intended entry point for scalar subqueries.
 
 ### Tuple queries
 
-Use `Database::project_tuple::<M>(values)` or `DBTransaction::project_tuple::<M>(values)`
-to project multiple expressions and decode them positionally into a Rust tuple via
+Use `Database::from::<M>().project_tuple(values)` or
+`DBTransaction::from::<M>().project_tuple(values)` to project multiple
+expressions and decode them positionally into a Rust tuple via
 `fetch::<(T1, T2, ...)>()` and `get::<(T1, T2, ...)>()`.
 
 ### Example
@@ -265,23 +280,23 @@ use kite_sql::orm::{case_when, count_all, func, sum, QueryExpr, QueryValue};
 use sqlparser::ast::{BinaryOperator, Expr};
 
 let exists = database
-    .select::<User>()
+    .from::<User>()
     .and(User::name().like("A%"), User::age().gte(18))
     .exists()?;
 
 let count = database
-    .select::<User>()
+    .from::<User>()
     .is_not_null(User::age())
     .count()?;
 
 let top = database
-    .select::<User>()
+    .from::<User>()
     .or(User::id().eq(1), User::id().eq(2))
     .desc(User::age())
     .get()?;
 
 let normalized = database
-    .select::<User>()
+    .from::<User>()
     .eq(
         func(
             "add_one",
@@ -292,22 +307,24 @@ let normalized = database
     .get()?;
 
 let ranged = database
-    .select::<User>()
+    .from::<User>()
     .between(User::id(), 1, 2)
     .fetch()?;
 
 let typed = database
-    .select::<User>()
+    .from::<User>()
     .eq(User::id().cast("BIGINT")?, 1_i64)
     .get()?;
 
 let ids = database
-    .project_value::<User, _>(User::id())
+    .from::<User>()
+    .project_value(User::id())
     .asc(User::id())
     .fetch::<i32>()?;
 
 let age_bucket = database
-    .project_value::<User, _>(
+    .from::<User>()
+    .project_value(
         case_when(
             [(User::age().is_null(), "unknown"), (User::age().lt(20), "minor")],
             "adult",
@@ -318,27 +335,31 @@ let age_bucket = database
     .fetch::<String>()?;
 
 let total_users = database
-    .project_value::<User, _>(count_all().alias("total_users"))
+    .from::<User>()
+    .project_value(count_all().alias("total_users"))
     .get::<i32>()?;
 
 let rows = database
-    .project_tuple::<User, _>((User::id(), User::name()))
+    .from::<User>()
+    .project_tuple((User::id(), User::name()))
     .asc(User::id())
     .fetch::<(i32, String)>()?;
 
 let repeated_ages = database
-    .project_value::<User, _>(User::age())
+    .from::<User>()
+    .project_value(User::age())
     .group_by(User::age())
     .having(count_all().gt(1))
     .fetch::<Option<i32>>()?;
 
 let grouped_ids = database
-    .project_tuple::<User, _>((User::age(), sum(User::id()).alias("total_ids")))
+    .from::<User>()
+    .project_tuple((User::age(), sum(User::id()).alias("total_ids")))
     .group_by(User::age())
     .fetch::<(Option<i32>, i32)>()?;
 
 let raw_ast = database
-    .select::<User>()
+    .from::<User>()
     .filter(QueryExpr::from_ast(Expr::BinaryOp {
         left: Box::new(QueryValue::from(User::id()).into_ast()),
         op: BinaryOperator::Eq,
@@ -347,20 +368,21 @@ let raw_ast = database
     .get()?;
 
 let uncorrelated = database
-    .select::<User>()
+    .from::<User>()
     .where_exists(
         database
-            .project_value::<User, _>(User::id())
+            .from::<User>()
+            .project_value(User::id())
             .eq(User::id(), 1),
     )
     .get()?;
 # Ok::<(), kite_sql::errors::DatabaseError>(())
 ```
 
-For scalar subqueries such as `IN (subquery)` and `EXISTS (subquery)`,
-use `Database::project_value::<M>(...)` or `DBTransaction::project_value::<M>(...)`
-to build a single-column subquery directly when the binder expects one expression
-to be returned.
+For scalar subqueries such as `IN (subquery)` and `EXISTS (subquery)`, use
+`Database::from::<M>().project_value(...)` or
+`DBTransaction::from::<M>().project_value(...)` to build a single-column
+subquery directly when the binder expects one expression to be returned.
 
 ## Public structs and enums
 
@@ -396,12 +418,23 @@ Methods:
 
 A typed model field handle used by the query builder.
 
+Common methods:
+
+- comparisons such as `eq`, `gt`, `lt`
+- null checks such as `is_null`
+- pattern matching such as `like`
+- range and membership checks such as `between` and `in_list`
+- `cast`, `cast_to`
+- `alias`
+- subquery predicates such as `in_subquery`
+
 ### `QueryValue`
 
 A query-side wrapper around `sqlparser::ast::Expr` for value-producing expressions.
 
 Helpers:
 
+- comparisons such as `eq`, `gt`, `lt`
 - `func(name, args)`
 - `count(expr)`
 - `count_all()`
@@ -427,7 +460,8 @@ Helpers:
 
 ### `ProjectedValue`
 
-A single projected expression for `project_value`, optionally carrying an alias.
+A projected select-list item used by `project_value(...)` and `project_tuple(...)`,
+optionally carrying an alias.
 
 ### `CompareOp`
 
@@ -458,13 +492,15 @@ Methods:
 - `as_ast()`
 - `into_ast()`
 
-### `SelectBuilder<Q, M>`
+### `FromBuilder<Q, M>`
 
 A lightweight single-table ORM query builder.
 
-Use `Database::project_value::<M>(expr)` or `DBTransaction::project_value::<M>(expr)`
-to create the matching single-value projection builder. It still supports filters,
-ordering, subquery composition, and typed `fetch::<T>()` / `get::<T>()`.
+`FromBuilder` is the public entry point for ORM DQL construction.
+
+By default it selects full model rows and supports `fetch()` / `get()` into `M`.
+Calling `project_value(...)` or `project_tuple(...)` keeps the same query chain
+but changes the final decoding shape to a scalar or tuple result.
 
 ## Public traits
 

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -149,9 +149,9 @@ from one ORM model table.
 If you need an explicit relation alias, call `.alias("name")` on a source or
 pending join, and re-qualify fields with `Field::qualify("name")` where needed.
 
-For ordinary multi-table queries, `inner_join::<N>().on(...)` and
-`left_join::<N>().on(...)` are enough. Aliases are mainly useful for self-joins
-or when you want explicit qualification.
+For ordinary multi-table queries, `inner_join::<N>().on(...)`,
+`left_join::<N>().on(...)`, and `using(...)` cover most cases. Aliases are
+mainly useful for self-joins or when you want explicit qualification.
 
 The query flow is:
 
@@ -226,7 +226,9 @@ or `project_tuple(...)`:
 - `filter(expr)`
 - `alias(name)`
 - `inner_join::<N>().on(expr)`
+- `inner_join::<N>().using(columns)`
 - `left_join::<N>().on(expr)`
+- `left_join::<N>().using(columns)`
 - `distinct()`
 - `and(left, right)`
 - `or(left, right)`

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -5,7 +5,7 @@ KiteSQL provides a built-in ORM behind `features = ["orm"]`.
 The ORM is centered around `#[derive(Model)]`. It generates:
 
 - tuple-to-struct mapping
-- cached CRUD statements
+- cached model statements
 - cached DDL statements
 - migration metadata
 - typed field accessors for query building
@@ -91,7 +91,7 @@ The derive macro generates:
 
 - the `Model` trait implementation
 - tuple mapping from query results into the Rust struct
-- cached statements for DDL and CRUD
+- cached statements for model reads, inserts, and DDL
 - static column metadata for migrations
 - typed field getters such as `User::id()` and `User::name()`
 
@@ -116,8 +116,8 @@ The following ORM helpers are available on `Database`.
 ### DML
 
 - `insert::<M>(&model)`
-- `update::<M>(&model)`
-- `delete_by_id::<M>(&key)`
+- `from::<M>()...update().set(...).execute()`
+- `from::<M>()...delete()`
 
 ### DQL
 
@@ -136,8 +136,8 @@ The following ORM helpers are available on `DBTransaction`.
 ### DML
 
 - `insert::<M>(&model)`
-- `update::<M>(&model)`
-- `delete_by_id::<M>(&key)`
+- `from::<M>()...update().set(...).execute()`
+- `from::<M>()...delete()`
 
 ### DQL
 
@@ -169,6 +169,25 @@ The usual flow is:
   `project_value(...)`, or `project_tuple(...)`
 - once the output shape is fixed, compose set queries with `union(...)`,
   `except(...)`, and optional `.all()`
+
+For native single-table mutations, reuse the same filtered `from::<M>()`
+entrypoint and then switch into `update()` or `delete()`:
+
+```rust
+database
+    .from::<User>()
+    .eq(User::id(), 1)
+    .update()
+    .set(User::name(), "Bob")
+    .set(User::age(), Some(20))
+    .execute()?;
+
+database
+    .from::<User>()
+    .eq(User::id(), 2)
+    .delete()?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
 
 Most expression building starts from generated fields such as `User::id()` and
 `User::name()`. Field values support arithmetic, comparison, null checks,

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -233,6 +233,8 @@ not expose yet.
 - `not_in_subquery(value, query)`
 - `where_exists(query)`
 - `where_not_exists(query)`
+- `group_by(value)`
+- `having(expr)`
 - `asc(value)`
 - `desc(value)`
 - `limit(n)`
@@ -247,8 +249,8 @@ not expose yet.
 
 Use `Database::project_value::<M>(expr)` or `DBTransaction::project_value::<M>(expr)`
 to start a single-value projection builder. It supports the same filtering,
-ordering, and subquery composition, and returns typed values via `fetch::<T>()`
-and `get::<T>()`.
+grouping, ordering, and subquery composition, and returns typed values via
+`fetch::<T>()` and `get::<T>()`.
 
 ### Example
 
@@ -312,6 +314,12 @@ let age_bucket = database
 let total_users = database
     .project_value::<User, _>(count_all().alias("total_users"))
     .get::<i32>()?;
+
+let repeated_ages = database
+    .project_value::<User, _>(User::age())
+    .group_by(User::age())
+    .having(count_all().gt(1))
+    .fetch::<Option<i32>>()?;
 
 let raw_ast = database
     .select::<User>()

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -159,11 +159,32 @@ Generated field accessors return `Field<M, T>`. A field supports:
 - `is_not_null()`
 - `like(pattern)`
 - `not_like(pattern)`
+- `in_list(values)`
+- `not_in_list(values)`
+- `between(low, high)`
+- `not_between(low, high)`
+- `cast("type")`
+- `cast_to(DataType)`
+- `in_subquery(query)`
+- `not_in_subquery(query)`
 
 ### Function calls
 
 Use `func(name, args)` to build scalar function calls, including registered UDFs.
 Function calls can be used anywhere a `QueryValue` is accepted, such as filters and sorting.
+
+### AST access
+
+`QueryValue` and `QueryExpr` are lightweight wrappers around `sqlparser::ast::Expr`.
+They support:
+
+- `from_ast(expr)`
+- `as_ast()`
+- `into_ast()`
+
+This lets you mix the typed ORM helpers with lower-level AST construction when
+KiteSQL already supports an expression shape that the high-level ORM helpers do
+not expose yet.
 
 ### Boolean composition
 
@@ -172,6 +193,8 @@ Function calls can be used anywhere a `QueryValue` is accepted, such as filters 
 - `and(rhs)`
 - `or(rhs)`
 - `not()`
+- `exists(query)`
+- `not_exists(query)`
 
 ### Builder methods
 
@@ -191,10 +214,19 @@ Function calls can be used anywhere a `QueryValue` is accepted, such as filters 
 - `is_not_null(value)`
 - `like(value, pattern)`
 - `not_like(value, pattern)`
+- `in_list(value, values)`
+- `not_in_list(value, values)`
+- `between(value, low, high)`
+- `not_between(value, low, high)`
+- `in_subquery(value, query)`
+- `not_in_subquery(value, query)`
+- `where_exists(query)`
+- `where_not_exists(query)`
 - `asc(value)`
 - `desc(value)`
 - `limit(n)`
 - `offset(n)`
+- `into_query()`
 - `raw()`
 - `fetch()`
 - `get()`
@@ -204,7 +236,8 @@ Function calls can be used anywhere a `QueryValue` is accepted, such as filters 
 ### Example
 
 ```rust
-use kite_sql::orm::{func, QueryValue};
+use kite_sql::orm::{func, QueryExpr, QueryValue};
+use sqlparser::ast::{BinaryOperator, Expr};
 
 let exists = database
     .select::<User>()
@@ -232,8 +265,47 @@ let normalized = database
         2,
     )
     .get()?;
+
+let ranged = database
+    .select::<User>()
+    .between(User::id(), 1, 2)
+    .fetch()?;
+
+let typed = database
+    .select::<User>()
+    .eq(User::id().cast("BIGINT")?, 1_i64)
+    .get()?;
+
+let query_ast = database
+    .select::<User>()
+    .eq(User::id(), 1)
+    .into_query();
+
+let raw_ast = database
+    .select::<User>()
+    .filter(QueryExpr::from_ast(Expr::BinaryOp {
+        left: Box::new(QueryValue::from(User::id()).into_ast()),
+        op: BinaryOperator::Eq,
+        right: Box::new(QueryValue::from(1).into_ast()),
+    }))
+    .get()?;
+
+let mut parser = sqlparser::parser::Parser::new(&sqlparser::dialect::PostgreSqlDialect {})
+    .try_with_sql("select id from users where id = 1")?;
+let exists_subquery = match parser.parse_statement()? {
+    sqlparser::ast::Statement::Query(query) => *query,
+    _ => unreachable!(),
+};
+let uncorrelated = database
+    .select::<User>()
+    .where_exists(exists_subquery)
+    .get()?;
 # Ok::<(), kite_sql::errors::DatabaseError>(())
 ```
+
+`into_query()` exports the current model-select AST, including the default full-row
+projection. For scalar subqueries such as `IN (subquery)` and `EXISTS (subquery)`,
+use a single-column `Query` today if the binder expects one expression to be returned.
 
 ## Public structs and enums
 
@@ -271,17 +343,23 @@ A typed model field handle used by the query builder.
 
 ### `QueryValue`
 
-A query-side value node used by expressions.
-
-Variants:
-
-- `Column { table, column }`
-- `Param(DataValue)`
-- `Function { name, args }`
+A query-side wrapper around `sqlparser::ast::Expr` for value-producing expressions.
 
 Helpers:
 
 - `func(name, args)`
+- `in_list(values)`
+- `not_in_list(values)`
+- `between(low, high)`
+- `not_between(low, high)`
+- `cast("type") -> Result<QueryValue, DatabaseError>`
+- `cast_to(DataType)`
+- `subquery(query)`
+- `in_subquery(query)`
+- `not_in_subquery(query)`
+- `from_ast(expr)`
+- `as_ast()`
+- `into_ast()`
 
 ### `CompareOp`
 
@@ -298,22 +376,19 @@ Variants:
 
 ### `QueryExpr`
 
-Boolean query expression used in `where` clauses.
-
-Variants:
-
-- `Compare`
-- `IsNull`
-- `Like`
-- `And`
-- `Or`
-- `Not`
+Boolean-oriented wrapper around `sqlparser::ast::Expr`, typically used in `where`
+clauses and builder filters.
 
 Methods:
 
 - `and(rhs)`
 - `or(rhs)`
 - `not()`
+- `exists(query)`
+- `not_exists(query)`
+- `from_ast(expr)`
+- `as_ast()`
+- `into_ast()`
 
 ### `SelectBuilder<Q, M>`
 

--- a/src/orm/README.md
+++ b/src/orm/README.md
@@ -272,6 +272,9 @@ Field-level renaming is supported with `#[projection(rename = "...")]`, which
 maps a DTO field to a different source column while still aliasing the result
 back to the DTO field name.
 
+For join projections, you can also pin a field to a specific relation or alias
+with `#[projection(from = "...")]`.
+
 If you need expression-based outputs, prefer `project_value(...)` or
 `project_tuple(...)` and assign explicit names with `.alias(...)`.
 
@@ -284,6 +287,27 @@ let rows = database
     .on(User::id().eq(Order::user_id()))
     .project_tuple((User::name(), Order::amount()))
     .fetch::<(String, i32)>()?;
+# let _ = rows;
+# Ok::<(), kite_sql::errors::DatabaseError>(())
+```
+
+Join DTOs can still use `project::<P>()` when fields declare their source:
+
+```rust
+#[derive(Default, Debug, PartialEq, kite_sql::Projection)]
+struct UserOrderSummary {
+    #[projection(from = "users", rename = "user_name")]
+    display_name: String,
+    #[projection(from = "orders")]
+    amount: i32,
+}
+
+let rows = database
+    .from::<User>()
+    .inner_join::<Order>()
+    .on(User::id().eq(Order::user_id()))
+    .project::<UserOrderSummary>()
+    .fetch()?;
 # let _ = rows;
 # Ok::<(), kite_sql::errors::DatabaseError>(())
 ```

--- a/src/orm/ddl.rs
+++ b/src/orm/ddl.rs
@@ -57,6 +57,50 @@ impl<S: Storage> Database<S> {
         Ok(())
     }
 
+    /// Truncates the model table.
+    pub fn truncate<M: Model>(&self) -> Result<(), DatabaseError> {
+        self.execute(&orm_truncate_statement(M::table_name()), &[])?
+            .done()
+    }
+
+    /// Creates a view from an ORM query builder.
+    pub fn create_view<Q: SubquerySource>(
+        &self,
+        view_name: &str,
+        query: Q,
+    ) -> Result<(), DatabaseError> {
+        self.execute(
+            &orm_create_view_statement(view_name, query.into_subquery(), false),
+            &[],
+        )?
+        .done()
+    }
+
+    /// Creates or replaces a view from an ORM query builder.
+    pub fn create_or_replace_view<Q: SubquerySource>(
+        &self,
+        view_name: &str,
+        query: Q,
+    ) -> Result<(), DatabaseError> {
+        self.execute(
+            &orm_create_view_statement(view_name, query.into_subquery(), true),
+            &[],
+        )?
+        .done()
+    }
+
+    /// Drops a view by name.
+    pub fn drop_view(&self, view_name: &str) -> Result<(), DatabaseError> {
+        self.execute(&orm_drop_view_statement(view_name, false), &[])?
+            .done()
+    }
+
+    /// Drops a view by name if it exists.
+    pub fn drop_view_if_exists(&self, view_name: &str) -> Result<(), DatabaseError> {
+        self.execute(&orm_drop_view_statement(view_name, true), &[])?
+            .done()
+    }
+
     /// Migrates an existing table to match the current model definition.
     ///
     /// This helper creates the table when it does not exist, adds missing

--- a/src/orm/ddl.rs
+++ b/src/orm/ddl.rs
@@ -58,6 +58,25 @@ impl<S: Storage> Database<S> {
     }
 
     /// Truncates the model table.
+    ///
+    /// ```rust
+    /// use kite_sql::db::DataBaseBuilder;
+    /// use kite_sql::Model;
+    ///
+    /// #[derive(Default, Debug, PartialEq, Model)]
+    /// #[model(table = "users")]
+    /// struct User {
+    ///     #[model(primary_key)]
+    ///     id: i32,
+    ///     name: String,
+    /// }
+    ///
+    /// let database = DataBaseBuilder::path(".").build_in_memory().unwrap();
+    /// database.create_table::<User>().unwrap();
+    /// database.insert(&User { id: 1, name: "Alice".to_string() }).unwrap();
+    /// database.truncate::<User>().unwrap();
+    /// assert_eq!(database.fetch::<User>().unwrap().count(), 0);
+    /// ```
     pub fn truncate<M: Model>(&self) -> Result<(), DatabaseError> {
         self.execute(&orm_truncate_statement(M::table_name()), &[])?
             .done()

--- a/src/orm/ddl.rs
+++ b/src/orm/ddl.rs
@@ -135,47 +135,30 @@ impl<S: Storage> Database<S> {
             }
 
             if !model_column_type_matches_catalog(column, current_column) {
-                self.run(::std::format!(
-                    "alter table {} alter column {} type {}",
+                let statement = orm_alter_column_type_statement(
                     M::table_name(),
                     column.name,
-                    column.ddl_type,
-                ))?
-                .done()?;
+                    &column.ddl_type,
+                )?;
+                self.execute(&statement, &[])?.done()?;
             }
 
             if model_column_default(column) != catalog_column_default(current_column) {
-                if let Some(default_expr) = column.default_expr {
-                    self.run(::std::format!(
-                        "alter table {} alter column {} set default {}",
-                        M::table_name(),
-                        column.name,
-                        default_expr,
-                    ))?
-                    .done()?;
-                } else {
-                    self.run(::std::format!(
-                        "alter table {} alter column {} drop default",
-                        M::table_name(),
-                        column.name,
-                    ))?
-                    .done()?;
-                }
+                let statement = orm_alter_column_default_statement(
+                    M::table_name(),
+                    column.name,
+                    column.default_expr,
+                )?;
+                self.execute(&statement, &[])?.done()?;
             }
 
             if column.nullable != current_column.nullable() {
-                let op = if column.nullable {
-                    "drop not null"
-                } else {
-                    "set not null"
-                };
-                self.run(::std::format!(
-                    "alter table {} alter column {} {}",
+                let statement = orm_alter_column_nullability_statement(
                     M::table_name(),
                     column.name,
-                    op,
-                ))?
-                .done()?;
+                    column.nullable,
+                );
+                self.execute(&statement, &[])?.done()?;
             }
         }
 
@@ -217,13 +200,8 @@ impl<S: Storage> Database<S> {
         }
 
         for (old_name, new_name) in rename_pairs {
-            self.run(::std::format!(
-                "alter table {} rename column {} to {}",
-                M::table_name(),
-                old_name,
-                new_name,
-            ))?
-            .done()?;
+            let statement = orm_rename_column_statement(M::table_name(), &old_name, new_name);
+            self.execute(&statement, &[])?.done()?;
         }
 
         for column in table.columns() {
@@ -240,12 +218,8 @@ impl<S: Storage> Database<S> {
                 )));
             }
 
-            self.run(::std::format!(
-                "alter table {} drop column {}",
-                M::table_name(),
-                column.name(),
-            ))?
-            .done()?;
+            let statement = orm_drop_column_statement(M::table_name(), column.name());
+            self.execute(&statement, &[])?.done()?;
         }
 
         for column in columns {
@@ -261,12 +235,8 @@ impl<S: Storage> Database<S> {
                 )));
             }
 
-            self.run(::std::format!(
-                "alter table {} add column {}",
-                M::table_name(),
-                column.definition_sql(),
-            ))?
-            .done()?;
+            let statement = orm_add_column_statement(M::table_name(), column)?;
+            self.execute(&statement, &[])?.done()?;
         }
 
         for statement in M::create_index_if_not_exists_statements() {
@@ -281,16 +251,14 @@ impl<S: Storage> Database<S> {
     /// Primary-key indexes are managed by the table definition itself and
     /// cannot be dropped independently.
     pub fn drop_index<M: Model>(&self, index_name: &str) -> Result<(), DatabaseError> {
-        let sql = ::std::format!("drop index {}.{}", M::table_name(), index_name);
-        let statement = crate::db::prepare(&sql)?;
+        let statement = orm_drop_index_statement(M::table_name(), index_name, false);
 
         self.execute(&statement, &[])?.done()
     }
 
     /// Drops a non-primary-key model index by name if it exists.
     pub fn drop_index_if_exists<M: Model>(&self, index_name: &str) -> Result<(), DatabaseError> {
-        let sql = ::std::format!("drop index if exists {}.{}", M::table_name(), index_name);
-        let statement = crate::db::prepare(&sql)?;
+        let statement = orm_drop_index_statement(M::table_name(), index_name, true);
 
         self.execute(&statement, &[])?.done()
     }

--- a/src/orm/dml.rs
+++ b/src/orm/dml.rs
@@ -35,6 +35,29 @@ impl<S: Storage> Database<S> {
     }
 
     /// Inserts multiple models into their backing table.
+    ///
+    /// ```rust
+    /// use kite_sql::db::DataBaseBuilder;
+    /// use kite_sql::Model;
+    ///
+    /// #[derive(Default, Debug, PartialEq, Model)]
+    /// #[model(table = "users")]
+    /// struct User {
+    ///     #[model(primary_key)]
+    ///     id: i32,
+    ///     name: String,
+    /// }
+    ///
+    /// let database = DataBaseBuilder::path(".").build_in_memory().unwrap();
+    /// database.create_table::<User>().unwrap();
+    /// database
+    ///     .insert_many([
+    ///         User { id: 1, name: "Alice".to_string() },
+    ///         User { id: 2, name: "Bob".to_string() },
+    ///     ])
+    ///     .unwrap();
+    /// assert_eq!(database.fetch::<User>().unwrap().count(), 2);
+    /// ```
     pub fn insert_many<M, I, B>(&self, models: I) -> Result<(), DatabaseError>
     where
         M: Model,

--- a/src/orm/dml.rs
+++ b/src/orm/dml.rs
@@ -32,40 +32,6 @@ impl<S: Storage> Database<S> {
     pub fn insert<M: Model>(&self, model: &M) -> Result<(), DatabaseError> {
         orm_insert::<_, M>(self, model)
     }
-
-    /// Updates a model in its backing table using the primary key.
-    pub fn update<M: Model>(&self, model: &M) -> Result<(), DatabaseError> {
-        orm_update::<_, M>(self, model)
-    }
-
-    /// Deletes a model from its backing table by primary key.
-    ///
-    /// The primary-key type is inferred from `M`, so callers do not need a
-    /// separate generic argument for the key type.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use kite_sql::db::DataBaseBuilder;
-    /// use kite_sql::Model;
-    ///
-    /// #[derive(Default, Debug, PartialEq, Model)]
-    /// #[model(table = "users")]
-    /// struct User {
-    ///     #[model(primary_key)]
-    ///     id: i32,
-    ///     name: String,
-    /// }
-    ///
-    /// let database = DataBaseBuilder::path(".").build_in_memory().unwrap();
-    /// database.create_table::<User>().unwrap();
-    /// database.insert(&User { id: 1, name: "Alice".to_string() }).unwrap();
-    /// database.delete_by_id::<User>(&1).unwrap();
-    /// assert!(database.get::<User>(&1).unwrap().is_none());
-    /// ```
-    pub fn delete_by_id<M: Model>(&self, key: &M::PrimaryKey) -> Result<(), DatabaseError> {
-        orm_delete_by_id::<_, M>(self, key)
-    }
 }
 
 impl<'a, S: Storage> DBTransaction<'a, S> {
@@ -77,15 +43,5 @@ impl<'a, S: Storage> DBTransaction<'a, S> {
     /// Inserts a model inside the current transaction.
     pub fn insert<M: Model>(&mut self, model: &M) -> Result<(), DatabaseError> {
         orm_insert::<_, M>(self, model)
-    }
-
-    /// Updates a model inside the current transaction.
-    pub fn update<M: Model>(&mut self, model: &M) -> Result<(), DatabaseError> {
-        orm_update::<_, M>(self, model)
-    }
-
-    /// Deletes a model by primary key inside the current transaction.
-    pub fn delete_by_id<M: Model>(&mut self, key: &M::PrimaryKey) -> Result<(), DatabaseError> {
-        orm_delete_by_id::<_, M>(self, key)
     }
 }

--- a/src/orm/dml.rs
+++ b/src/orm/dml.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::borrow::Borrow;
 
 impl<S: Storage> Database<S> {
     /// Refreshes optimizer statistics for the model table.
@@ -32,6 +33,19 @@ impl<S: Storage> Database<S> {
     pub fn insert<M: Model>(&self, model: &M) -> Result<(), DatabaseError> {
         orm_insert::<_, M>(self, model)
     }
+
+    /// Inserts multiple models into their backing table.
+    pub fn insert_many<M, I, B>(&self, models: I) -> Result<(), DatabaseError>
+    where
+        M: Model,
+        I: IntoIterator<Item = B>,
+        B: Borrow<M>,
+    {
+        for model in models {
+            orm_insert::<_, M>(self, model.borrow())?;
+        }
+        Ok(())
+    }
 }
 
 impl<'a, S: Storage> DBTransaction<'a, S> {
@@ -43,5 +57,18 @@ impl<'a, S: Storage> DBTransaction<'a, S> {
     /// Inserts a model inside the current transaction.
     pub fn insert<M: Model>(&mut self, model: &M) -> Result<(), DatabaseError> {
         orm_insert::<_, M>(self, model)
+    }
+
+    /// Inserts multiple models inside the current transaction.
+    pub fn insert_many<M, I, B>(&mut self, models: I) -> Result<(), DatabaseError>
+    where
+        M: Model,
+        I: IntoIterator<Item = B>,
+        B: Borrow<M>,
+    {
+        for model in models {
+            orm_insert::<_, M>(&mut *self, model.borrow())?;
+        }
+        Ok(())
     }
 }

--- a/src/orm/dql.rs
+++ b/src/orm/dql.rs
@@ -109,12 +109,6 @@ impl<S: Storage> Database<S> {
     }
 
     /// Lists all view names.
-    ///
-    /// ```rust,ignore
-    /// let views = database.show_views()?.collect::<Result<Vec<_>, _>>()?;
-    /// # let _ = views;
-    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
-    /// ```
     pub fn show_views(
         &self,
     ) -> Result<ProjectValueIter<DatabaseIter<'_, S>, String>, DatabaseError> {

--- a/src/orm/dql.rs
+++ b/src/orm/dql.rs
@@ -62,6 +62,14 @@ impl<S: Storage> Database<S> {
     pub fn select<M: Model>(&self) -> SelectBuilder<&Database<S>, M> {
         SelectBuilder::new(self)
     }
+
+    /// Starts a typed single-value projection query builder for the given model.
+    pub fn project_value<M: Model, V: Into<QueryValue>>(
+        &self,
+        value: V,
+    ) -> ProjectValueBuilder<&Database<S>, M> {
+        SelectBuilder::new_value(self, value)
+    }
 }
 
 impl<'a, S: Storage> DBTransaction<'a, S> {
@@ -78,5 +86,13 @@ impl<'a, S: Storage> DBTransaction<'a, S> {
     /// Starts a typed single-table query builder inside the current transaction.
     pub fn select<M: Model>(&mut self) -> SelectBuilder<&mut DBTransaction<'a, S>, M> {
         SelectBuilder::new(self)
+    }
+
+    /// Starts a typed single-value projection query builder inside the current transaction.
+    pub fn project_value<M: Model, V: Into<QueryValue>>(
+        &mut self,
+        value: V,
+    ) -> ProjectValueBuilder<&mut DBTransaction<'a, S>, M> {
+        SelectBuilder::new_value(self, value)
     }
 }

--- a/src/orm/dql.rs
+++ b/src/orm/dql.rs
@@ -62,6 +62,14 @@ impl<S: Storage> Database<S> {
     pub fn from<M: Model>(&self) -> FromBuilder<&Database<S>, M> {
         FromBuilder::from_inner(QueryBuilder::new(self))
     }
+
+    /// Starts a typed single-table query builder using a table alias.
+    ///
+    /// Fields can be rebound to the alias with [`Field::qualified`] when the
+    /// query needs explicit qualification.
+    pub fn from_alias<M: Model>(&self, alias: impl Into<String>) -> FromBuilder<&Database<S>, M> {
+        FromBuilder::from_inner(QueryBuilder::aliased(self, alias))
+    }
 }
 
 impl<'a, S: Storage> DBTransaction<'a, S> {
@@ -78,5 +86,13 @@ impl<'a, S: Storage> DBTransaction<'a, S> {
     /// Starts a typed single-table query builder inside the current transaction.
     pub fn from<M: Model>(&mut self) -> FromBuilder<&mut DBTransaction<'a, S>, M> {
         FromBuilder::from_inner(QueryBuilder::new(self))
+    }
+
+    /// Starts a typed single-table query builder using a table alias inside the current transaction.
+    pub fn from_alias<M: Model>(
+        &mut self,
+        alias: impl Into<String>,
+    ) -> FromBuilder<&mut DBTransaction<'a, S>, M> {
+        FromBuilder::from_inner(QueryBuilder::aliased(self, alias))
     }
 }

--- a/src/orm/dql.rs
+++ b/src/orm/dql.rs
@@ -59,11 +59,47 @@ impl<S: Storage> Database<S> {
     }
 
     /// Starts a typed single-table query builder for the given model.
+    ///
+    /// ```rust
+    /// use kite_sql::db::DataBaseBuilder;
+    /// use kite_sql::Model;
+    ///
+    /// #[derive(Default, Debug, PartialEq, Model)]
+    /// #[model(table = "users")]
+    /// struct User {
+    ///     #[model(primary_key)]
+    ///     id: i32,
+    ///     name: String,
+    /// }
+    ///
+    /// let database = DataBaseBuilder::path(".").build_in_memory().unwrap();
+    /// database.create_table::<User>().unwrap();
+    /// let count = database.from::<User>().count().unwrap();
+    /// assert_eq!(count, 0);
+    /// ```
     pub fn from<M: Model>(&self) -> FromBuilder<&Database<S>, M> {
         FromBuilder::from_inner(QueryBuilder::new(self))
     }
 
     /// Lists all table names.
+    ///
+    /// ```rust
+    /// use kite_sql::db::DataBaseBuilder;
+    /// use kite_sql::Model;
+    ///
+    /// #[derive(Default, Debug, PartialEq, Model)]
+    /// #[model(table = "users")]
+    /// struct User {
+    ///     #[model(primary_key)]
+    ///     id: i32,
+    ///     name: String,
+    /// }
+    ///
+    /// let database = DataBaseBuilder::path(".").build_in_memory().unwrap();
+    /// database.create_table::<User>().unwrap();
+    /// let tables = database.show_tables().unwrap().collect::<Result<Vec<_>, _>>().unwrap();
+    /// assert!(tables.iter().any(|name| name == "users"));
+    /// ```
     pub fn show_tables(
         &self,
     ) -> Result<ProjectValueIter<DatabaseIter<'_, S>, String>, DatabaseError> {
@@ -73,6 +109,12 @@ impl<S: Storage> Database<S> {
     }
 
     /// Lists all view names.
+    ///
+    /// ```rust,ignore
+    /// let views = database.show_views()?.collect::<Result<Vec<_>, _>>()?;
+    /// # let _ = views;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn show_views(
         &self,
     ) -> Result<ProjectValueIter<DatabaseIter<'_, S>, String>, DatabaseError> {
@@ -82,6 +124,24 @@ impl<S: Storage> Database<S> {
     }
 
     /// Describes the schema of the model table.
+    ///
+    /// ```rust
+    /// use kite_sql::db::DataBaseBuilder;
+    /// use kite_sql::Model;
+    ///
+    /// #[derive(Default, Debug, PartialEq, Model)]
+    /// #[model(table = "users")]
+    /// struct User {
+    ///     #[model(primary_key)]
+    ///     id: i32,
+    ///     name: String,
+    /// }
+    ///
+    /// let database = DataBaseBuilder::path(".").build_in_memory().unwrap();
+    /// database.create_table::<User>().unwrap();
+    /// let columns = database.describe::<User>().unwrap().collect::<Result<Vec<_>, _>>().unwrap();
+    /// assert!(columns.iter().any(|column| column.field == "id"));
+    /// ```
     pub fn describe<M: Model>(
         &self,
     ) -> Result<OrmIter<DatabaseIter<'_, S>, DescribeColumn>, DatabaseError> {

--- a/src/orm/dql.rs
+++ b/src/orm/dql.rs
@@ -59,8 +59,8 @@ impl<S: Storage> Database<S> {
     }
 
     /// Starts a typed single-table query builder for the given model.
-    pub fn select<M: Model>(&self) -> SelectBuilder<DatabaseSelectSource<'_, S>, M> {
-        SelectBuilder::new(DatabaseSelectSource(self))
+    pub fn select<M: Model>(&self) -> SelectBuilder<&Database<S>, M> {
+        SelectBuilder::new(self)
     }
 }
 
@@ -76,7 +76,7 @@ impl<'a, S: Storage> DBTransaction<'a, S> {
     }
 
     /// Starts a typed single-table query builder inside the current transaction.
-    pub fn select<M: Model>(&mut self) -> SelectBuilder<TransactionSelectSource<'_, 'a, S>, M> {
-        SelectBuilder::new(TransactionSelectSource(self))
+    pub fn select<M: Model>(&mut self) -> SelectBuilder<&mut DBTransaction<'a, S>, M> {
+        SelectBuilder::new(self)
     }
 }

--- a/src/orm/dql.rs
+++ b/src/orm/dql.rs
@@ -70,6 +70,14 @@ impl<S: Storage> Database<S> {
     ) -> ProjectValueBuilder<&Database<S>, M> {
         SelectBuilder::new_value(self, value)
     }
+
+    /// Starts a typed tuple projection query builder for the given model.
+    pub fn project_tuple<M: Model, V: IntoProjectedTuple>(
+        &self,
+        values: V,
+    ) -> ProjectTupleBuilder<&Database<S>, M> {
+        SelectBuilder::new_tuple(self, values)
+    }
 }
 
 impl<'a, S: Storage> DBTransaction<'a, S> {
@@ -94,5 +102,13 @@ impl<'a, S: Storage> DBTransaction<'a, S> {
         value: V,
     ) -> ProjectValueBuilder<&mut DBTransaction<'a, S>, M> {
         SelectBuilder::new_value(self, value)
+    }
+
+    /// Starts a typed tuple projection query builder inside the current transaction.
+    pub fn project_tuple<M: Model, V: IntoProjectedTuple>(
+        &mut self,
+        values: V,
+    ) -> ProjectTupleBuilder<&mut DBTransaction<'a, S>, M> {
+        SelectBuilder::new_tuple(self, values)
     }
 }

--- a/src/orm/dql.rs
+++ b/src/orm/dql.rs
@@ -64,7 +64,7 @@ impl<S: Storage> Database<S> {
     }
 
     /// Starts a typed single-value projection query builder for the given model.
-    pub fn project_value<M: Model, V: Into<QueryValue>>(
+    pub fn project_value<M: Model, V: Into<ProjectedValue>>(
         &self,
         value: V,
     ) -> ProjectValueBuilder<&Database<S>, M> {
@@ -89,7 +89,7 @@ impl<'a, S: Storage> DBTransaction<'a, S> {
     }
 
     /// Starts a typed single-value projection query builder inside the current transaction.
-    pub fn project_value<M: Model, V: Into<QueryValue>>(
+    pub fn project_value<M: Model, V: Into<ProjectedValue>>(
         &mut self,
         value: V,
     ) -> ProjectValueBuilder<&mut DBTransaction<'a, S>, M> {

--- a/src/orm/dql.rs
+++ b/src/orm/dql.rs
@@ -62,14 +62,6 @@ impl<S: Storage> Database<S> {
     pub fn from<M: Model>(&self) -> FromBuilder<&Database<S>, M> {
         FromBuilder::from_inner(QueryBuilder::new(self))
     }
-
-    /// Starts a typed single-table query builder using a table alias.
-    ///
-    /// Fields can be rebound to the alias with [`Field::qualified`] when the
-    /// query needs explicit qualification.
-    pub fn from_alias<M: Model>(&self, alias: impl Into<String>) -> FromBuilder<&Database<S>, M> {
-        FromBuilder::from_inner(QueryBuilder::aliased(self, alias))
-    }
 }
 
 impl<'a, S: Storage> DBTransaction<'a, S> {
@@ -86,13 +78,5 @@ impl<'a, S: Storage> DBTransaction<'a, S> {
     /// Starts a typed single-table query builder inside the current transaction.
     pub fn from<M: Model>(&mut self) -> FromBuilder<&mut DBTransaction<'a, S>, M> {
         FromBuilder::from_inner(QueryBuilder::new(self))
-    }
-
-    /// Starts a typed single-table query builder using a table alias inside the current transaction.
-    pub fn from_alias<M: Model>(
-        &mut self,
-        alias: impl Into<String>,
-    ) -> FromBuilder<&mut DBTransaction<'a, S>, M> {
-        FromBuilder::from_inner(QueryBuilder::aliased(self, alias))
     }
 }

--- a/src/orm/dql.rs
+++ b/src/orm/dql.rs
@@ -59,24 +59,8 @@ impl<S: Storage> Database<S> {
     }
 
     /// Starts a typed single-table query builder for the given model.
-    pub fn select<M: Model>(&self) -> SelectBuilder<&Database<S>, M> {
-        SelectBuilder::new(self)
-    }
-
-    /// Starts a typed single-value projection query builder for the given model.
-    pub fn project_value<M: Model, V: Into<ProjectedValue>>(
-        &self,
-        value: V,
-    ) -> ProjectValueBuilder<&Database<S>, M> {
-        SelectBuilder::new_value(self, value)
-    }
-
-    /// Starts a typed tuple projection query builder for the given model.
-    pub fn project_tuple<M: Model, V: IntoProjectedTuple>(
-        &self,
-        values: V,
-    ) -> ProjectTupleBuilder<&Database<S>, M> {
-        SelectBuilder::new_tuple(self, values)
+    pub fn from<M: Model>(&self) -> FromBuilder<&Database<S>, M> {
+        FromBuilder::from_inner(QueryBuilder::new(self))
     }
 }
 
@@ -92,23 +76,7 @@ impl<'a, S: Storage> DBTransaction<'a, S> {
     }
 
     /// Starts a typed single-table query builder inside the current transaction.
-    pub fn select<M: Model>(&mut self) -> SelectBuilder<&mut DBTransaction<'a, S>, M> {
-        SelectBuilder::new(self)
-    }
-
-    /// Starts a typed single-value projection query builder inside the current transaction.
-    pub fn project_value<M: Model, V: Into<ProjectedValue>>(
-        &mut self,
-        value: V,
-    ) -> ProjectValueBuilder<&mut DBTransaction<'a, S>, M> {
-        SelectBuilder::new_value(self, value)
-    }
-
-    /// Starts a typed tuple projection query builder inside the current transaction.
-    pub fn project_tuple<M: Model, V: IntoProjectedTuple>(
-        &mut self,
-        values: V,
-    ) -> ProjectTupleBuilder<&mut DBTransaction<'a, S>, M> {
-        SelectBuilder::new_tuple(self, values)
+    pub fn from<M: Model>(&mut self) -> FromBuilder<&mut DBTransaction<'a, S>, M> {
+        FromBuilder::from_inner(QueryBuilder::new(self))
     }
 }

--- a/src/orm/dql.rs
+++ b/src/orm/dql.rs
@@ -62,6 +62,33 @@ impl<S: Storage> Database<S> {
     pub fn from<M: Model>(&self) -> FromBuilder<&Database<S>, M> {
         FromBuilder::from_inner(QueryBuilder::new(self))
     }
+
+    /// Lists all table names.
+    pub fn show_tables(
+        &self,
+    ) -> Result<ProjectValueIter<DatabaseIter<'_, S>, String>, DatabaseError> {
+        Ok(ProjectValueIter::new(
+            self.execute(&orm_show_tables_statement(), &[])?,
+        ))
+    }
+
+    /// Lists all view names.
+    pub fn show_views(
+        &self,
+    ) -> Result<ProjectValueIter<DatabaseIter<'_, S>, String>, DatabaseError> {
+        Ok(ProjectValueIter::new(
+            self.execute(&orm_show_views_statement(), &[])?,
+        ))
+    }
+
+    /// Describes the schema of the model table.
+    pub fn describe<M: Model>(
+        &self,
+    ) -> Result<OrmIter<DatabaseIter<'_, S>, DescribeColumn>, DatabaseError> {
+        Ok(self
+            .execute(&orm_describe_statement(M::table_name()), &[])?
+            .orm::<DescribeColumn>())
+    }
 }
 
 impl<'a, S: Storage> DBTransaction<'a, S> {
@@ -78,5 +105,32 @@ impl<'a, S: Storage> DBTransaction<'a, S> {
     /// Starts a typed single-table query builder inside the current transaction.
     pub fn from<M: Model>(&mut self) -> FromBuilder<&mut DBTransaction<'a, S>, M> {
         FromBuilder::from_inner(QueryBuilder::new(self))
+    }
+
+    /// Lists all table names inside the current transaction.
+    pub fn show_tables(
+        &mut self,
+    ) -> Result<ProjectValueIter<TransactionIter<'_>, String>, DatabaseError> {
+        Ok(ProjectValueIter::new(
+            self.execute(&orm_show_tables_statement(), &[])?,
+        ))
+    }
+
+    /// Lists all view names inside the current transaction.
+    pub fn show_views(
+        &mut self,
+    ) -> Result<ProjectValueIter<TransactionIter<'_>, String>, DatabaseError> {
+        Ok(ProjectValueIter::new(
+            self.execute(&orm_show_views_statement(), &[])?,
+        ))
+    }
+
+    /// Describes the schema of the model table inside the current transaction.
+    pub fn describe<M: Model>(
+        &mut self,
+    ) -> Result<OrmIter<TransactionIter<'_>, DescribeColumn>, DatabaseError> {
+        Ok(self
+            .execute(&orm_describe_statement(M::table_name()), &[])?
+            .orm::<DescribeColumn>())
     }
 }

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -37,6 +37,7 @@ mod dql;
 /// Static metadata about a single model field.
 ///
 /// This type is primarily consumed by code generated from `#[derive(Model)]`.
+#[doc(hidden)]
 pub struct OrmField {
     pub column: &'static str,
     pub placeholder: &'static str,
@@ -48,6 +49,7 @@ pub struct OrmField {
 /// Static metadata about a single persisted model column.
 ///
 /// This is primarily consumed by the built-in ORM migration helper.
+#[doc(hidden)]
 pub struct OrmColumn {
     pub name: &'static str,
     pub ddl_type: String,
@@ -58,28 +60,6 @@ pub struct OrmColumn {
 }
 
 impl OrmColumn {
-    /// Renders the SQL column definition used by `CREATE TABLE` and migrations.
-    pub fn definition_sql(&self) -> String {
-        let mut column_def = ::std::format!("{} {}", self.name, self.ddl_type);
-
-        if self.primary_key {
-            column_def.push_str(" primary key");
-        } else {
-            if !self.nullable {
-                column_def.push_str(" not null");
-            }
-            if self.unique {
-                column_def.push_str(" unique");
-            }
-        }
-        if let Some(default_expr) = self.default_expr {
-            column_def.push_str(" default ");
-            column_def.push_str(default_expr);
-        }
-
-        column_def
-    }
-
     fn column_def(&self) -> Result<ColumnDef, DatabaseError> {
         let mut options = Vec::new();
 
@@ -127,6 +107,9 @@ impl OrmColumn {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Typed column handle generated for `#[derive(Model)]` query builders.
+///
+/// Most users obtain this through generated model accessors such as `User::id()`
+/// rather than constructing it directly.
 pub struct Field<M, T> {
     table: &'static str,
     column: &'static str,
@@ -137,78 +120,78 @@ trait ValueExpressionOps: Sized {
     fn into_query_value(self) -> QueryValue;
 
     fn eq_expr<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::from_ast(Expr::BinaryOp {
-            left: Box::new(self.into_query_value().into_ast()),
+        QueryExpr::from_expr(Expr::BinaryOp {
+            left: Box::new(self.into_query_value().into_expr()),
             op: CompareOp::Eq.as_ast(),
-            right: Box::new(value.into().into_ast()),
+            right: Box::new(value.into().into_expr()),
         })
     }
 
     fn ne_expr<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::from_ast(Expr::BinaryOp {
-            left: Box::new(self.into_query_value().into_ast()),
+        QueryExpr::from_expr(Expr::BinaryOp {
+            left: Box::new(self.into_query_value().into_expr()),
             op: CompareOp::Ne.as_ast(),
-            right: Box::new(value.into().into_ast()),
+            right: Box::new(value.into().into_expr()),
         })
     }
 
     fn gt_expr<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::from_ast(Expr::BinaryOp {
-            left: Box::new(self.into_query_value().into_ast()),
+        QueryExpr::from_expr(Expr::BinaryOp {
+            left: Box::new(self.into_query_value().into_expr()),
             op: CompareOp::Gt.as_ast(),
-            right: Box::new(value.into().into_ast()),
+            right: Box::new(value.into().into_expr()),
         })
     }
 
     fn gte_expr<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::from_ast(Expr::BinaryOp {
-            left: Box::new(self.into_query_value().into_ast()),
+        QueryExpr::from_expr(Expr::BinaryOp {
+            left: Box::new(self.into_query_value().into_expr()),
             op: CompareOp::Gte.as_ast(),
-            right: Box::new(value.into().into_ast()),
+            right: Box::new(value.into().into_expr()),
         })
     }
 
     fn lt_expr<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::from_ast(Expr::BinaryOp {
-            left: Box::new(self.into_query_value().into_ast()),
+        QueryExpr::from_expr(Expr::BinaryOp {
+            left: Box::new(self.into_query_value().into_expr()),
             op: CompareOp::Lt.as_ast(),
-            right: Box::new(value.into().into_ast()),
+            right: Box::new(value.into().into_expr()),
         })
     }
 
     fn lte_expr<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::from_ast(Expr::BinaryOp {
-            left: Box::new(self.into_query_value().into_ast()),
+        QueryExpr::from_expr(Expr::BinaryOp {
+            left: Box::new(self.into_query_value().into_expr()),
             op: CompareOp::Lte.as_ast(),
-            right: Box::new(value.into().into_ast()),
+            right: Box::new(value.into().into_expr()),
         })
     }
 
     fn is_null_expr(self) -> QueryExpr {
-        QueryExpr::from_ast(Expr::IsNull(Box::new(self.into_query_value().into_ast())))
+        QueryExpr::from_expr(Expr::IsNull(Box::new(self.into_query_value().into_expr())))
     }
 
     fn is_not_null_expr(self) -> QueryExpr {
-        QueryExpr::from_ast(Expr::IsNotNull(Box::new(
-            self.into_query_value().into_ast(),
+        QueryExpr::from_expr(Expr::IsNotNull(Box::new(
+            self.into_query_value().into_expr(),
         )))
     }
 
     fn like_expr<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
-        QueryExpr::from_ast(Expr::Like {
+        QueryExpr::from_expr(Expr::Like {
             negated: false,
-            expr: Box::new(self.into_query_value().into_ast()),
-            pattern: Box::new(pattern.into().into_ast()),
+            expr: Box::new(self.into_query_value().into_expr()),
+            pattern: Box::new(pattern.into().into_expr()),
             escape_char: None,
             any: false,
         })
     }
 
     fn not_like_expr<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
-        QueryExpr::from_ast(Expr::Like {
+        QueryExpr::from_expr(Expr::Like {
             negated: true,
-            expr: Box::new(self.into_query_value().into_ast()),
-            pattern: Box::new(pattern.into().into_ast()),
+            expr: Box::new(self.into_query_value().into_expr()),
+            pattern: Box::new(pattern.into().into_expr()),
             escape_char: None,
             any: false,
         })
@@ -219,12 +202,12 @@ trait ValueExpressionOps: Sized {
         I: IntoIterator<Item = V>,
         V: Into<QueryValue>,
     {
-        QueryExpr::from_ast(Expr::InList {
-            expr: Box::new(self.into_query_value().into_ast()),
+        QueryExpr::from_expr(Expr::InList {
+            expr: Box::new(self.into_query_value().into_expr()),
             list: values
                 .into_iter()
                 .map(Into::into)
-                .map(QueryValue::into_ast)
+                .map(QueryValue::into_expr)
                 .collect(),
             negated: false,
         })
@@ -235,23 +218,23 @@ trait ValueExpressionOps: Sized {
         I: IntoIterator<Item = V>,
         V: Into<QueryValue>,
     {
-        QueryExpr::from_ast(Expr::InList {
-            expr: Box::new(self.into_query_value().into_ast()),
+        QueryExpr::from_expr(Expr::InList {
+            expr: Box::new(self.into_query_value().into_expr()),
             list: values
                 .into_iter()
                 .map(Into::into)
-                .map(QueryValue::into_ast)
+                .map(QueryValue::into_expr)
                 .collect(),
             negated: true,
         })
     }
 
     fn between_expr<L: Into<QueryValue>, H: Into<QueryValue>>(self, low: L, high: H) -> QueryExpr {
-        QueryExpr::from_ast(Expr::Between {
-            expr: Box::new(self.into_query_value().into_ast()),
+        QueryExpr::from_expr(Expr::Between {
+            expr: Box::new(self.into_query_value().into_expr()),
             negated: false,
-            low: Box::new(low.into().into_ast()),
-            high: Box::new(high.into().into_ast()),
+            low: Box::new(low.into().into_expr()),
+            high: Box::new(high.into().into_expr()),
         })
     }
 
@@ -260,11 +243,11 @@ trait ValueExpressionOps: Sized {
         low: L,
         high: H,
     ) -> QueryExpr {
-        QueryExpr::from_ast(Expr::Between {
-            expr: Box::new(self.into_query_value().into_ast()),
+        QueryExpr::from_expr(Expr::Between {
+            expr: Box::new(self.into_query_value().into_expr()),
             negated: true,
-            low: Box::new(low.into().into_ast()),
-            high: Box::new(high.into().into_ast()),
+            low: Box::new(low.into().into_expr()),
+            high: Box::new(high.into().into_expr()),
         })
     }
 
@@ -273,9 +256,9 @@ trait ValueExpressionOps: Sized {
     }
 
     fn cast_to_value(self, data_type: DataType) -> QueryValue {
-        QueryValue::from_ast(Expr::Cast {
+        QueryValue::from_expr(Expr::Cast {
             kind: CastKind::Cast,
-            expr: Box::new(self.into_query_value().into_ast()),
+            expr: Box::new(self.into_query_value().into_expr()),
             data_type,
             array: false,
             format: None,
@@ -285,23 +268,23 @@ trait ValueExpressionOps: Sized {
     fn alias_value(self, alias: &str) -> ProjectedValue {
         ProjectedValue {
             item: SelectItem::ExprWithAlias {
-                expr: self.into_query_value().into_ast(),
+                expr: self.into_query_value().into_expr(),
                 alias: ident(alias),
             },
         }
     }
 
     fn in_subquery_expr<S: SubquerySource>(self, subquery: S) -> QueryExpr {
-        QueryExpr::from_ast(Expr::InSubquery {
-            expr: Box::new(self.into_query_value().into_ast()),
+        QueryExpr::from_expr(Expr::InSubquery {
+            expr: Box::new(self.into_query_value().into_expr()),
             subquery: Box::new(subquery.into_subquery()),
             negated: false,
         })
     }
 
     fn not_in_subquery_expr<S: SubquerySource>(self, subquery: S) -> QueryExpr {
-        QueryExpr::from_ast(Expr::InSubquery {
-            expr: Box::new(self.into_query_value().into_ast()),
+        QueryExpr::from_expr(Expr::InSubquery {
+            expr: Box::new(self.into_query_value().into_expr()),
             subquery: Box::new(subquery.into_subquery()),
             negated: true,
         })
@@ -309,6 +292,7 @@ trait ValueExpressionOps: Sized {
 }
 
 impl<M, T> Field<M, T> {
+    #[doc(hidden)]
     pub const fn new(table: &'static str, column: &'static str) -> Self {
         Self {
             table,
@@ -318,52 +302,63 @@ impl<M, T> Field<M, T> {
     }
 
     fn value(self) -> QueryValue {
-        QueryValue::from_ast(Expr::CompoundIdentifier(vec![
+        QueryValue::from_expr(Expr::CompoundIdentifier(vec![
             ident(self.table),
             ident(self.column),
         ]))
     }
 
+    /// Builds `field = value`.
     pub fn eq<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
         ValueExpressionOps::eq_expr(self, value)
     }
 
+    /// Builds `field <> value`.
     pub fn ne<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
         ValueExpressionOps::ne_expr(self, value)
     }
 
+    /// Builds `field > value`.
     pub fn gt<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
         ValueExpressionOps::gt_expr(self, value)
     }
 
+    /// Builds `field >= value`.
     pub fn gte<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
         ValueExpressionOps::gte_expr(self, value)
     }
 
+    /// Builds `field < value`.
     pub fn lt<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
         ValueExpressionOps::lt_expr(self, value)
     }
 
+    /// Builds `field <= value`.
     pub fn lte<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
         ValueExpressionOps::lte_expr(self, value)
     }
 
+    /// Builds `field IS NULL`.
     pub fn is_null(self) -> QueryExpr {
         ValueExpressionOps::is_null_expr(self)
     }
 
+    /// Builds `field IS NOT NULL`.
     pub fn is_not_null(self) -> QueryExpr {
         ValueExpressionOps::is_not_null_expr(self)
     }
 
+    /// Builds `field LIKE pattern`.
     pub fn like<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
         ValueExpressionOps::like_expr(self, pattern)
     }
 
+    /// Builds `field NOT LIKE pattern`.
     pub fn not_like<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
         ValueExpressionOps::not_like_expr(self, pattern)
     }
 
+    /// Builds `field IN (...)`.
     pub fn in_list<I, V>(self, values: I) -> QueryExpr
     where
         I: IntoIterator<Item = V>,
@@ -372,6 +367,7 @@ impl<M, T> Field<M, T> {
         ValueExpressionOps::in_list_expr(self, values)
     }
 
+    /// Builds `field NOT IN (...)`.
     pub fn not_in_list<I, V>(self, values: I) -> QueryExpr
     where
         I: IntoIterator<Item = V>,
@@ -380,10 +376,12 @@ impl<M, T> Field<M, T> {
         ValueExpressionOps::not_in_list_expr(self, values)
     }
 
+    /// Builds `field BETWEEN low AND high`.
     pub fn between<L: Into<QueryValue>, H: Into<QueryValue>>(self, low: L, high: H) -> QueryExpr {
         ValueExpressionOps::between_expr(self, low, high)
     }
 
+    /// Builds `field NOT BETWEEN low AND high`.
     pub fn not_between<L: Into<QueryValue>, H: Into<QueryValue>>(
         self,
         low: L,
@@ -392,22 +390,27 @@ impl<M, T> Field<M, T> {
         ValueExpressionOps::not_between_expr(self, low, high)
     }
 
+    /// Casts this field using a SQL type string such as `"BIGINT"`.
     pub fn cast(self, data_type: &str) -> Result<QueryValue, DatabaseError> {
         ValueExpressionOps::cast_value(self, data_type)
     }
 
+    /// Casts this field using an explicit SQL AST data type.
     pub fn cast_to(self, data_type: DataType) -> QueryValue {
         ValueExpressionOps::cast_to_value(self, data_type)
     }
 
+    /// Aliases this field in the select list.
     pub fn alias(self, alias: &str) -> ProjectedValue {
         ValueExpressionOps::alias_value(self, alias)
     }
 
+    /// Builds `field IN (subquery)`.
     pub fn in_subquery<S: SubquerySource>(self, subquery: S) -> QueryExpr {
         ValueExpressionOps::in_subquery_expr(self, subquery)
     }
 
+    /// Builds `field NOT IN (subquery)`.
     pub fn not_in_subquery<S: SubquerySource>(self, subquery: S) -> QueryExpr {
         ValueExpressionOps::not_in_subquery_expr(self, subquery)
     }
@@ -415,18 +418,30 @@ impl<M, T> Field<M, T> {
 
 #[derive(Debug, Clone, PartialEq)]
 /// A lightweight ORM expression wrapper for value-producing SQL AST nodes.
+///
+/// `QueryValue` is the common currency for computed ORM expressions such as
+/// functions, aggregates, `CASE` expressions, casts, and subqueries.
+///
+/// It also supports the same comparison and predicate-style composition used by
+/// [`Field`], including helpers such as `eq`, `gt`, `like`, `in_list`, and
+/// `between`.
 pub struct QueryValue {
     expr: Expr,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 /// A projected ORM expression, optionally carrying a select-list alias.
+///
+/// This is typically produced by calling `.alias(...)` on a [`Field`] or
+/// [`QueryValue`], and then passed into `project_value(...)` or
+/// `project_tuple(...)`.
+#[doc(hidden)]
 pub struct ProjectedValue {
     item: SelectItem,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CompareOp {
+enum CompareOp {
     Eq,
     Ne,
     Gt,
@@ -437,10 +452,22 @@ pub enum CompareOp {
 
 #[derive(Debug, Clone, PartialEq)]
 /// A lightweight ORM expression wrapper for predicate-oriented SQL AST nodes.
+///
+/// `QueryExpr` is used for `WHERE` and `HAVING` clauses, as well as boolean
+/// composition such as `and`, `or`, and `not`.
 pub struct QueryExpr {
     expr: Expr,
 }
 
+/// Builds a scalar function call expression.
+///
+/// This is commonly used for UDFs registered on the database.
+///
+/// ```rust,ignore
+/// let expr = kite_sql::orm::func("add_one", [User::id()]);
+/// let row = database.from::<User>().eq(expr, 2).get()?;
+/// # Ok::<(), kite_sql::errors::DatabaseError>(())
+/// ```
 pub fn func<N, I, V>(name: N, args: I) -> QueryValue
 where
     N: Into<String>,
@@ -450,30 +477,53 @@ where
     QueryValue::function(name, args)
 }
 
+/// Builds `count(expr)`.
 pub fn count<V: Into<QueryValue>>(value: V) -> QueryValue {
     QueryValue::aggregate("count", [value.into()])
 }
 
+/// Builds `count(*)`.
+///
+/// ```rust,ignore
+/// let total = database
+///     .from::<User>()
+///     .project_value(kite_sql::orm::count_all().alias("total_users"))
+///     .get::<i32>()?;
+/// # Ok::<(), kite_sql::errors::DatabaseError>(())
+/// ```
 pub fn count_all() -> QueryValue {
     QueryValue::aggregate_all("count")
 }
 
+/// Builds `sum(expr)`.
 pub fn sum<V: Into<QueryValue>>(value: V) -> QueryValue {
     QueryValue::aggregate("sum", [value.into()])
 }
 
+/// Builds `avg(expr)`.
 pub fn avg<V: Into<QueryValue>>(value: V) -> QueryValue {
     QueryValue::aggregate("avg", [value.into()])
 }
 
+/// Builds `min(expr)`.
 pub fn min<V: Into<QueryValue>>(value: V) -> QueryValue {
     QueryValue::aggregate("min", [value.into()])
 }
 
+/// Builds `max(expr)`.
 pub fn max<V: Into<QueryValue>>(value: V) -> QueryValue {
     QueryValue::aggregate("max", [value.into()])
 }
 
+/// Builds a searched `CASE WHEN ... THEN ... ELSE ... END` expression.
+///
+/// ```rust,ignore
+/// let bucket = kite_sql::orm::case_when(
+///     [(User::age().is_null(), "unknown"), (User::age().lt(20), "minor")],
+///     "adult",
+/// );
+/// # let _ = bucket;
+/// ```
 pub fn case_when<I, C, R, E>(conditions: I, else_result: E) -> QueryValue
 where
     I: IntoIterator<Item = (C, R)>,
@@ -484,6 +534,7 @@ where
     QueryValue::searched_case(conditions, else_result)
 }
 
+/// Builds a simple `CASE value WHEN ... THEN ... ELSE ... END` expression.
 pub fn case_value<O, I, W, R, E>(operand: O, conditions: I, else_result: E) -> QueryValue
 where
     O: Into<QueryValue>,
@@ -496,50 +547,59 @@ where
 }
 
 impl QueryExpr {
-    pub fn from_ast(expr: Expr) -> QueryExpr {
+    fn from_expr(expr: Expr) -> QueryExpr {
         Self { expr }
     }
 
-    pub fn as_ast(&self) -> &Expr {
-        &self.expr
-    }
-
-    pub fn into_ast(self) -> Expr {
+    fn into_expr(self) -> Expr {
         self.expr
     }
 
+    /// Combines two predicates with `AND`.
     pub fn and(self, rhs: QueryExpr) -> QueryExpr {
-        QueryExpr::from_ast(Expr::BinaryOp {
-            left: Box::new(nested_expr(self.into_ast())),
+        QueryExpr::from_expr(Expr::BinaryOp {
+            left: Box::new(nested_expr(self.into_expr())),
             op: SqlBinaryOperator::And,
-            right: Box::new(nested_expr(rhs.into_ast())),
+            right: Box::new(nested_expr(rhs.into_expr())),
         })
     }
 
+    /// Combines two predicates with `OR`.
     pub fn or(self, rhs: QueryExpr) -> QueryExpr {
-        QueryExpr::from_ast(Expr::BinaryOp {
-            left: Box::new(nested_expr(self.into_ast())),
+        QueryExpr::from_expr(Expr::BinaryOp {
+            left: Box::new(nested_expr(self.into_expr())),
             op: SqlBinaryOperator::Or,
-            right: Box::new(nested_expr(rhs.into_ast())),
+            right: Box::new(nested_expr(rhs.into_expr())),
         })
     }
 
+    /// Negates a predicate with `NOT`.
     pub fn not(self) -> QueryExpr {
-        QueryExpr::from_ast(Expr::UnaryOp {
+        QueryExpr::from_expr(Expr::UnaryOp {
             op: sqlparser::ast::UnaryOperator::Not,
-            expr: Box::new(nested_expr(self.into_ast())),
+            expr: Box::new(nested_expr(self.into_expr())),
         })
     }
 
+    /// Builds an `EXISTS (subquery)` predicate.
+    ///
+    /// ```rust,ignore
+    /// let expr = kite_sql::orm::QueryExpr::exists(
+    ///     database.from::<User>().project_value(User::id()).eq(User::id(), 1),
+    /// );
+    /// let found = database.from::<User>().filter(expr).exists()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn exists<S: SubquerySource>(subquery: S) -> QueryExpr {
-        QueryExpr::from_ast(Expr::Exists {
+        QueryExpr::from_expr(Expr::Exists {
             subquery: Box::new(subquery.into_subquery()),
             negated: false,
         })
     }
 
+    /// Builds a `NOT EXISTS (subquery)` predicate.
     pub fn not_exists<S: SubquerySource>(subquery: S) -> QueryExpr {
-        QueryExpr::from_ast(Expr::Exists {
+        QueryExpr::from_expr(Expr::Exists {
             subquery: Box::new(subquery.into_subquery()),
             negated: true,
         })
@@ -559,7 +619,7 @@ impl SortExpr {
 
     fn into_ast(self) -> OrderByExpr {
         OrderByExpr {
-            expr: self.value.into_ast(),
+            expr: self.value.into_expr(),
             options: OrderByOptions {
                 asc: Some(!self.desc),
                 nulls_first: None,
@@ -570,18 +630,21 @@ impl SortExpr {
 }
 
 impl QueryValue {
-    pub fn from_ast(expr: Expr) -> Self {
+    fn from_expr(expr: Expr) -> Self {
         Self { expr }
     }
 
-    pub fn as_ast(&self) -> &Expr {
-        &self.expr
-    }
-
-    pub fn into_ast(self) -> Expr {
+    fn into_expr(self) -> Expr {
         self.expr
     }
 
+    /// Builds a scalar function call.
+    ///
+    /// ```rust,ignore
+    /// let expr = kite_sql::orm::QueryValue::function("add_one", [User::id()]);
+    /// let row = database.from::<User>().eq(expr, 2).get()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn function<N, I, V>(name: N, args: I) -> Self
     where
         N: Into<String>,
@@ -592,11 +655,12 @@ impl QueryValue {
             name,
             args.into_iter()
                 .map(Into::into)
-                .map(QueryValue::into_ast)
+                .map(QueryValue::into_expr)
                 .map(FunctionArgExpr::Expr),
         )
     }
 
+    /// Builds an aggregate function call such as `sum(expr)` or `count(expr)`.
     pub fn aggregate<N, I, V>(name: N, args: I) -> Self
     where
         N: Into<String>,
@@ -606,19 +670,22 @@ impl QueryValue {
         Self::function(name, args)
     }
 
+    /// Builds an aggregate function call that uses `*`, such as `count(*)`.
     pub fn aggregate_all(name: impl Into<String>) -> Self {
         Self::function_with_args(name, [FunctionArgExpr::Wildcard])
     }
 
+    /// Assigns a select-list alias to this value expression.
     pub fn alias(self, alias: &str) -> ProjectedValue {
         ProjectedValue {
             item: SelectItem::ExprWithAlias {
-                expr: self.into_ast(),
+                expr: self.into_expr(),
                 alias: ident(alias),
             },
         }
     }
 
+    /// Builds a searched `CASE WHEN ... THEN ... ELSE ... END` expression.
     pub fn searched_case<I, C, R, E>(conditions: I, else_result: E) -> Self
     where
         I: IntoIterator<Item = (C, R)>,
@@ -626,21 +693,22 @@ impl QueryValue {
         R: Into<QueryValue>,
         E: Into<QueryValue>,
     {
-        Self::from_ast(Expr::Case {
+        Self::from_expr(Expr::Case {
             case_token: AttachedToken::empty(),
             end_token: AttachedToken::empty(),
             operand: None,
             conditions: conditions
                 .into_iter()
                 .map(|(condition, result)| CaseWhen {
-                    condition: condition.into().into_ast(),
-                    result: result.into().into_ast(),
+                    condition: condition.into().into_expr(),
+                    result: result.into().into_expr(),
                 })
                 .collect(),
-            else_result: Some(Box::new(else_result.into().into_ast())),
+            else_result: Some(Box::new(else_result.into().into_expr())),
         })
     }
 
+    /// Builds a simple `CASE value WHEN ... THEN ... ELSE ... END` expression.
     pub fn simple_case<O, I, W, R, E>(operand: O, conditions: I, else_result: E) -> Self
     where
         O: Into<QueryValue>,
@@ -649,61 +717,72 @@ impl QueryValue {
         R: Into<QueryValue>,
         E: Into<QueryValue>,
     {
-        Self::from_ast(Expr::Case {
+        Self::from_expr(Expr::Case {
             case_token: AttachedToken::empty(),
             end_token: AttachedToken::empty(),
-            operand: Some(Box::new(operand.into().into_ast())),
+            operand: Some(Box::new(operand.into().into_expr())),
             conditions: conditions
                 .into_iter()
                 .map(|(condition, result)| CaseWhen {
-                    condition: condition.into().into_ast(),
-                    result: result.into().into_ast(),
+                    condition: condition.into().into_expr(),
+                    result: result.into().into_expr(),
                 })
                 .collect(),
-            else_result: Some(Box::new(else_result.into().into_ast())),
+            else_result: Some(Box::new(else_result.into().into_expr())),
         })
     }
 
+    /// Builds `expr = value`.
     pub fn eq<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
         ValueExpressionOps::eq_expr(self, value)
     }
 
+    /// Builds `expr <> value`.
     pub fn ne<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
         ValueExpressionOps::ne_expr(self, value)
     }
 
+    /// Builds `expr > value`.
     pub fn gt<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
         ValueExpressionOps::gt_expr(self, value)
     }
 
+    /// Builds `expr >= value`.
     pub fn gte<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
         ValueExpressionOps::gte_expr(self, value)
     }
 
+    /// Builds `expr < value`.
     pub fn lt<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
         ValueExpressionOps::lt_expr(self, value)
     }
 
+    /// Builds `expr <= value`.
     pub fn lte<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
         ValueExpressionOps::lte_expr(self, value)
     }
 
+    /// Builds `expr IS NULL`.
     pub fn is_null(self) -> QueryExpr {
         ValueExpressionOps::is_null_expr(self)
     }
 
+    /// Builds `expr IS NOT NULL`.
     pub fn is_not_null(self) -> QueryExpr {
         ValueExpressionOps::is_not_null_expr(self)
     }
 
+    /// Builds `expr LIKE pattern`.
     pub fn like<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
         ValueExpressionOps::like_expr(self, pattern)
     }
 
+    /// Builds `expr NOT LIKE pattern`.
     pub fn not_like<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
         ValueExpressionOps::not_like_expr(self, pattern)
     }
 
+    /// Builds `expr IN (...)`.
     pub fn in_list<I, V>(self, values: I) -> QueryExpr
     where
         I: IntoIterator<Item = V>,
@@ -712,6 +791,7 @@ impl QueryValue {
         ValueExpressionOps::in_list_expr(self, values)
     }
 
+    /// Builds `expr NOT IN (...)`.
     pub fn not_in_list<I, V>(self, values: I) -> QueryExpr
     where
         I: IntoIterator<Item = V>,
@@ -720,10 +800,12 @@ impl QueryValue {
         ValueExpressionOps::not_in_list_expr(self, values)
     }
 
+    /// Builds `expr BETWEEN low AND high`.
     pub fn between<L: Into<QueryValue>, H: Into<QueryValue>>(self, low: L, high: H) -> QueryExpr {
         ValueExpressionOps::between_expr(self, low, high)
     }
 
+    /// Builds `expr NOT BETWEEN low AND high`.
     pub fn not_between<L: Into<QueryValue>, H: Into<QueryValue>>(
         self,
         low: L,
@@ -732,22 +814,35 @@ impl QueryValue {
         ValueExpressionOps::not_between_expr(self, low, high)
     }
 
+    /// Casts this expression using a SQL type string such as `"BIGINT"`.
     pub fn cast(self, data_type: &str) -> Result<QueryValue, DatabaseError> {
         ValueExpressionOps::cast_value(self, data_type)
     }
 
+    /// Casts this expression using an explicit SQL AST data type.
+    ///
+    /// ```rust,ignore
+    /// use sqlparser::ast::DataType;
+    ///
+    /// let expr = User::id().cast_to(DataType::BigInt(None));
+    /// let row = database.from::<User>().eq(expr, 1_i64).get()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn cast_to(self, data_type: DataType) -> QueryValue {
         ValueExpressionOps::cast_to_value(self, data_type)
     }
 
+    /// Wraps a query builder as a scalar subquery expression.
     pub fn subquery<S: SubquerySource>(query: S) -> QueryValue {
-        QueryValue::from_ast(Expr::Subquery(Box::new(query.into_subquery())))
+        QueryValue::from_expr(Expr::Subquery(Box::new(query.into_subquery())))
     }
 
+    /// Builds `expr IN (subquery)`.
     pub fn in_subquery<S: SubquerySource>(self, subquery: S) -> QueryExpr {
         ValueExpressionOps::in_subquery_expr(self, subquery)
     }
 
+    /// Builds `expr NOT IN (subquery)`.
     pub fn not_in_subquery<S: SubquerySource>(self, subquery: S) -> QueryExpr {
         ValueExpressionOps::not_in_subquery_expr(self, subquery)
     }
@@ -766,7 +861,7 @@ impl QueryValue {
         I: IntoIterator<Item = FunctionArgExpr>,
     {
         let name = name.into();
-        Self::from_ast(Expr::Function(Function {
+        Self::from_expr(Expr::Function(Function {
             name: object_name(&name),
             uses_odbc_syntax: false,
             parameters: FunctionArguments::None,
@@ -820,7 +915,7 @@ pub fn projection_column<M: Model>(column: &'static str) -> ProjectedValue {
 impl<V: Into<QueryValue>> From<V> for ProjectedValue {
     fn from(value: V) -> Self {
         Self {
-            item: SelectItem::UnnamedExpr(value.into().into_ast()),
+            item: SelectItem::UnnamedExpr(value.into().into_expr()),
         }
     }
 }
@@ -852,21 +947,9 @@ impl_into_projected_tuple!(
     (A, B, C, D, E, F, G, H),
 );
 
-impl From<Expr> for QueryValue {
-    fn from(value: Expr) -> Self {
-        QueryValue::from_ast(value)
-    }
-}
-
-impl From<Expr> for QueryExpr {
-    fn from(value: Expr) -> Self {
-        QueryExpr::from_ast(value)
-    }
-}
-
 impl<T: ToDataValue> From<T> for QueryValue {
     fn from(value: T) -> Self {
-        QueryValue::from_ast(data_value_to_ast_expr(&value.to_data_value()))
+        QueryValue::from_expr(data_value_to_ast_expr(&value.to_data_value()))
     }
 }
 
@@ -883,9 +966,11 @@ impl CompareOp {
     }
 }
 
+#[doc(hidden)]
 pub trait StatementSource {
     type Iter: ResultIter;
 
+    /// Executes a prepared ORM statement with named parameters.
     fn execute_statement<A: AsRef<[(&'static str, DataValue)]>>(
         self,
         statement: &Statement,
@@ -932,12 +1017,12 @@ struct QueryBuilder<Q: StatementSource, M: Model, P = ModelProjection> {
 }
 
 /// Lightweight single-table query builder for ORM models.
+///
+/// This is the main entry point returned by `Database::from::<M>()` and
+/// `DBTransaction::from::<M>()`.
 pub struct FromBuilder<Q: StatementSource, M: Model, P = ModelProjection> {
     inner: QueryBuilder<Q, M, P>,
 }
-
-#[doc(hidden)]
-pub type ProjectionBuilder<Q, M, P> = FromBuilder<Q, M, P>;
 
 #[doc(hidden)]
 pub struct ModelProjection;
@@ -1012,6 +1097,7 @@ pub trait ProjectionSpec<M: Model> {
 ///
 /// This trait is typically derived with `#[derive(Projection)]`.
 pub trait Projection: for<'a> From<(&'a SchemaRef, Tuple)> {
+    /// Returns the projected select-list items for model `M`.
     fn projected_values<M: Model>() -> Vec<ProjectedValue>;
 }
 
@@ -1086,127 +1172,184 @@ impl<Q: StatementSource, M: Model, P> FromBuilder<Q, M, P> {
 }
 
 impl<Q: StatementSource, M: Model> FromBuilder<Q, M, ModelProjection> {
-    pub fn project<T: Projection>(self) -> ProjectionBuilder<Q, M, StructProjection<T>> {
+    /// Switches the query into a struct projection.
+    ///
+    /// ```rust,ignore
+    /// #[derive(Default, kite_sql::Projection)]
+    /// struct UserSummary {
+    ///     id: i32,
+    ///     #[projection(rename = "user_name")]
+    ///     display_name: String,
+    /// }
+    ///
+    /// let users = database.from::<User>().project::<UserSummary>().fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
+    pub fn project<T: Projection>(self) -> FromBuilder<Q, M, StructProjection<T>> {
         self.with_projection(StructProjection {
             _marker: PhantomData,
         })
     }
 
+    /// Switches the query into a single-value projection.
+    ///
+    /// ```rust,ignore
+    /// let ids = database
+    ///     .from::<User>()
+    ///     .project_value(User::id())
+    ///     .fetch::<i32>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn project_value<V: Into<ProjectedValue>>(
         self,
         value: V,
-    ) -> ProjectionBuilder<Q, M, ValueProjection> {
+    ) -> FromBuilder<Q, M, ValueProjection> {
         self.with_projection(ValueProjection {
             value: value.into(),
         })
     }
 
+    /// Switches the query into a tuple projection.
+    ///
+    /// ```rust,ignore
+    /// let rows = database
+    ///     .from::<User>()
+    ///     .project_tuple((User::id(), User::name()))
+    ///     .fetch::<(i32, String)>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn project_tuple<V: IntoProjectedTuple>(
         self,
         values: V,
-    ) -> ProjectionBuilder<Q, M, TupleProjection> {
+    ) -> FromBuilder<Q, M, TupleProjection> {
         self.with_projection(TupleProjection {
             values: values.into_projected_values(),
         })
     }
+
+    /// Executes the query and decodes rows into the model type.
     pub fn fetch(self) -> Result<OrmIter<Q::Iter, M>, DatabaseError> {
         Ok(self.raw()?.orm::<M>())
     }
 
+    /// Executes the query with `LIMIT 1` semantics and decodes one model row.
     pub fn get(self) -> Result<Option<M>, DatabaseError> {
         extract_optional_model(self.limit(1).raw()?)
     }
 }
 
 impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
+    /// Replaces the current `WHERE` predicate.
     pub fn filter(self, expr: QueryExpr) -> Self {
         Self::from_inner(self.inner.filter(expr))
     }
 
+    /// Appends `left AND right` to the current filter state.
     pub fn and(self, left: QueryExpr, right: QueryExpr) -> Self {
         Self::from_inner(self.inner.and(left, right))
     }
 
+    /// Appends `left OR right` to the current filter state.
     pub fn or(self, left: QueryExpr, right: QueryExpr) -> Self {
         Self::from_inner(self.inner.or(left, right))
     }
 
+    /// Replaces the current filter with `NOT expr`.
     pub fn not(self, expr: QueryExpr) -> Self {
         Self::from_inner(self.inner.not(expr))
     }
 
+    /// Replaces the current filter with `EXISTS (subquery)`.
     pub fn where_exists<S: SubquerySource>(self, subquery: S) -> Self {
         Self::from_inner(self.inner.where_exists(subquery))
     }
 
+    /// Replaces the current filter with `NOT EXISTS (subquery)`.
     pub fn where_not_exists<S: SubquerySource>(self, subquery: S) -> Self {
         Self::from_inner(self.inner.where_not_exists(subquery))
     }
 
+    /// Appends a `GROUP BY` expression.
     pub fn group_by<V: Into<QueryValue>>(self, value: V) -> Self {
         Self::from_inner(self.inner.group_by(value))
     }
 
+    /// Sets the `HAVING` predicate.
     pub fn having(self, expr: QueryExpr) -> Self {
         Self::from_inner(self.inner.having(expr))
     }
 
+    /// Appends an ascending sort key.
     pub fn asc<V: Into<QueryValue>>(self, value: V) -> Self {
         Self::from_inner(self.inner.asc(value))
     }
 
+    /// Appends a descending sort key.
     pub fn desc<V: Into<QueryValue>>(self, value: V) -> Self {
         Self::from_inner(self.inner.desc(value))
     }
 
+    /// Sets the query `LIMIT`.
     pub fn limit(self, limit: usize) -> Self {
         Self::from_inner(self.inner.limit(limit))
     }
 
+    /// Sets the query `OFFSET`.
     pub fn offset(self, offset: usize) -> Self {
         Self::from_inner(self.inner.offset(offset))
     }
 
+    /// Appends `left = right` to the filter state.
     pub fn eq<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         Self::from_inner(self.inner.eq(left, right))
     }
 
+    /// Appends `left <> right` to the filter state.
     pub fn ne<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         Self::from_inner(self.inner.ne(left, right))
     }
 
+    /// Appends `left > right` to the filter state.
     pub fn gt<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         Self::from_inner(self.inner.gt(left, right))
     }
 
+    /// Appends `left >= right` to the filter state.
     pub fn gte<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         Self::from_inner(self.inner.gte(left, right))
     }
 
+    /// Appends `left < right` to the filter state.
     pub fn lt<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         Self::from_inner(self.inner.lt(left, right))
     }
 
+    /// Appends `left <= right` to the filter state.
     pub fn lte<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         Self::from_inner(self.inner.lte(left, right))
     }
 
+    /// Appends `value IS NULL` to the filter state.
     pub fn is_null<V: Into<QueryValue>>(self, value: V) -> Self {
         Self::from_inner(self.inner.is_null(value))
     }
 
+    /// Appends `value IS NOT NULL` to the filter state.
     pub fn is_not_null<V: Into<QueryValue>>(self, value: V) -> Self {
         Self::from_inner(self.inner.is_not_null(value))
     }
 
+    /// Appends `value LIKE pattern` to the filter state.
     pub fn like<L: Into<QueryValue>, R: Into<QueryValue>>(self, value: L, pattern: R) -> Self {
         Self::from_inner(self.inner.like(value, pattern))
     }
 
+    /// Appends `value NOT LIKE pattern` to the filter state.
     pub fn not_like<L: Into<QueryValue>, R: Into<QueryValue>>(self, value: L, pattern: R) -> Self {
         Self::from_inner(self.inner.not_like(value, pattern))
     }
 
+    /// Appends `left IN (...)` to the filter state.
     pub fn in_list<L, I, V>(self, left: L, values: I) -> Self
     where
         L: Into<QueryValue>,
@@ -1216,6 +1359,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
         Self::from_inner(self.inner.in_list(left, values))
     }
 
+    /// Appends `left NOT IN (...)` to the filter state.
     pub fn not_in_list<L, I, V>(self, left: L, values: I) -> Self
     where
         L: Into<QueryValue>,
@@ -1225,6 +1369,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
         Self::from_inner(self.inner.not_in_list(left, values))
     }
 
+    /// Appends `expr BETWEEN low AND high` to the filter state.
     pub fn between<L, Low, High>(self, expr: L, low: Low, high: High) -> Self
     where
         L: Into<QueryValue>,
@@ -1234,6 +1379,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
         Self::from_inner(self.inner.between(expr, low, high))
     }
 
+    /// Appends `expr NOT BETWEEN low AND high` to the filter state.
     pub fn not_between<L, Low, High>(self, expr: L, low: Low, high: High) -> Self
     where
         L: Into<QueryValue>,
@@ -1243,10 +1389,12 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
         Self::from_inner(self.inner.not_between(expr, low, high))
     }
 
+    /// Appends `left IN (subquery)` to the filter state.
     pub fn in_subquery<L: Into<QueryValue>, S: SubquerySource>(self, left: L, subquery: S) -> Self {
         Self::from_inner(self.inner.in_subquery(left, subquery))
     }
 
+    /// Appends `left NOT IN (subquery)` to the filter state.
     pub fn not_in_subquery<L: Into<QueryValue>, S: SubquerySource>(
         self,
         left: L,
@@ -1255,44 +1403,53 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
         Self::from_inner(self.inner.not_in_subquery(left, subquery))
     }
 
+    /// Executes the query and returns the raw result iterator.
     pub fn raw(self) -> Result<Q::Iter, DatabaseError> {
         self.inner.raw()
     }
 
+    /// Returns whether the query produces at least one row.
     pub fn exists(self) -> Result<bool, DatabaseError> {
         self.inner.exists()
     }
 
+    /// Returns the row count for the current query shape.
     pub fn count(self) -> Result<usize, DatabaseError> {
         self.inner.count()
     }
 }
 
 impl<Q: StatementSource, M: Model> FromBuilder<Q, M, ValueProjection> {
+    /// Executes a single-value projection and decodes each row into `T`.
     pub fn fetch<T: FromDataValue>(self) -> Result<ProjectValueIter<Q::Iter, T>, DatabaseError> {
         Ok(ProjectValueIter::new(self.raw()?))
     }
 
+    /// Executes a single-value projection and decodes one value.
     pub fn get<T: FromDataValue>(self) -> Result<Option<T>, DatabaseError> {
         extract_optional_value(self.limit(1).raw()?)
     }
 }
 
 impl<Q: StatementSource, M: Model> FromBuilder<Q, M, TupleProjection> {
+    /// Executes a tuple projection and decodes each row into `T`.
     pub fn fetch<T: FromQueryTuple>(self) -> Result<ProjectTupleIter<Q::Iter, T>, DatabaseError> {
         Ok(ProjectTupleIter::new(self.raw()?))
     }
 
+    /// Executes a tuple projection and decodes one row into `T`.
     pub fn get<T: FromQueryTuple>(self) -> Result<Option<T>, DatabaseError> {
         extract_optional_tuple(self.limit(1).raw()?)
     }
 }
 
 impl<Q: StatementSource, M: Model, T: Projection> FromBuilder<Q, M, StructProjection<T>> {
+    /// Executes a struct projection and decodes each row into `T`.
     pub fn fetch(self) -> Result<OrmIter<Q::Iter, T>, DatabaseError> {
         Ok(self.raw()?.orm::<T>())
     }
 
+    /// Executes a struct projection and decodes one row into `T`.
     pub fn get(self) -> Result<Option<T>, DatabaseError> {
         extract_optional_row(self.limit(1).raw()?)
     }
@@ -1306,33 +1463,33 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         }
     }
 
-    pub fn filter(mut self, expr: QueryExpr) -> Self {
+    fn filter(mut self, expr: QueryExpr) -> Self {
         self.state.filter = Some(expr);
         self
     }
 
-    pub fn and(self, left: QueryExpr, right: QueryExpr) -> Self {
+    fn and(self, left: QueryExpr, right: QueryExpr) -> Self {
         Self {
             state: self.state.push_filter(left.and(right), FilterMode::And),
             projection: self.projection,
         }
     }
 
-    pub fn or(self, left: QueryExpr, right: QueryExpr) -> Self {
+    fn or(self, left: QueryExpr, right: QueryExpr) -> Self {
         Self {
             state: self.state.push_filter(left.or(right), FilterMode::Or),
             projection: self.projection,
         }
     }
 
-    pub fn not(self, expr: QueryExpr) -> Self {
+    fn not(self, expr: QueryExpr) -> Self {
         Self {
             state: self.state.push_filter(expr.not(), FilterMode::Replace),
             projection: self.projection,
         }
     }
 
-    pub fn where_exists<S: SubquerySource>(self, subquery: S) -> Self {
+    fn where_exists<S: SubquerySource>(self, subquery: S) -> Self {
         Self {
             state: self
                 .state
@@ -1341,7 +1498,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         }
     }
 
-    pub fn where_not_exists<S: SubquerySource>(self, subquery: S) -> Self {
+    fn where_not_exists<S: SubquerySource>(self, subquery: S) -> Self {
         Self {
             state: self
                 .state
@@ -1350,38 +1507,38 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         }
     }
 
-    pub fn group_by<V: Into<QueryValue>>(self, value: V) -> Self {
+    fn group_by<V: Into<QueryValue>>(self, value: V) -> Self {
         Self {
             state: self.state.push_group_by(value.into()),
             projection: self.projection,
         }
     }
 
-    pub fn having(mut self, expr: QueryExpr) -> Self {
+    fn having(mut self, expr: QueryExpr) -> Self {
         self.state.having = Some(expr);
         self
     }
 
-    pub fn asc<V: Into<QueryValue>>(self, value: V) -> Self {
+    fn asc<V: Into<QueryValue>>(self, value: V) -> Self {
         Self {
             state: self.state.push_order(value.into().asc()),
             projection: self.projection,
         }
     }
 
-    pub fn desc<V: Into<QueryValue>>(self, value: V) -> Self {
+    fn desc<V: Into<QueryValue>>(self, value: V) -> Self {
         Self {
             state: self.state.push_order(value.into().desc()),
             projection: self.projection,
         }
     }
 
-    pub fn limit(mut self, limit: usize) -> Self {
+    fn limit(mut self, limit: usize) -> Self {
         self.state.limit = Some(limit);
         self
     }
 
-    pub fn offset(mut self, offset: usize) -> Self {
+    fn offset(mut self, offset: usize) -> Self {
         self.state.offset = Some(offset);
         self
     }
@@ -1444,47 +1601,47 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         (source, statement)
     }
 
-    pub fn eq<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+    fn eq<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         self.push_filter(left.into().eq(right), FilterMode::Replace)
     }
 
-    pub fn ne<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+    fn ne<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         self.push_filter(left.into().ne(right), FilterMode::Replace)
     }
 
-    pub fn gt<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+    fn gt<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         self.push_filter(left.into().gt(right), FilterMode::Replace)
     }
 
-    pub fn gte<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+    fn gte<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         self.push_filter(left.into().gte(right), FilterMode::Replace)
     }
 
-    pub fn lt<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+    fn lt<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         self.push_filter(left.into().lt(right), FilterMode::Replace)
     }
 
-    pub fn lte<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+    fn lte<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         self.push_filter(left.into().lte(right), FilterMode::Replace)
     }
 
-    pub fn is_null<V: Into<QueryValue>>(self, value: V) -> Self {
+    fn is_null<V: Into<QueryValue>>(self, value: V) -> Self {
         self.push_filter(value.into().is_null(), FilterMode::Replace)
     }
 
-    pub fn is_not_null<V: Into<QueryValue>>(self, value: V) -> Self {
+    fn is_not_null<V: Into<QueryValue>>(self, value: V) -> Self {
         self.push_filter(value.into().is_not_null(), FilterMode::Replace)
     }
 
-    pub fn like<L: Into<QueryValue>, R: Into<QueryValue>>(self, value: L, pattern: R) -> Self {
+    fn like<L: Into<QueryValue>, R: Into<QueryValue>>(self, value: L, pattern: R) -> Self {
         self.push_filter(value.into().like(pattern), FilterMode::Replace)
     }
 
-    pub fn not_like<L: Into<QueryValue>, R: Into<QueryValue>>(self, value: L, pattern: R) -> Self {
+    fn not_like<L: Into<QueryValue>, R: Into<QueryValue>>(self, value: L, pattern: R) -> Self {
         self.push_filter(value.into().not_like(pattern), FilterMode::Replace)
     }
 
-    pub fn in_list<L, I, V>(self, left: L, values: I) -> Self
+    fn in_list<L, I, V>(self, left: L, values: I) -> Self
     where
         L: Into<QueryValue>,
         I: IntoIterator<Item = V>,
@@ -1498,7 +1655,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         }
     }
 
-    pub fn not_in_list<L, I, V>(self, left: L, values: I) -> Self
+    fn not_in_list<L, I, V>(self, left: L, values: I) -> Self
     where
         L: Into<QueryValue>,
         I: IntoIterator<Item = V>,
@@ -1512,7 +1669,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         }
     }
 
-    pub fn between<L, Low, High>(self, expr: L, low: Low, high: High) -> Self
+    fn between<L, Low, High>(self, expr: L, low: Low, high: High) -> Self
     where
         L: Into<QueryValue>,
         Low: Into<QueryValue>,
@@ -1526,7 +1683,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         }
     }
 
-    pub fn not_between<L, Low, High>(self, expr: L, low: Low, high: High) -> Self
+    fn not_between<L, Low, High>(self, expr: L, low: Low, high: High) -> Self
     where
         L: Into<QueryValue>,
         Low: Into<QueryValue>,
@@ -1540,7 +1697,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         }
     }
 
-    pub fn in_subquery<L: Into<QueryValue>, S: SubquerySource>(self, left: L, subquery: S) -> Self {
+    fn in_subquery<L: Into<QueryValue>, S: SubquerySource>(self, left: L, subquery: S) -> Self {
         Self {
             state: self
                 .state
@@ -1549,11 +1706,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         }
     }
 
-    pub fn not_in_subquery<L: Into<QueryValue>, S: SubquerySource>(
-        self,
-        left: L,
-        subquery: S,
-    ) -> Self {
+    fn not_in_subquery<L: Into<QueryValue>, S: SubquerySource>(self, left: L, subquery: S) -> Self {
         Self {
             state: self
                 .state
@@ -1562,17 +1715,17 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         }
     }
 
-    pub fn raw(self) -> Result<Q::Iter, DatabaseError> {
+    fn raw(self) -> Result<Q::Iter, DatabaseError> {
         let (source, statement) = self.into_statement();
         source.execute_statement(&statement, &[])
     }
 
-    pub fn exists(self) -> Result<bool, DatabaseError> {
+    fn exists(self) -> Result<bool, DatabaseError> {
         let mut iter = self.limit(1).raw()?;
         Ok(iter.next().transpose()?.is_some())
     }
 
-    pub fn count(self) -> Result<usize, DatabaseError> {
+    fn count(self) -> Result<usize, DatabaseError> {
         let has_grouping = !self.state.group_bys.is_empty() || self.state.having.is_some();
         if has_grouping {
             let mut iter = self.raw()?;
@@ -1705,16 +1858,16 @@ fn select_query(
             from: vec![table_with_joins(table_name)],
             lateral_views: vec![],
             prewhere: None,
-            selection: filter.map(QueryExpr::into_ast),
+            selection: filter.map(QueryExpr::into_expr),
             connect_by: vec![],
             group_by: GroupByExpr::Expressions(
-                group_bys.into_iter().map(QueryValue::into_ast).collect(),
+                group_bys.into_iter().map(QueryValue::into_expr).collect(),
                 vec![],
             ),
             cluster_by: vec![],
             distribute_by: vec![],
             sort_by: vec![],
-            having: having.map(QueryExpr::into_ast),
+            having: having.map(QueryExpr::into_expr),
             named_window: vec![],
             qualify: None,
             window_before_qualify: false,
@@ -2302,6 +2455,7 @@ pub trait Model: Sized + for<'a> From<(&'a SchemaRef, Tuple)> {
     /// Returns the cached `ANALYZE TABLE` statement for the model.
     fn analyze_statement() -> &'static Statement;
 
+    /// Returns metadata for the primary-key field.
     fn primary_key_field() -> &'static OrmField {
         Self::fields()
             .iter()
@@ -2315,17 +2469,24 @@ pub trait Model: Sized + for<'a> From<(&'a SchemaRef, Tuple)> {
 /// This trait is mainly intended for framework internals and derive-generated
 /// code.
 pub trait FromDataValue: Sized {
+    /// Returns the logical SQL type used for conversion, when one is required.
     fn logical_type() -> Option<LogicalType>;
 
+    /// Attempts to convert a raw [`DataValue`] into `Self`.
     fn from_data_value(value: DataValue) -> Option<Self>;
 }
 
 /// Conversion trait from a projected result tuple into a Rust value.
+///
+/// This is implemented for tuples such as `(i32, String)` by the ORM itself.
 pub trait FromQueryTuple: Sized {
+    /// Decodes one projected tuple into `Self`.
     fn from_query_tuple(tuple: Tuple) -> Result<Self, DatabaseError>;
 }
 
 /// Typed adapter over a [`ResultIter`] that yields projected values instead of raw tuples.
+///
+/// This is returned by `project_value(...).fetch::<T>()`.
 pub struct ProjectValueIter<I, T> {
     inner: I,
     _marker: PhantomData<T>,
@@ -2350,6 +2511,8 @@ where
 }
 
 /// Typed adapter over a [`ResultIter`] that yields projected tuples.
+///
+/// This is returned by `project_tuple(...).fetch::<T>()`.
 pub struct ProjectTupleIter<I, T> {
     inner: I,
     _marker: PhantomData<T>,
@@ -2378,6 +2541,7 @@ where
     I: ResultIter,
     T: FromDataValue,
 {
+    /// Each item is one projected scalar value decoded into `T`.
     type Item = Result<T, DatabaseError>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -2392,6 +2556,7 @@ where
     I: ResultIter,
     T: FromQueryTuple,
 {
+    /// Each item is one projected row decoded into `T`.
     type Item = Result<T, DatabaseError>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -2406,6 +2571,7 @@ where
 /// This trait is mainly intended for framework internals and derive-generated
 /// code.
 pub trait ToDataValue {
+    /// Converts the value into a [`DataValue`].
     fn to_data_value(&self) -> DataValue;
 }
 
@@ -2415,8 +2581,10 @@ pub trait ToDataValue {
 /// Most built-in scalar types already implement it, and custom types can opt in
 /// by implementing this trait together with [`FromDataValue`] and [`ToDataValue`].
 pub trait ModelColumnType {
+    /// Returns the SQL type name used in ORM-generated DDL.
     fn ddl_type() -> String;
 
+    /// Whether this field type maps to a nullable SQL column.
     fn nullable() -> bool {
         false
     }
@@ -2424,15 +2592,16 @@ pub trait ModelColumnType {
 
 /// Marker trait for string-like model fields that support `#[model(varchar = N)]`
 /// and `#[model(char = N)]`.
+///
+/// This is mainly used by the `Model` derive macro.
 pub trait StringType {}
 
 /// Marker trait for decimal-like model fields that support precision/scale DDL attributes.
+///
+/// This is mainly used by the `Model` derive macro.
 pub trait DecimalType {}
 
-/// Extracts and converts a named field from a tuple using the given schema.
-///
-/// This helper is used by code generated from `#[derive(Model)]` and by the
-/// lower-level `from_tuple!` macro.
+#[doc(hidden)]
 pub fn try_get<T: FromDataValue>(
     tuple: &mut Tuple,
     schema: &SchemaRef,

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -15,8 +15,8 @@ use sqlparser::ast::helpers::attached_token::AttachedToken;
 use sqlparser::ast::{
     AlterColumnOperation, AlterTable, AlterTableOperation, Analyze, Assignment, AssignmentTarget,
     BinaryOperator as SqlBinaryOperator, CaseWhen, CastKind, CharLengthUnits, ColumnDef,
-    ColumnOption, ColumnOptionDef, CreateIndex, CreateTable, DataType, Delete, Expr, FromTable,
-    Distinct, Function, FunctionArg, FunctionArgExpr, FunctionArgumentList, FunctionArguments,
+    ColumnOption, ColumnOptionDef, CreateIndex, CreateTable, DataType, Delete, Distinct, Expr,
+    FromTable, Function, FunctionArg, FunctionArgExpr, FunctionArgumentList, FunctionArguments,
     GroupByExpr, HiveDistributionStyle, Ident, IndexColumn, Insert, KeyOrIndexDisplay, LimitClause,
     NullsDistinctOption, ObjectName, ObjectType, Offset, OffsetRows, OrderBy, OrderByExpr,
     OrderByKind, OrderByOptions, PrimaryKeyConstraint, Query, Select, SelectFlavor, SelectItem,
@@ -118,6 +118,45 @@ pub struct Field<M, T> {
 
 trait ValueExpressionOps: Sized {
     fn into_query_value(self) -> QueryValue;
+
+    fn binary_value_expr<V: Into<QueryValue>>(self, op: SqlBinaryOperator, value: V) -> QueryValue {
+        QueryValue::from_expr(Expr::BinaryOp {
+            left: Box::new(self.into_query_value().into_expr()),
+            op,
+            right: Box::new(value.into().into_expr()),
+        })
+    }
+
+    fn unary_value_expr(self, op: sqlparser::ast::UnaryOperator) -> QueryValue {
+        QueryValue::from_expr(Expr::UnaryOp {
+            op,
+            expr: Box::new(self.into_query_value().into_expr()),
+        })
+    }
+
+    fn add_expr<V: Into<QueryValue>>(self, value: V) -> QueryValue {
+        self.binary_value_expr(SqlBinaryOperator::Plus, value)
+    }
+
+    fn sub_expr<V: Into<QueryValue>>(self, value: V) -> QueryValue {
+        self.binary_value_expr(SqlBinaryOperator::Minus, value)
+    }
+
+    fn mul_expr<V: Into<QueryValue>>(self, value: V) -> QueryValue {
+        self.binary_value_expr(SqlBinaryOperator::Multiply, value)
+    }
+
+    fn div_expr<V: Into<QueryValue>>(self, value: V) -> QueryValue {
+        self.binary_value_expr(SqlBinaryOperator::Divide, value)
+    }
+
+    fn modulo_expr<V: Into<QueryValue>>(self, value: V) -> QueryValue {
+        self.binary_value_expr(SqlBinaryOperator::Modulo, value)
+    }
+
+    fn neg_expr(self) -> QueryValue {
+        self.unary_value_expr(sqlparser::ast::UnaryOperator::Minus)
+    }
 
     fn eq_expr<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
         QueryExpr::from_expr(Expr::BinaryOp {
@@ -306,6 +345,36 @@ impl<M, T> Field<M, T> {
             ident(self.table),
             ident(self.column),
         ]))
+    }
+
+    /// Builds `field + value`.
+    pub fn add<V: Into<QueryValue>>(self, value: V) -> QueryValue {
+        ValueExpressionOps::add_expr(self, value)
+    }
+
+    /// Builds `field - value`.
+    pub fn sub<V: Into<QueryValue>>(self, value: V) -> QueryValue {
+        ValueExpressionOps::sub_expr(self, value)
+    }
+
+    /// Builds `field * value`.
+    pub fn mul<V: Into<QueryValue>>(self, value: V) -> QueryValue {
+        ValueExpressionOps::mul_expr(self, value)
+    }
+
+    /// Builds `field / value`.
+    pub fn div<V: Into<QueryValue>>(self, value: V) -> QueryValue {
+        ValueExpressionOps::div_expr(self, value)
+    }
+
+    /// Builds `field % value`.
+    pub fn modulo<V: Into<QueryValue>>(self, value: V) -> QueryValue {
+        ValueExpressionOps::modulo_expr(self, value)
+    }
+
+    /// Builds unary `-field`.
+    pub fn neg(self) -> QueryValue {
+        ValueExpressionOps::neg_expr(self)
     }
 
     /// Builds `field = value`.
@@ -730,6 +799,36 @@ impl QueryValue {
                 .collect(),
             else_result: Some(Box::new(else_result.into().into_expr())),
         })
+    }
+
+    /// Builds `expr + value`.
+    pub fn add<V: Into<QueryValue>>(self, value: V) -> QueryValue {
+        ValueExpressionOps::add_expr(self, value)
+    }
+
+    /// Builds `expr - value`.
+    pub fn sub<V: Into<QueryValue>>(self, value: V) -> QueryValue {
+        ValueExpressionOps::sub_expr(self, value)
+    }
+
+    /// Builds `expr * value`.
+    pub fn mul<V: Into<QueryValue>>(self, value: V) -> QueryValue {
+        ValueExpressionOps::mul_expr(self, value)
+    }
+
+    /// Builds `expr / value`.
+    pub fn div<V: Into<QueryValue>>(self, value: V) -> QueryValue {
+        ValueExpressionOps::div_expr(self, value)
+    }
+
+    /// Builds `expr % value`.
+    pub fn modulo<V: Into<QueryValue>>(self, value: V) -> QueryValue {
+        ValueExpressionOps::modulo_expr(self, value)
+    }
+
+    /// Builds unary `-expr`.
+    pub fn neg(self) -> QueryValue {
+        ValueExpressionOps::neg_expr(self)
     }
 
     /// Builds `expr = value`.

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -17,13 +17,14 @@ use sqlparser::ast::{
     AlterColumnOperation, AlterTable, AlterTableOperation, Analyze, Assignment, AssignmentTarget,
     BinaryOperator as SqlBinaryOperator, CaseWhen, CastKind, CharLengthUnits, ColumnDef,
     ColumnOption, ColumnOptionDef, CreateIndex, CreateTable, CreateTableOptions, CreateView,
-    DataType, Delete, Distinct, Expr, FromTable, Function, FunctionArg, FunctionArgExpr,
-    FunctionArgumentList, FunctionArguments, GroupByExpr, HiveDistributionStyle, Ident,
-    IndexColumn, Insert, Join, JoinConstraint, JoinOperator, KeyOrIndexDisplay, LimitClause,
+    DataType, Delete, DescribeAlias, Distinct, Expr, FromTable, Function, FunctionArg,
+    FunctionArgExpr, FunctionArgumentList, FunctionArguments, GroupByExpr, HiveDistributionStyle,
+    Ident, IndexColumn, Insert, Join, JoinConstraint, JoinOperator, KeyOrIndexDisplay, LimitClause,
     NullsDistinctOption, ObjectName, ObjectType, Offset, OffsetRows, OrderBy, OrderByExpr,
     OrderByKind, OrderByOptions, PrimaryKeyConstraint, Query, Select, SelectFlavor, SelectItem,
-    SetExpr, SetOperator, SetQuantifier, TableAlias, TableFactor, TableObject, TableWithJoins,
-    TimezoneInfo, Truncate, UniqueConstraint, Update, Value, Values, ViewColumnDef,
+    SetExpr, SetOperator, SetQuantifier, ShowStatementOptions, TableAlias, TableFactor,
+    TableObject, TableWithJoins, TimezoneInfo, Truncate, UniqueConstraint, Update, Value, Values,
+    ViewColumnDef,
 };
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
@@ -59,6 +60,42 @@ pub struct OrmColumn {
     pub primary_key: bool,
     pub unique: bool,
     pub default_expr: Option<&'static str>,
+}
+
+/// One row returned by [`Database::describe`] or [`DBTransaction::describe`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DescribeColumn {
+    pub field: String,
+    pub data_type: String,
+    pub len: String,
+    pub nullable: bool,
+    pub key: String,
+    pub default: String,
+}
+
+impl From<(&SchemaRef, Tuple)> for DescribeColumn {
+    fn from((_, tuple): (&SchemaRef, Tuple)) -> Self {
+        let mut values = tuple.values.into_iter();
+
+        let field = describe_text_value(values.next());
+        let data_type = describe_text_value(values.next());
+        let len = describe_text_value(values.next());
+        let nullable = matches!(
+            values.next(),
+            Some(DataValue::Utf8 { value, .. }) if value == "true"
+        );
+        let key = describe_text_value(values.next());
+        let default = describe_text_value(values.next());
+
+        Self {
+            field,
+            data_type,
+            len,
+            nullable,
+            key,
+            default,
+        }
+    }
 }
 
 impl OrmColumn {
@@ -2007,6 +2044,11 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
         execute_query(self.source, self.query)
     }
 
+    /// Returns the logical plan text for the current set query.
+    pub fn explain(self) -> Result<String, DatabaseError> {
+        query_explain(self.source, self.query)
+    }
+
     /// Returns whether the set query produces at least one row.
     ///
     /// ```rust,ignore
@@ -2885,6 +2927,11 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
         self.inner.raw()
     }
 
+    /// Returns the logical plan text for the current query.
+    pub fn explain(self) -> Result<String, DatabaseError> {
+        self.inner.explain()
+    }
+
     /// Returns whether the query produces at least one row.
     ///
     /// ```rust,ignore
@@ -3481,6 +3528,11 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         }
     }
 
+    fn explain(self) -> Result<String, DatabaseError> {
+        let (source, query) = self.into_query_parts();
+        query_explain(source, query)
+    }
+
     fn exists(self) -> Result<bool, DatabaseError> {
         let mut iter = self.limit(1).raw()?;
         Ok(iter.next().transpose()?.is_some())
@@ -3679,6 +3731,14 @@ fn number_expr(value: impl ToString) -> Expr {
 
 fn string_expr(value: impl Into<String>) -> Expr {
     Expr::Value(Value::SingleQuotedString(value.into()).with_empty_span())
+}
+
+fn describe_text_value(value: Option<DataValue>) -> String {
+    match value {
+        Some(DataValue::Utf8 { value, .. }) => value,
+        Some(other) => other.to_string(),
+        None => String::new(),
+    }
 }
 
 fn placeholder_expr(value: &str) -> Expr {
@@ -4000,6 +4060,20 @@ fn execute_insert_query<Q: StatementSource>(
     source.execute_statement(&statement, &[])?.done()
 }
 
+fn query_explain<Q: StatementSource>(source: Q, query: Query) -> Result<String, DatabaseError> {
+    let mut iter = source.execute_statement(&orm_explain_query_statement(query), &[])?;
+    let plan = match iter.next().transpose()? {
+        Some(tuple) => extract_value_from_tuple::<String>(tuple)?,
+        None => {
+            return Err(DatabaseError::InvalidValue(
+                "EXPLAIN returned no plan rows".to_string(),
+            ))
+        }
+    };
+    iter.done()?;
+    Ok(plan)
+}
+
 fn orm_update_builder_statement(
     source: &QuerySource,
     filter: Option<QueryExpr>,
@@ -4047,6 +4121,57 @@ fn orm_insert_query_statement(
         settings: None,
         format_clause: None,
     })
+}
+
+fn empty_show_options() -> ShowStatementOptions {
+    ShowStatementOptions {
+        show_in: None,
+        starts_with: None,
+        limit: None,
+        limit_from: None,
+        filter_position: None,
+    }
+}
+
+fn orm_show_tables_statement() -> Statement {
+    Statement::ShowTables {
+        terse: false,
+        history: false,
+        extended: false,
+        full: false,
+        external: false,
+        show_options: empty_show_options(),
+    }
+}
+
+fn orm_show_views_statement() -> Statement {
+    Statement::ShowViews {
+        terse: false,
+        materialized: false,
+        show_options: empty_show_options(),
+    }
+}
+
+fn orm_describe_statement(table_name: &str) -> Statement {
+    Statement::ExplainTable {
+        describe_alias: DescribeAlias::Describe,
+        hive_format: None,
+        has_table_keyword: false,
+        table_name: object_name(table_name),
+    }
+}
+
+fn orm_explain_query_statement(query: Query) -> Statement {
+    Statement::Explain {
+        describe_alias: DescribeAlias::Explain,
+        analyze: false,
+        verbose: false,
+        query_plan: false,
+        estimate: false,
+        statement: Box::new(Statement::Query(Box::new(query))),
+        format: None,
+        options: None,
+    }
 }
 
 fn orm_delete_builder_statement(source: &QuerySource, filter: Option<QueryExpr>) -> Statement {

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -225,11 +225,11 @@ impl<M, T> Field<M, T> {
         self.value().cast_to(data_type)
     }
 
-    pub fn in_subquery(self, subquery: Query) -> QueryExpr {
+    pub fn in_subquery<S: SubquerySource>(self, subquery: S) -> QueryExpr {
         self.value().in_subquery(subquery)
     }
 
-    pub fn not_in_subquery(self, subquery: Query) -> QueryExpr {
+    pub fn not_in_subquery<S: SubquerySource>(self, subquery: S) -> QueryExpr {
         self.value().not_in_subquery(subquery)
     }
 }
@@ -301,16 +301,16 @@ impl QueryExpr {
         })
     }
 
-    pub fn exists(subquery: Query) -> QueryExpr {
+    pub fn exists<S: SubquerySource>(subquery: S) -> QueryExpr {
         QueryExpr::from_ast(Expr::Exists {
-            subquery: Box::new(subquery),
+            subquery: Box::new(subquery.into_subquery()),
             negated: false,
         })
     }
 
-    pub fn not_exists(subquery: Query) -> QueryExpr {
+    pub fn not_exists<S: SubquerySource>(subquery: S) -> QueryExpr {
         QueryExpr::from_ast(Expr::Exists {
-            subquery: Box::new(subquery),
+            subquery: Box::new(subquery.into_subquery()),
             negated: true,
         })
     }
@@ -525,22 +525,22 @@ impl QueryValue {
         })
     }
 
-    pub fn subquery(query: Query) -> QueryValue {
-        QueryValue::from_ast(Expr::Subquery(Box::new(query)))
+    pub fn subquery<S: SubquerySource>(query: S) -> QueryValue {
+        QueryValue::from_ast(Expr::Subquery(Box::new(query.into_subquery())))
     }
 
-    pub fn in_subquery(self, subquery: Query) -> QueryExpr {
+    pub fn in_subquery<S: SubquerySource>(self, subquery: S) -> QueryExpr {
         QueryExpr::from_ast(Expr::InSubquery {
             expr: Box::new(self.into_ast()),
-            subquery: Box::new(subquery),
+            subquery: Box::new(subquery.into_subquery()),
             negated: false,
         })
     }
 
-    pub fn not_in_subquery(self, subquery: Query) -> QueryExpr {
+    pub fn not_in_subquery<S: SubquerySource>(self, subquery: S) -> QueryExpr {
         QueryExpr::from_ast(Expr::InSubquery {
             expr: Box::new(self.into_ast()),
-            subquery: Box::new(subquery),
+            subquery: Box::new(subquery.into_subquery()),
             negated: true,
         })
     }
@@ -625,14 +625,82 @@ impl<'a, 'tx, S: Storage> StatementSource for &'a mut DBTransaction<'tx, S> {
     }
 }
 
+mod private {
+    pub trait Sealed {}
+}
+
+#[doc(hidden)]
+pub trait SubquerySource: private::Sealed {
+    fn into_subquery(self) -> Query;
+}
+
 /// Lightweight single-table query builder for ORM models.
-pub struct SelectBuilder<Q: StatementSource, M: Model> {
+pub struct SelectBuilder<Q: StatementSource, M: Model, P = ModelProjection> {
+    state: BuilderState<Q, M>,
+    projection: P,
+}
+
+/// Lightweight single-table query builder for scalar value projections.
+pub type ProjectValueBuilder<Q, M> = SelectBuilder<Q, M, ValueProjection>;
+
+pub struct ModelProjection;
+
+pub struct ValueProjection {
+    value: QueryValue,
+}
+
+struct BuilderState<Q: StatementSource, M: Model> {
     source: Q,
     filter: Option<QueryExpr>,
     order_bys: Vec<SortExpr>,
     limit: Option<usize>,
     offset: Option<usize>,
     _marker: PhantomData<M>,
+}
+
+impl<Q: StatementSource, M: Model> BuilderState<Q, M> {
+    fn new(source: Q) -> Self {
+        Self {
+            source,
+            filter: None,
+            order_bys: Vec::new(),
+            limit: None,
+            offset: None,
+            _marker: PhantomData,
+        }
+    }
+
+    fn push_filter(mut self, expr: QueryExpr, mode: FilterMode) -> Self {
+        self.filter = Some(match (mode, self.filter.take()) {
+            (FilterMode::Replace, _) => expr,
+            (FilterMode::And, Some(current)) => current.and(expr),
+            (FilterMode::Or, Some(current)) => current.or(expr),
+            (_, None) => expr,
+        });
+        self
+    }
+
+    fn push_order(mut self, order: SortExpr) -> Self {
+        self.order_bys.push(order);
+        self
+    }
+}
+
+#[doc(hidden)]
+pub trait ProjectionSpec<M: Model> {
+    fn into_select_items(self) -> Vec<SelectItem>;
+}
+
+impl<M: Model> ProjectionSpec<M> for ModelProjection {
+    fn into_select_items(self) -> Vec<SelectItem> {
+        select_projection(M::fields())
+    }
+}
+
+impl<M: Model> ProjectionSpec<M> for ValueProjection {
+    fn into_select_items(self) -> Vec<SelectItem> {
+        vec![SelectItem::UnnamedExpr(self.value.into_ast())]
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -672,89 +740,135 @@ macro_rules! impl_select_builder_like_methods {
     };
 }
 
-impl<Q: StatementSource, M: Model> SelectBuilder<Q, M> {
+impl<Q: StatementSource, M: Model> SelectBuilder<Q, M, ModelProjection> {
     fn new(source: Q) -> Self {
         Self {
-            source,
-            filter: None,
-            order_bys: Vec::new(),
-            limit: None,
-            offset: None,
-            _marker: PhantomData,
+            state: BuilderState::new(source),
+            projection: ModelProjection,
         }
     }
 
-    fn push_filter(mut self, expr: QueryExpr, mode: FilterMode) -> Self {
-        self.filter = Some(match (mode, self.filter.take()) {
-            (FilterMode::Replace, _) => expr,
-            (FilterMode::And, Some(current)) => current.and(expr),
-            (FilterMode::Or, Some(current)) => current.or(expr),
-            (_, None) => expr,
-        });
-        self
+    pub fn fetch(self) -> Result<OrmIter<Q::Iter, M>, DatabaseError> {
+        Ok(self.raw()?.orm::<M>())
+    }
+
+    pub fn get(self) -> Result<Option<M>, DatabaseError> {
+        extract_optional_model(self.limit(1).raw()?)
+    }
+}
+
+impl<Q: StatementSource, M: Model> SelectBuilder<Q, M, ValueProjection> {
+    fn new_value<V: Into<QueryValue>>(source: Q, value: V) -> Self {
+        Self {
+            state: BuilderState::new(source),
+            projection: ValueProjection {
+                value: value.into(),
+            },
+        }
+    }
+
+    pub fn fetch<T: FromDataValue>(self) -> Result<ProjectValueIter<Q::Iter, T>, DatabaseError> {
+        Ok(ProjectValueIter::new(self.raw()?))
+    }
+
+    pub fn get<T: FromDataValue>(self) -> Result<Option<T>, DatabaseError> {
+        extract_optional_value(self.limit(1).raw()?)
+    }
+}
+
+impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> SelectBuilder<Q, M, P> {
+    fn push_filter(self, expr: QueryExpr, mode: FilterMode) -> Self {
+        Self {
+            state: self.state.push_filter(expr, mode),
+            projection: self.projection,
+        }
     }
 
     pub fn filter(mut self, expr: QueryExpr) -> Self {
-        self.filter = Some(expr);
+        self.state.filter = Some(expr);
         self
     }
 
     pub fn and(self, left: QueryExpr, right: QueryExpr) -> Self {
-        self.push_filter(left.and(right), FilterMode::And)
+        Self {
+            state: self.state.push_filter(left.and(right), FilterMode::And),
+            projection: self.projection,
+        }
     }
 
     pub fn or(self, left: QueryExpr, right: QueryExpr) -> Self {
-        self.push_filter(left.or(right), FilterMode::Or)
+        Self {
+            state: self.state.push_filter(left.or(right), FilterMode::Or),
+            projection: self.projection,
+        }
     }
 
     pub fn not(self, expr: QueryExpr) -> Self {
-        self.push_filter(expr.not(), FilterMode::Replace)
+        Self {
+            state: self.state.push_filter(expr.not(), FilterMode::Replace),
+            projection: self.projection,
+        }
     }
 
-    pub fn where_exists(self, subquery: Query) -> Self {
-        self.push_filter(QueryExpr::exists(subquery), FilterMode::Replace)
+    pub fn where_exists<S: SubquerySource>(self, subquery: S) -> Self {
+        Self {
+            state: self
+                .state
+                .push_filter(QueryExpr::exists(subquery), FilterMode::Replace),
+            projection: self.projection,
+        }
     }
 
-    pub fn where_not_exists(self, subquery: Query) -> Self {
-        self.push_filter(QueryExpr::not_exists(subquery), FilterMode::Replace)
-    }
-
-    fn push_order(mut self, order: SortExpr) -> Self {
-        self.order_bys.push(order);
-        self
+    pub fn where_not_exists<S: SubquerySource>(self, subquery: S) -> Self {
+        Self {
+            state: self
+                .state
+                .push_filter(QueryExpr::not_exists(subquery), FilterMode::Replace),
+            projection: self.projection,
+        }
     }
 
     pub fn asc<V: Into<QueryValue>>(self, value: V) -> Self {
-        self.push_order(value.into().asc())
+        Self {
+            state: self.state.push_order(value.into().asc()),
+            projection: self.projection,
+        }
     }
 
     pub fn desc<V: Into<QueryValue>>(self, value: V) -> Self {
-        self.push_order(value.into().desc())
+        Self {
+            state: self.state.push_order(value.into().desc()),
+            projection: self.projection,
+        }
     }
 
     pub fn limit(mut self, limit: usize) -> Self {
-        self.limit = Some(limit);
+        self.state.limit = Some(limit);
         self
     }
 
     pub fn offset(mut self, offset: usize) -> Self {
-        self.offset = Some(offset);
+        self.state.offset = Some(offset);
         self
     }
 
-    pub fn into_query(self) -> Query {
+    fn build_query(self) -> Query {
         let SelectBuilder {
-            source: _,
-            filter,
-            order_bys,
-            limit,
-            offset,
-            ..
+            state:
+                BuilderState {
+                    source: _,
+                    filter,
+                    order_bys,
+                    limit,
+                    offset,
+                    ..
+                },
+            projection,
         } = self;
 
         select_query(
             M::table_name(),
-            select_projection(M::fields()),
+            projection.into_select_items(),
             filter,
             order_bys,
             limit,
@@ -764,22 +878,26 @@ impl<Q: StatementSource, M: Model> SelectBuilder<Q, M> {
 
     fn into_statement(self) -> (Q, Statement) {
         let SelectBuilder {
-            source,
-            filter,
-            order_bys,
-            limit,
-            offset,
-            ..
+            state:
+                BuilderState {
+                    source,
+                    filter,
+                    order_bys,
+                    limit,
+                    offset,
+                    ..
+                },
+            projection,
         } = self;
 
-        let statement = orm_select_query_statement(
+        let statement = Statement::Query(Box::new(select_query(
             M::table_name(),
-            M::fields(),
+            projection.into_select_items(),
             filter,
             order_bys,
             limit,
             offset,
-        );
+        )));
 
         (source, statement)
     }
@@ -796,7 +914,12 @@ impl<Q: StatementSource, M: Model> SelectBuilder<Q, M> {
         I: IntoIterator<Item = V>,
         V: Into<QueryValue>,
     {
-        self.push_filter(left.into().in_list(values), FilterMode::Replace)
+        Self {
+            state: self
+                .state
+                .push_filter(left.into().in_list(values), FilterMode::Replace),
+            projection: self.projection,
+        }
     }
 
     pub fn not_in_list<L, I, V>(self, left: L, values: I) -> Self
@@ -805,7 +928,12 @@ impl<Q: StatementSource, M: Model> SelectBuilder<Q, M> {
         I: IntoIterator<Item = V>,
         V: Into<QueryValue>,
     {
-        self.push_filter(left.into().not_in_list(values), FilterMode::Replace)
+        Self {
+            state: self
+                .state
+                .push_filter(left.into().not_in_list(values), FilterMode::Replace),
+            projection: self.projection,
+        }
     }
 
     pub fn between<L, Low, High>(self, expr: L, low: Low, high: High) -> Self
@@ -814,7 +942,12 @@ impl<Q: StatementSource, M: Model> SelectBuilder<Q, M> {
         Low: Into<QueryValue>,
         High: Into<QueryValue>,
     {
-        self.push_filter(expr.into().between(low, high), FilterMode::Replace)
+        Self {
+            state: self
+                .state
+                .push_filter(expr.into().between(low, high), FilterMode::Replace),
+            projection: self.projection,
+        }
     }
 
     pub fn not_between<L, Low, High>(self, expr: L, low: Low, high: High) -> Self
@@ -823,28 +956,39 @@ impl<Q: StatementSource, M: Model> SelectBuilder<Q, M> {
         Low: Into<QueryValue>,
         High: Into<QueryValue>,
     {
-        self.push_filter(expr.into().not_between(low, high), FilterMode::Replace)
+        Self {
+            state: self
+                .state
+                .push_filter(expr.into().not_between(low, high), FilterMode::Replace),
+            projection: self.projection,
+        }
     }
 
-    pub fn in_subquery<L: Into<QueryValue>>(self, left: L, subquery: Query) -> Self {
-        self.push_filter(left.into().in_subquery(subquery), FilterMode::Replace)
+    pub fn in_subquery<L: Into<QueryValue>, S: SubquerySource>(self, left: L, subquery: S) -> Self {
+        Self {
+            state: self
+                .state
+                .push_filter(left.into().in_subquery(subquery), FilterMode::Replace),
+            projection: self.projection,
+        }
     }
 
-    pub fn not_in_subquery<L: Into<QueryValue>>(self, left: L, subquery: Query) -> Self {
-        self.push_filter(left.into().not_in_subquery(subquery), FilterMode::Replace)
+    pub fn not_in_subquery<L: Into<QueryValue>, S: SubquerySource>(
+        self,
+        left: L,
+        subquery: S,
+    ) -> Self {
+        Self {
+            state: self
+                .state
+                .push_filter(left.into().not_in_subquery(subquery), FilterMode::Replace),
+            projection: self.projection,
+        }
     }
 
     pub fn raw(self) -> Result<Q::Iter, DatabaseError> {
         let (source, statement) = self.into_statement();
         source.execute_statement(&statement, &[])
-    }
-
-    pub fn fetch(self) -> Result<OrmIter<Q::Iter, M>, DatabaseError> {
-        Ok(self.raw()?.orm::<M>())
-    }
-
-    pub fn get(self) -> Result<Option<M>, DatabaseError> {
-        extract_optional_model(self.limit(1).raw()?)
     }
 
     pub fn exists(self) -> Result<bool, DatabaseError> {
@@ -853,7 +997,7 @@ impl<Q: StatementSource, M: Model> SelectBuilder<Q, M> {
     }
 
     pub fn count(self) -> Result<usize, DatabaseError> {
-        let SelectBuilder { source, filter, .. } = self;
+        let BuilderState { source, filter, .. } = self.state;
         let statement = orm_count_statement(M::table_name(), filter);
         let mut iter = source.execute_statement(&statement, &[])?;
         let count = match iter.next().transpose()? {
@@ -873,6 +1017,17 @@ impl<Q: StatementSource, M: Model> SelectBuilder<Q, M> {
         };
         iter.done()?;
         Ok(count)
+    }
+}
+
+impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> private::Sealed
+    for SelectBuilder<Q, M, P>
+{
+}
+
+impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> SubquerySource for SelectBuilder<Q, M, P> {
+    fn into_subquery(self) -> Query {
+        self.build_query()
     }
 }
 
@@ -1346,24 +1501,6 @@ pub fn orm_analyze_statement(table_name: &str) -> Statement {
     })
 }
 
-fn orm_select_query_statement(
-    table_name: &str,
-    fields: &[OrmField],
-    filter: Option<QueryExpr>,
-    order_bys: Vec<SortExpr>,
-    limit: Option<usize>,
-    offset: Option<usize>,
-) -> Statement {
-    Statement::Query(Box::new(select_query(
-        table_name,
-        select_projection(fields),
-        filter,
-        order_bys,
-        limit,
-        offset,
-    )))
-}
-
 fn orm_count_statement(table_name: &str, filter: Option<QueryExpr>) -> Statement {
     Statement::Query(Box::new(select_query(
         table_name,
@@ -1588,6 +1725,44 @@ pub trait FromDataValue: Sized {
     fn logical_type() -> Option<LogicalType>;
 
     fn from_data_value(value: DataValue) -> Option<Self>;
+}
+
+/// Typed adapter over a [`ResultIter`] that yields projected values instead of raw tuples.
+pub struct ProjectValueIter<I, T> {
+    inner: I,
+    _marker: PhantomData<T>,
+}
+
+impl<I, T> ProjectValueIter<I, T>
+where
+    I: ResultIter,
+    T: FromDataValue,
+{
+    fn new(inner: I) -> Self {
+        Self {
+            inner,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Finishes the underlying raw iterator.
+    pub fn done(self) -> Result<(), DatabaseError> {
+        self.inner.done()
+    }
+}
+
+impl<I, T> Iterator for ProjectValueIter<I, T>
+where
+    I: ResultIter,
+    T: FromDataValue,
+{
+    type Item = Result<T, DatabaseError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next()
+            .map(|result| result.and_then(extract_value_from_tuple::<T>))
+    }
 }
 
 /// Conversion trait from Rust values into [`DataValue`] for ORM parameters.
@@ -1918,6 +2093,40 @@ where
 
     Ok(match iter.next() {
         Some(tuple) => Some(M::from((&schema, tuple?))),
+        None => None,
+    })
+}
+
+fn extract_value_from_tuple<T: FromDataValue>(mut tuple: Tuple) -> Result<T, DatabaseError> {
+    let value = if tuple.values.len() == 1 {
+        tuple.values.swap_remove(0)
+    } else {
+        return Err(DatabaseError::MisMatch(
+            "one projected expression",
+            "the query result",
+        ));
+    };
+
+    let value = match T::logical_type() {
+        Some(ty) => value.cast(&ty)?,
+        None => value,
+    };
+
+    T::from_data_value(value).ok_or_else(|| {
+        DatabaseError::InvalidValue(format!(
+            "failed to convert projected value into {}",
+            std::any::type_name::<T>()
+        ))
+    })
+}
+
+fn extract_optional_value<I, T>(mut iter: I) -> Result<Option<T>, DatabaseError>
+where
+    I: ResultIter,
+    T: FromDataValue,
+{
+    Ok(match iter.next() {
+        Some(tuple) => Some(extract_value_from_tuple(tuple?)?),
         None => None,
     })
 }

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -12,17 +12,18 @@ use crate::types::LogicalType;
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use rust_decimal::Decimal;
 use sqlparser::ast::helpers::attached_token::AttachedToken;
+use sqlparser::ast::TruncateTableTarget;
 use sqlparser::ast::{
     AlterColumnOperation, AlterTable, AlterTableOperation, Analyze, Assignment, AssignmentTarget,
     BinaryOperator as SqlBinaryOperator, CaseWhen, CastKind, CharLengthUnits, ColumnDef,
-    ColumnOption, ColumnOptionDef, CreateIndex, CreateTable, DataType, Delete, Distinct, Expr,
-    FromTable, Function, FunctionArg, FunctionArgExpr, FunctionArgumentList, FunctionArguments,
-    GroupByExpr, HiveDistributionStyle, Ident, IndexColumn, Insert, Join, JoinConstraint,
-    JoinOperator, KeyOrIndexDisplay, LimitClause, NullsDistinctOption, ObjectName, ObjectType,
-    Offset, OffsetRows, OrderBy, OrderByExpr, OrderByKind, OrderByOptions, PrimaryKeyConstraint,
-    Query, Select, SelectFlavor, SelectItem, SetExpr, SetOperator, SetQuantifier, TableAlias,
-    TableFactor, TableObject, TableWithJoins, TimezoneInfo, UniqueConstraint, Update, Value,
-    Values,
+    ColumnOption, ColumnOptionDef, CreateIndex, CreateTable, CreateTableOptions, CreateView,
+    DataType, Delete, Distinct, Expr, FromTable, Function, FunctionArg, FunctionArgExpr,
+    FunctionArgumentList, FunctionArguments, GroupByExpr, HiveDistributionStyle, Ident,
+    IndexColumn, Insert, Join, JoinConstraint, JoinOperator, KeyOrIndexDisplay, LimitClause,
+    NullsDistinctOption, ObjectName, ObjectType, Offset, OffsetRows, OrderBy, OrderByExpr,
+    OrderByKind, OrderByOptions, PrimaryKeyConstraint, Query, Select, SelectFlavor, SelectItem,
+    SetExpr, SetOperator, SetQuantifier, TableAlias, TableFactor, TableObject, TableWithJoins,
+    TimezoneInfo, Truncate, UniqueConstraint, Update, Value, Values, ViewColumnDef,
 };
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
@@ -823,11 +824,21 @@ impl QueryExpr {
 struct SortExpr {
     value: QueryValue,
     desc: bool,
+    nulls_first: Option<bool>,
 }
 
 impl SortExpr {
     fn new(value: QueryValue, desc: bool) -> Self {
-        Self { value, desc }
+        Self {
+            value,
+            desc,
+            nulls_first: None,
+        }
+    }
+
+    fn with_nulls(mut self, nulls_first: bool) -> Self {
+        self.nulls_first = Some(nulls_first);
+        self
     }
 
     fn into_ast(self) -> OrderByExpr {
@@ -835,7 +846,7 @@ impl SortExpr {
             expr: self.value.into_expr(),
             options: OrderByOptions {
                 asc: Some(!self.desc),
-                nulls_first: None,
+                nulls_first: self.nulls_first,
             },
             with_fill: None,
         }
@@ -1919,6 +1930,12 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
         self
     }
 
+    /// Applies `NULLS FIRST` to the most recently added sort key.
+    pub fn nulls_first(mut self) -> Self {
+        query_set_last_order_nulls(&mut self.query, true);
+        self
+    }
+
     /// Appends a descending sort key to the set query result.
     ///
     /// ```rust,ignore
@@ -1932,6 +1949,12 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
     /// ```
     pub fn desc<V: Into<QueryValue>>(mut self, value: V) -> Self {
         query_push_order(&mut self.query, set_query_order_value(value.into()).desc());
+        self
+    }
+
+    /// Applies `NULLS LAST` to the most recently added sort key.
+    pub fn nulls_last(mut self) -> Self {
+        query_set_last_order_nulls(&mut self.query, false);
         self
     }
 
@@ -2591,6 +2614,16 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
         Self::from_inner(self.inner.asc(value))
     }
 
+    /// Applies `NULLS FIRST` to the most recently added sort key.
+    pub fn nulls_first(self) -> Self {
+        Self::from_inner(self.inner.nulls_first())
+    }
+
+    /// Applies `NULLS LAST` to the most recently added sort key.
+    pub fn nulls_last(self) -> Self {
+        Self::from_inner(self.inner.nulls_last())
+    }
+
     /// Appends a descending sort key.
     ///
     /// ```rust,ignore
@@ -3225,6 +3258,20 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
             state: self.state.push_order(value.into().asc()),
             projection: self.projection,
         }
+    }
+
+    fn nulls_first(mut self) -> Self {
+        if let Some(last) = self.state.order_bys.last_mut() {
+            *last = last.clone().with_nulls(true);
+        }
+        self
+    }
+
+    fn nulls_last(mut self) -> Self {
+        if let Some(last) = self.state.order_bys.last_mut() {
+            *last = last.clone().with_nulls(false);
+        }
+        self
     }
 
     fn desc<V: Into<QueryValue>>(self, value: V) -> Self {
@@ -3889,6 +3936,19 @@ fn query_push_order(query: &mut Query, order: SortExpr) {
     }
 }
 
+fn query_set_last_order_nulls(query: &mut Query, nulls_first: bool) {
+    if let Some(order_by) = query.order_by.as_mut() {
+        match &mut order_by.kind {
+            OrderByKind::Expressions(exprs) => {
+                if let Some(last) = exprs.last_mut() {
+                    last.options.nulls_first = Some(nulls_first);
+                }
+            }
+            OrderByKind::All(_) => {}
+        }
+    }
+}
+
 fn query_set_limit(query: &mut Query, limit: usize) {
     let offset = query_current_offset(query);
     query.limit_clause = Some(LimitClause::LimitOffset {
@@ -4109,6 +4169,19 @@ pub fn orm_select_statement(table_name: &str, fields: &[OrmField]) -> Statement 
 
 #[doc(hidden)]
 pub fn orm_insert_statement(table_name: &str, fields: &[OrmField]) -> Statement {
+    orm_insert_values_statement(table_name, fields, false)
+}
+
+#[doc(hidden)]
+pub fn orm_overwrite_statement(table_name: &str, fields: &[OrmField]) -> Statement {
+    orm_insert_values_statement(table_name, fields, true)
+}
+
+fn orm_insert_values_statement(
+    table_name: &str,
+    fields: &[OrmField],
+    overwrite: bool,
+) -> Statement {
     Statement::Insert(Insert {
         insert_token: AttachedToken::empty(),
         optimizer_hint: None,
@@ -4118,7 +4191,7 @@ pub fn orm_insert_statement(table_name: &str, fields: &[OrmField]) -> Statement 
         table: TableObject::TableName(object_name(table_name)),
         table_alias: None,
         columns: fields.iter().map(|field| ident(field.column)).collect(),
-        overwrite: false,
+        overwrite,
         source: Some(Box::new(values_query(
             fields
                 .iter()
@@ -4137,6 +4210,59 @@ pub fn orm_insert_statement(table_name: &str, fields: &[OrmField]) -> Statement 
         settings: None,
         format_clause: None,
     })
+}
+
+#[doc(hidden)]
+pub fn orm_truncate_statement(table_name: &str) -> Statement {
+    Statement::Truncate(Truncate {
+        table_names: vec![TruncateTableTarget {
+            name: object_name(table_name),
+            only: false,
+            has_asterisk: false,
+        }],
+        partitions: None,
+        table: true,
+        if_exists: false,
+        identity: None,
+        cascade: None,
+        on_cluster: None,
+    })
+}
+
+#[doc(hidden)]
+pub fn orm_create_view_statement(view_name: &str, query: Query, or_replace: bool) -> Statement {
+    Statement::CreateView(CreateView {
+        or_alter: false,
+        or_replace,
+        materialized: false,
+        secure: false,
+        name: object_name(view_name),
+        name_before_not_exists: false,
+        columns: Vec::<ViewColumnDef>::new(),
+        query: Box::new(query),
+        options: CreateTableOptions::None,
+        cluster_by: vec![],
+        comment: None,
+        with_no_schema_binding: false,
+        if_not_exists: false,
+        temporary: false,
+        to: None,
+        params: None,
+    })
+}
+
+#[doc(hidden)]
+pub fn orm_drop_view_statement(view_name: &str, if_exists: bool) -> Statement {
+    Statement::Drop {
+        object_type: ObjectType::View,
+        if_exists,
+        names: vec![object_name(view_name)],
+        cascade: false,
+        restrict: false,
+        purge: false,
+        temporary: false,
+        table: None,
+    }
 }
 
 #[doc(hidden)]
@@ -5156,9 +5282,19 @@ fn orm_analyze<E: StatementSource, M: Model>(executor: E) -> Result<(), Database
 }
 
 fn orm_insert<E: StatementSource, M: Model>(executor: E, model: &M) -> Result<(), DatabaseError> {
-    executor
-        .execute_statement(M::insert_statement(), model.params())?
-        .done()
+    orm_insert_model(executor, M::insert_statement(), model.params())
+}
+
+fn orm_insert_model<E, A>(
+    executor: E,
+    statement: &Statement,
+    params: A,
+) -> Result<(), DatabaseError>
+where
+    E: StatementSource,
+    A: AsRef<[(&'static str, DataValue)]>,
+{
+    executor.execute_statement(statement, params)?.done()
 }
 
 fn orm_get<E: StatementSource, M: Model>(

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -133,6 +133,181 @@ pub struct Field<M, T> {
     _marker: PhantomData<(M, T)>,
 }
 
+trait ValueExpressionOps: Sized {
+    fn into_query_value(self) -> QueryValue;
+
+    fn eq_expr<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        QueryExpr::from_ast(Expr::BinaryOp {
+            left: Box::new(self.into_query_value().into_ast()),
+            op: CompareOp::Eq.as_ast(),
+            right: Box::new(value.into().into_ast()),
+        })
+    }
+
+    fn ne_expr<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        QueryExpr::from_ast(Expr::BinaryOp {
+            left: Box::new(self.into_query_value().into_ast()),
+            op: CompareOp::Ne.as_ast(),
+            right: Box::new(value.into().into_ast()),
+        })
+    }
+
+    fn gt_expr<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        QueryExpr::from_ast(Expr::BinaryOp {
+            left: Box::new(self.into_query_value().into_ast()),
+            op: CompareOp::Gt.as_ast(),
+            right: Box::new(value.into().into_ast()),
+        })
+    }
+
+    fn gte_expr<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        QueryExpr::from_ast(Expr::BinaryOp {
+            left: Box::new(self.into_query_value().into_ast()),
+            op: CompareOp::Gte.as_ast(),
+            right: Box::new(value.into().into_ast()),
+        })
+    }
+
+    fn lt_expr<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        QueryExpr::from_ast(Expr::BinaryOp {
+            left: Box::new(self.into_query_value().into_ast()),
+            op: CompareOp::Lt.as_ast(),
+            right: Box::new(value.into().into_ast()),
+        })
+    }
+
+    fn lte_expr<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        QueryExpr::from_ast(Expr::BinaryOp {
+            left: Box::new(self.into_query_value().into_ast()),
+            op: CompareOp::Lte.as_ast(),
+            right: Box::new(value.into().into_ast()),
+        })
+    }
+
+    fn is_null_expr(self) -> QueryExpr {
+        QueryExpr::from_ast(Expr::IsNull(Box::new(self.into_query_value().into_ast())))
+    }
+
+    fn is_not_null_expr(self) -> QueryExpr {
+        QueryExpr::from_ast(Expr::IsNotNull(Box::new(
+            self.into_query_value().into_ast(),
+        )))
+    }
+
+    fn like_expr<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
+        QueryExpr::from_ast(Expr::Like {
+            negated: false,
+            expr: Box::new(self.into_query_value().into_ast()),
+            pattern: Box::new(pattern.into().into_ast()),
+            escape_char: None,
+            any: false,
+        })
+    }
+
+    fn not_like_expr<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
+        QueryExpr::from_ast(Expr::Like {
+            negated: true,
+            expr: Box::new(self.into_query_value().into_ast()),
+            pattern: Box::new(pattern.into().into_ast()),
+            escape_char: None,
+            any: false,
+        })
+    }
+
+    fn in_list_expr<I, V>(self, values: I) -> QueryExpr
+    where
+        I: IntoIterator<Item = V>,
+        V: Into<QueryValue>,
+    {
+        QueryExpr::from_ast(Expr::InList {
+            expr: Box::new(self.into_query_value().into_ast()),
+            list: values
+                .into_iter()
+                .map(Into::into)
+                .map(QueryValue::into_ast)
+                .collect(),
+            negated: false,
+        })
+    }
+
+    fn not_in_list_expr<I, V>(self, values: I) -> QueryExpr
+    where
+        I: IntoIterator<Item = V>,
+        V: Into<QueryValue>,
+    {
+        QueryExpr::from_ast(Expr::InList {
+            expr: Box::new(self.into_query_value().into_ast()),
+            list: values
+                .into_iter()
+                .map(Into::into)
+                .map(QueryValue::into_ast)
+                .collect(),
+            negated: true,
+        })
+    }
+
+    fn between_expr<L: Into<QueryValue>, H: Into<QueryValue>>(self, low: L, high: H) -> QueryExpr {
+        QueryExpr::from_ast(Expr::Between {
+            expr: Box::new(self.into_query_value().into_ast()),
+            negated: false,
+            low: Box::new(low.into().into_ast()),
+            high: Box::new(high.into().into_ast()),
+        })
+    }
+
+    fn not_between_expr<L: Into<QueryValue>, H: Into<QueryValue>>(
+        self,
+        low: L,
+        high: H,
+    ) -> QueryExpr {
+        QueryExpr::from_ast(Expr::Between {
+            expr: Box::new(self.into_query_value().into_ast()),
+            negated: true,
+            low: Box::new(low.into().into_ast()),
+            high: Box::new(high.into().into_ast()),
+        })
+    }
+
+    fn cast_value(self, data_type: &str) -> Result<QueryValue, DatabaseError> {
+        Ok(self.cast_to_value(parse_data_type_fragment(data_type)?))
+    }
+
+    fn cast_to_value(self, data_type: DataType) -> QueryValue {
+        QueryValue::from_ast(Expr::Cast {
+            kind: CastKind::Cast,
+            expr: Box::new(self.into_query_value().into_ast()),
+            data_type,
+            array: false,
+            format: None,
+        })
+    }
+
+    fn alias_value(self, alias: &str) -> ProjectedValue {
+        ProjectedValue {
+            item: SelectItem::ExprWithAlias {
+                expr: self.into_query_value().into_ast(),
+                alias: ident(alias),
+            },
+        }
+    }
+
+    fn in_subquery_expr<S: SubquerySource>(self, subquery: S) -> QueryExpr {
+        QueryExpr::from_ast(Expr::InSubquery {
+            expr: Box::new(self.into_query_value().into_ast()),
+            subquery: Box::new(subquery.into_subquery()),
+            negated: false,
+        })
+    }
+
+    fn not_in_subquery_expr<S: SubquerySource>(self, subquery: S) -> QueryExpr {
+        QueryExpr::from_ast(Expr::InSubquery {
+            expr: Box::new(self.into_query_value().into_ast()),
+            subquery: Box::new(subquery.into_subquery()),
+            negated: true,
+        })
+    }
+}
+
 impl<M, T> Field<M, T> {
     pub const fn new(table: &'static str, column: &'static str) -> Self {
         Self {
@@ -150,43 +325,43 @@ impl<M, T> Field<M, T> {
     }
 
     pub fn eq<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        self.value().eq(value)
+        ValueExpressionOps::eq_expr(self, value)
     }
 
     pub fn ne<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        self.value().ne(value)
+        ValueExpressionOps::ne_expr(self, value)
     }
 
     pub fn gt<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        self.value().gt(value)
+        ValueExpressionOps::gt_expr(self, value)
     }
 
     pub fn gte<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        self.value().gte(value)
+        ValueExpressionOps::gte_expr(self, value)
     }
 
     pub fn lt<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        self.value().lt(value)
+        ValueExpressionOps::lt_expr(self, value)
     }
 
     pub fn lte<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        self.value().lte(value)
+        ValueExpressionOps::lte_expr(self, value)
     }
 
     pub fn is_null(self) -> QueryExpr {
-        self.value().is_null()
+        ValueExpressionOps::is_null_expr(self)
     }
 
     pub fn is_not_null(self) -> QueryExpr {
-        self.value().is_not_null()
+        ValueExpressionOps::is_not_null_expr(self)
     }
 
     pub fn like<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
-        self.value().like(pattern)
+        ValueExpressionOps::like_expr(self, pattern)
     }
 
     pub fn not_like<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
-        self.value().not_like(pattern)
+        ValueExpressionOps::not_like_expr(self, pattern)
     }
 
     pub fn in_list<I, V>(self, values: I) -> QueryExpr
@@ -194,7 +369,7 @@ impl<M, T> Field<M, T> {
         I: IntoIterator<Item = V>,
         V: Into<QueryValue>,
     {
-        self.value().in_list(values)
+        ValueExpressionOps::in_list_expr(self, values)
     }
 
     pub fn not_in_list<I, V>(self, values: I) -> QueryExpr
@@ -202,11 +377,11 @@ impl<M, T> Field<M, T> {
         I: IntoIterator<Item = V>,
         V: Into<QueryValue>,
     {
-        self.value().not_in_list(values)
+        ValueExpressionOps::not_in_list_expr(self, values)
     }
 
     pub fn between<L: Into<QueryValue>, H: Into<QueryValue>>(self, low: L, high: H) -> QueryExpr {
-        self.value().between(low, high)
+        ValueExpressionOps::between_expr(self, low, high)
     }
 
     pub fn not_between<L: Into<QueryValue>, H: Into<QueryValue>>(
@@ -214,27 +389,27 @@ impl<M, T> Field<M, T> {
         low: L,
         high: H,
     ) -> QueryExpr {
-        self.value().not_between(low, high)
+        ValueExpressionOps::not_between_expr(self, low, high)
     }
 
     pub fn cast(self, data_type: &str) -> Result<QueryValue, DatabaseError> {
-        self.value().cast(data_type)
+        ValueExpressionOps::cast_value(self, data_type)
     }
 
     pub fn cast_to(self, data_type: DataType) -> QueryValue {
-        self.value().cast_to(data_type)
+        ValueExpressionOps::cast_to_value(self, data_type)
     }
 
     pub fn alias(self, alias: &str) -> ProjectedValue {
-        self.value().alias(alias)
+        ValueExpressionOps::alias_value(self, alias)
     }
 
     pub fn in_subquery<S: SubquerySource>(self, subquery: S) -> QueryExpr {
-        self.value().in_subquery(subquery)
+        ValueExpressionOps::in_subquery_expr(self, subquery)
     }
 
     pub fn not_in_subquery<S: SubquerySource>(self, subquery: S) -> QueryExpr {
-        self.value().not_in_subquery(subquery)
+        ValueExpressionOps::not_in_subquery_expr(self, subquery)
     }
 }
 
@@ -490,79 +665,43 @@ impl QueryValue {
     }
 
     pub fn eq<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::from_ast(Expr::BinaryOp {
-            left: Box::new(self.into_ast()),
-            op: CompareOp::Eq.as_ast(),
-            right: Box::new(value.into().into_ast()),
-        })
+        ValueExpressionOps::eq_expr(self, value)
     }
 
     pub fn ne<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::from_ast(Expr::BinaryOp {
-            left: Box::new(self.into_ast()),
-            op: CompareOp::Ne.as_ast(),
-            right: Box::new(value.into().into_ast()),
-        })
+        ValueExpressionOps::ne_expr(self, value)
     }
 
     pub fn gt<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::from_ast(Expr::BinaryOp {
-            left: Box::new(self.into_ast()),
-            op: CompareOp::Gt.as_ast(),
-            right: Box::new(value.into().into_ast()),
-        })
+        ValueExpressionOps::gt_expr(self, value)
     }
 
     pub fn gte<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::from_ast(Expr::BinaryOp {
-            left: Box::new(self.into_ast()),
-            op: CompareOp::Gte.as_ast(),
-            right: Box::new(value.into().into_ast()),
-        })
+        ValueExpressionOps::gte_expr(self, value)
     }
 
     pub fn lt<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::from_ast(Expr::BinaryOp {
-            left: Box::new(self.into_ast()),
-            op: CompareOp::Lt.as_ast(),
-            right: Box::new(value.into().into_ast()),
-        })
+        ValueExpressionOps::lt_expr(self, value)
     }
 
     pub fn lte<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::from_ast(Expr::BinaryOp {
-            left: Box::new(self.into_ast()),
-            op: CompareOp::Lte.as_ast(),
-            right: Box::new(value.into().into_ast()),
-        })
+        ValueExpressionOps::lte_expr(self, value)
     }
 
     pub fn is_null(self) -> QueryExpr {
-        QueryExpr::from_ast(Expr::IsNull(Box::new(self.into_ast())))
+        ValueExpressionOps::is_null_expr(self)
     }
 
     pub fn is_not_null(self) -> QueryExpr {
-        QueryExpr::from_ast(Expr::IsNotNull(Box::new(self.into_ast())))
+        ValueExpressionOps::is_not_null_expr(self)
     }
 
     pub fn like<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
-        QueryExpr::from_ast(Expr::Like {
-            negated: false,
-            expr: Box::new(self.into_ast()),
-            pattern: Box::new(pattern.into().into_ast()),
-            escape_char: None,
-            any: false,
-        })
+        ValueExpressionOps::like_expr(self, pattern)
     }
 
     pub fn not_like<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
-        QueryExpr::from_ast(Expr::Like {
-            negated: true,
-            expr: Box::new(self.into_ast()),
-            pattern: Box::new(pattern.into().into_ast()),
-            escape_char: None,
-            any: false,
-        })
+        ValueExpressionOps::not_like_expr(self, pattern)
     }
 
     pub fn in_list<I, V>(self, values: I) -> QueryExpr
@@ -570,15 +709,7 @@ impl QueryValue {
         I: IntoIterator<Item = V>,
         V: Into<QueryValue>,
     {
-        QueryExpr::from_ast(Expr::InList {
-            expr: Box::new(self.into_ast()),
-            list: values
-                .into_iter()
-                .map(Into::into)
-                .map(QueryValue::into_ast)
-                .collect(),
-            negated: false,
-        })
+        ValueExpressionOps::in_list_expr(self, values)
     }
 
     pub fn not_in_list<I, V>(self, values: I) -> QueryExpr
@@ -586,24 +717,11 @@ impl QueryValue {
         I: IntoIterator<Item = V>,
         V: Into<QueryValue>,
     {
-        QueryExpr::from_ast(Expr::InList {
-            expr: Box::new(self.into_ast()),
-            list: values
-                .into_iter()
-                .map(Into::into)
-                .map(QueryValue::into_ast)
-                .collect(),
-            negated: true,
-        })
+        ValueExpressionOps::not_in_list_expr(self, values)
     }
 
     pub fn between<L: Into<QueryValue>, H: Into<QueryValue>>(self, low: L, high: H) -> QueryExpr {
-        QueryExpr::from_ast(Expr::Between {
-            expr: Box::new(self.into_ast()),
-            negated: false,
-            low: Box::new(low.into().into_ast()),
-            high: Box::new(high.into().into_ast()),
-        })
+        ValueExpressionOps::between_expr(self, low, high)
     }
 
     pub fn not_between<L: Into<QueryValue>, H: Into<QueryValue>>(
@@ -611,26 +729,15 @@ impl QueryValue {
         low: L,
         high: H,
     ) -> QueryExpr {
-        QueryExpr::from_ast(Expr::Between {
-            expr: Box::new(self.into_ast()),
-            negated: true,
-            low: Box::new(low.into().into_ast()),
-            high: Box::new(high.into().into_ast()),
-        })
+        ValueExpressionOps::not_between_expr(self, low, high)
     }
 
     pub fn cast(self, data_type: &str) -> Result<QueryValue, DatabaseError> {
-        Ok(self.cast_to(parse_data_type_fragment(data_type)?))
+        ValueExpressionOps::cast_value(self, data_type)
     }
 
     pub fn cast_to(self, data_type: DataType) -> QueryValue {
-        QueryValue::from_ast(Expr::Cast {
-            kind: CastKind::Cast,
-            expr: Box::new(self.into_ast()),
-            data_type,
-            array: false,
-            format: None,
-        })
+        ValueExpressionOps::cast_to_value(self, data_type)
     }
 
     pub fn subquery<S: SubquerySource>(query: S) -> QueryValue {
@@ -638,19 +745,11 @@ impl QueryValue {
     }
 
     pub fn in_subquery<S: SubquerySource>(self, subquery: S) -> QueryExpr {
-        QueryExpr::from_ast(Expr::InSubquery {
-            expr: Box::new(self.into_ast()),
-            subquery: Box::new(subquery.into_subquery()),
-            negated: false,
-        })
+        ValueExpressionOps::in_subquery_expr(self, subquery)
     }
 
     pub fn not_in_subquery<S: SubquerySource>(self, subquery: S) -> QueryExpr {
-        QueryExpr::from_ast(Expr::InSubquery {
-            expr: Box::new(self.into_ast()),
-            subquery: Box::new(subquery.into_subquery()),
-            negated: true,
-        })
+        ValueExpressionOps::not_in_subquery_expr(self, subquery)
     }
 
     fn asc(self) -> SortExpr {
@@ -687,6 +786,18 @@ impl QueryValue {
 impl<M, T> From<Field<M, T>> for QueryValue {
     fn from(value: Field<M, T>) -> Self {
         value.value()
+    }
+}
+
+impl<M, T> ValueExpressionOps for Field<M, T> {
+    fn into_query_value(self) -> QueryValue {
+        self.value()
+    }
+}
+
+impl ValueExpressionOps for QueryValue {
+    fn into_query_value(self) -> QueryValue {
+        self
     }
 }
 
@@ -805,23 +916,28 @@ pub trait SubquerySource: private::Sealed {
     fn into_subquery(self) -> Query;
 }
 
-/// Lightweight single-table query builder for ORM models.
-pub struct SelectBuilder<Q: StatementSource, M: Model, P = ModelProjection> {
+struct QueryBuilder<Q: StatementSource, M: Model, P = ModelProjection> {
     state: BuilderState<Q, M>,
     projection: P,
 }
 
-/// Lightweight single-table query builder for scalar value projections.
-pub type ProjectValueBuilder<Q, M> = SelectBuilder<Q, M, ValueProjection>;
-/// Lightweight single-table query builder for tuple projections.
-pub type ProjectTupleBuilder<Q, M> = SelectBuilder<Q, M, TupleProjection>;
+/// Lightweight single-table query builder for ORM models.
+pub struct FromBuilder<Q: StatementSource, M: Model, P = ModelProjection> {
+    inner: QueryBuilder<Q, M, P>,
+}
 
+#[doc(hidden)]
+pub type ProjectionBuilder<Q, M, P> = FromBuilder<Q, M, P>;
+
+#[doc(hidden)]
 pub struct ModelProjection;
 
+#[doc(hidden)]
 pub struct ValueProjection {
     value: ProjectedValue,
 }
 
+#[doc(hidden)]
 pub struct TupleProjection {
     values: Vec<ProjectedValue>,
 }
@@ -910,44 +1026,52 @@ enum FilterMode {
     Or,
 }
 
-macro_rules! impl_select_builder_compare_methods {
-    ($($name:ident),+ $(,)?) => {
-        $(
-            pub fn $name<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
-                self.push_filter(left.into().$name(right), FilterMode::Replace)
-            }
-        )+
-    };
-}
-
-macro_rules! impl_select_builder_null_methods {
-    ($($name:ident),+ $(,)?) => {
-        $(
-            pub fn $name<V: Into<QueryValue>>(self, value: V) -> Self {
-                self.push_filter(value.into().$name(), FilterMode::Replace)
-            }
-        )+
-    };
-}
-
-macro_rules! impl_select_builder_like_methods {
-    ($($name:ident),+ $(,)?) => {
-        $(
-            pub fn $name<L: Into<QueryValue>, R: Into<QueryValue>>(self, value: L, pattern: R) -> Self {
-                self.push_filter(value.into().$name(pattern), FilterMode::Replace)
-            }
-        )+
-    };
-}
-
-impl<Q: StatementSource, M: Model> SelectBuilder<Q, M, ModelProjection> {
+impl<Q: StatementSource, M: Model> QueryBuilder<Q, M, ModelProjection> {
     fn new(source: Q) -> Self {
         Self {
             state: BuilderState::new(source),
             projection: ModelProjection,
         }
     }
+}
 
+impl<Q: StatementSource, M: Model, P> QueryBuilder<Q, M, P> {
+    fn with_projection<P2>(self, projection: P2) -> QueryBuilder<Q, M, P2> {
+        QueryBuilder {
+            state: self.state,
+            projection,
+        }
+    }
+}
+
+impl<Q: StatementSource, M: Model, P> FromBuilder<Q, M, P> {
+    fn from_inner(inner: QueryBuilder<Q, M, P>) -> Self {
+        Self { inner }
+    }
+
+    fn with_projection<P2>(self, projection: P2) -> FromBuilder<Q, M, P2> {
+        FromBuilder::from_inner(self.inner.with_projection(projection))
+    }
+}
+
+impl<Q: StatementSource, M: Model> FromBuilder<Q, M, ModelProjection> {
+    pub fn project_value<V: Into<ProjectedValue>>(
+        self,
+        value: V,
+    ) -> ProjectionBuilder<Q, M, ValueProjection> {
+        self.with_projection(ValueProjection {
+            value: value.into(),
+        })
+    }
+
+    pub fn project_tuple<V: IntoProjectedTuple>(
+        self,
+        values: V,
+    ) -> ProjectionBuilder<Q, M, TupleProjection> {
+        self.with_projection(TupleProjection {
+            values: values.into_projected_values(),
+        })
+    }
     pub fn fetch(self) -> Result<OrmIter<Q::Iter, M>, DatabaseError> {
         Ok(self.raw()?.orm::<M>())
     }
@@ -957,16 +1081,157 @@ impl<Q: StatementSource, M: Model> SelectBuilder<Q, M, ModelProjection> {
     }
 }
 
-impl<Q: StatementSource, M: Model> SelectBuilder<Q, M, ValueProjection> {
-    fn new_value<V: Into<ProjectedValue>>(source: Q, value: V) -> Self {
-        Self {
-            state: BuilderState::new(source),
-            projection: ValueProjection {
-                value: value.into(),
-            },
-        }
+impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
+    pub fn filter(self, expr: QueryExpr) -> Self {
+        Self::from_inner(self.inner.filter(expr))
     }
 
+    pub fn and(self, left: QueryExpr, right: QueryExpr) -> Self {
+        Self::from_inner(self.inner.and(left, right))
+    }
+
+    pub fn or(self, left: QueryExpr, right: QueryExpr) -> Self {
+        Self::from_inner(self.inner.or(left, right))
+    }
+
+    pub fn not(self, expr: QueryExpr) -> Self {
+        Self::from_inner(self.inner.not(expr))
+    }
+
+    pub fn where_exists<S: SubquerySource>(self, subquery: S) -> Self {
+        Self::from_inner(self.inner.where_exists(subquery))
+    }
+
+    pub fn where_not_exists<S: SubquerySource>(self, subquery: S) -> Self {
+        Self::from_inner(self.inner.where_not_exists(subquery))
+    }
+
+    pub fn group_by<V: Into<QueryValue>>(self, value: V) -> Self {
+        Self::from_inner(self.inner.group_by(value))
+    }
+
+    pub fn having(self, expr: QueryExpr) -> Self {
+        Self::from_inner(self.inner.having(expr))
+    }
+
+    pub fn asc<V: Into<QueryValue>>(self, value: V) -> Self {
+        Self::from_inner(self.inner.asc(value))
+    }
+
+    pub fn desc<V: Into<QueryValue>>(self, value: V) -> Self {
+        Self::from_inner(self.inner.desc(value))
+    }
+
+    pub fn limit(self, limit: usize) -> Self {
+        Self::from_inner(self.inner.limit(limit))
+    }
+
+    pub fn offset(self, offset: usize) -> Self {
+        Self::from_inner(self.inner.offset(offset))
+    }
+
+    pub fn eq<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+        Self::from_inner(self.inner.eq(left, right))
+    }
+
+    pub fn ne<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+        Self::from_inner(self.inner.ne(left, right))
+    }
+
+    pub fn gt<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+        Self::from_inner(self.inner.gt(left, right))
+    }
+
+    pub fn gte<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+        Self::from_inner(self.inner.gte(left, right))
+    }
+
+    pub fn lt<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+        Self::from_inner(self.inner.lt(left, right))
+    }
+
+    pub fn lte<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+        Self::from_inner(self.inner.lte(left, right))
+    }
+
+    pub fn is_null<V: Into<QueryValue>>(self, value: V) -> Self {
+        Self::from_inner(self.inner.is_null(value))
+    }
+
+    pub fn is_not_null<V: Into<QueryValue>>(self, value: V) -> Self {
+        Self::from_inner(self.inner.is_not_null(value))
+    }
+
+    pub fn like<L: Into<QueryValue>, R: Into<QueryValue>>(self, value: L, pattern: R) -> Self {
+        Self::from_inner(self.inner.like(value, pattern))
+    }
+
+    pub fn not_like<L: Into<QueryValue>, R: Into<QueryValue>>(self, value: L, pattern: R) -> Self {
+        Self::from_inner(self.inner.not_like(value, pattern))
+    }
+
+    pub fn in_list<L, I, V>(self, left: L, values: I) -> Self
+    where
+        L: Into<QueryValue>,
+        I: IntoIterator<Item = V>,
+        V: Into<QueryValue>,
+    {
+        Self::from_inner(self.inner.in_list(left, values))
+    }
+
+    pub fn not_in_list<L, I, V>(self, left: L, values: I) -> Self
+    where
+        L: Into<QueryValue>,
+        I: IntoIterator<Item = V>,
+        V: Into<QueryValue>,
+    {
+        Self::from_inner(self.inner.not_in_list(left, values))
+    }
+
+    pub fn between<L, Low, High>(self, expr: L, low: Low, high: High) -> Self
+    where
+        L: Into<QueryValue>,
+        Low: Into<QueryValue>,
+        High: Into<QueryValue>,
+    {
+        Self::from_inner(self.inner.between(expr, low, high))
+    }
+
+    pub fn not_between<L, Low, High>(self, expr: L, low: Low, high: High) -> Self
+    where
+        L: Into<QueryValue>,
+        Low: Into<QueryValue>,
+        High: Into<QueryValue>,
+    {
+        Self::from_inner(self.inner.not_between(expr, low, high))
+    }
+
+    pub fn in_subquery<L: Into<QueryValue>, S: SubquerySource>(self, left: L, subquery: S) -> Self {
+        Self::from_inner(self.inner.in_subquery(left, subquery))
+    }
+
+    pub fn not_in_subquery<L: Into<QueryValue>, S: SubquerySource>(
+        self,
+        left: L,
+        subquery: S,
+    ) -> Self {
+        Self::from_inner(self.inner.not_in_subquery(left, subquery))
+    }
+
+    pub fn raw(self) -> Result<Q::Iter, DatabaseError> {
+        self.inner.raw()
+    }
+
+    pub fn exists(self) -> Result<bool, DatabaseError> {
+        self.inner.exists()
+    }
+
+    pub fn count(self) -> Result<usize, DatabaseError> {
+        self.inner.count()
+    }
+}
+
+impl<Q: StatementSource, M: Model> FromBuilder<Q, M, ValueProjection> {
     pub fn fetch<T: FromDataValue>(self) -> Result<ProjectValueIter<Q::Iter, T>, DatabaseError> {
         Ok(ProjectValueIter::new(self.raw()?))
     }
@@ -976,16 +1241,7 @@ impl<Q: StatementSource, M: Model> SelectBuilder<Q, M, ValueProjection> {
     }
 }
 
-impl<Q: StatementSource, M: Model> SelectBuilder<Q, M, TupleProjection> {
-    fn new_tuple<V: IntoProjectedTuple>(source: Q, values: V) -> Self {
-        Self {
-            state: BuilderState::new(source),
-            projection: TupleProjection {
-                values: values.into_projected_values(),
-            },
-        }
-    }
-
+impl<Q: StatementSource, M: Model> FromBuilder<Q, M, TupleProjection> {
     pub fn fetch<T: FromQueryTuple>(self) -> Result<ProjectTupleIter<Q::Iter, T>, DatabaseError> {
         Ok(ProjectTupleIter::new(self.raw()?))
     }
@@ -995,7 +1251,7 @@ impl<Q: StatementSource, M: Model> SelectBuilder<Q, M, TupleProjection> {
     }
 }
 
-impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> SelectBuilder<Q, M, P> {
+impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
     fn push_filter(self, expr: QueryExpr, mode: FilterMode) -> Self {
         Self {
             state: self.state.push_filter(expr, mode),
@@ -1084,7 +1340,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> SelectBuilder<Q, M, P> 
     }
 
     fn build_query(self) -> Query {
-        let SelectBuilder {
+        let QueryBuilder {
             state:
                 BuilderState {
                     source: _,
@@ -1112,7 +1368,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> SelectBuilder<Q, M, P> 
     }
 
     fn into_statement(self) -> (Q, Statement) {
-        let SelectBuilder {
+        let QueryBuilder {
             state:
                 BuilderState {
                     source,
@@ -1141,11 +1397,45 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> SelectBuilder<Q, M, P> 
         (source, statement)
     }
 
-    impl_select_builder_compare_methods!(eq, ne, gt, gte, lt, lte);
+    pub fn eq<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+        self.push_filter(left.into().eq(right), FilterMode::Replace)
+    }
 
-    impl_select_builder_null_methods!(is_null, is_not_null);
+    pub fn ne<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+        self.push_filter(left.into().ne(right), FilterMode::Replace)
+    }
 
-    impl_select_builder_like_methods!(like, not_like);
+    pub fn gt<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+        self.push_filter(left.into().gt(right), FilterMode::Replace)
+    }
+
+    pub fn gte<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+        self.push_filter(left.into().gte(right), FilterMode::Replace)
+    }
+
+    pub fn lt<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+        self.push_filter(left.into().lt(right), FilterMode::Replace)
+    }
+
+    pub fn lte<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+        self.push_filter(left.into().lte(right), FilterMode::Replace)
+    }
+
+    pub fn is_null<V: Into<QueryValue>>(self, value: V) -> Self {
+        self.push_filter(value.into().is_null(), FilterMode::Replace)
+    }
+
+    pub fn is_not_null<V: Into<QueryValue>>(self, value: V) -> Self {
+        self.push_filter(value.into().is_not_null(), FilterMode::Replace)
+    }
+
+    pub fn like<L: Into<QueryValue>, R: Into<QueryValue>>(self, value: L, pattern: R) -> Self {
+        self.push_filter(value.into().like(pattern), FilterMode::Replace)
+    }
+
+    pub fn not_like<L: Into<QueryValue>, R: Into<QueryValue>>(self, value: L, pattern: R) -> Self {
+        self.push_filter(value.into().not_like(pattern), FilterMode::Replace)
+    }
 
     pub fn in_list<L, I, V>(self, left: L, values: I) -> Self
     where
@@ -1270,14 +1560,11 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> SelectBuilder<Q, M, P> 
     }
 }
 
-impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> private::Sealed
-    for SelectBuilder<Q, M, P>
-{
-}
+impl<Q: StatementSource, M: Model, P> private::Sealed for FromBuilder<Q, M, P> {}
 
-impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> SubquerySource for SelectBuilder<Q, M, P> {
+impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> SubquerySource for FromBuilder<Q, M, P> {
     fn into_subquery(self) -> Query {
-        self.build_query()
+        self.inner.build_query()
     }
 }
 

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -564,6 +564,14 @@ impl<M, T> Field<M, T> {
 /// It also supports the same comparison and predicate-style composition used by
 /// [`Field`], including helpers such as `eq`, `gt`, `like`, `in_list`, and
 /// `between`.
+///
+/// ```rust,ignore
+/// let adults = database
+///     .from::<User>()
+///     .filter(User::age().gt(18))
+///     .fetch()?;
+/// # Ok::<(), kite_sql::errors::DatabaseError>(())
+/// ```
 pub struct QueryValue {
     expr: Expr,
 }
@@ -740,6 +748,12 @@ impl QueryExpr {
     }
 
     /// Combines two predicates with `OR`.
+    ///
+    /// ```rust,ignore
+    /// let expr = User::name().like("A%").or(User::name().like("B%"));
+    /// let users = database.from::<User>().filter(expr).fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn or(self, rhs: QueryExpr) -> QueryExpr {
         QueryExpr::from_expr(Expr::BinaryOp {
             left: Box::new(nested_expr(self.into_expr())),
@@ -749,6 +763,12 @@ impl QueryExpr {
     }
 
     /// Negates a predicate with `NOT`.
+    ///
+    /// ```rust,ignore
+    /// let expr = User::name().like("A%").not();
+    /// let users = database.from::<User>().filter(expr).fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn not(self) -> QueryExpr {
         QueryExpr::from_expr(Expr::UnaryOp {
             op: sqlparser::ast::UnaryOperator::Not,
@@ -844,6 +864,12 @@ impl QueryValue {
     }
 
     /// Builds an aggregate function call such as `sum(expr)` or `count(expr)`.
+    ///
+    /// ```rust,ignore
+    /// let total = kite_sql::orm::QueryValue::aggregate("sum", [Order::amount()]);
+    /// let row = database.from::<Order>().project_value(total).get::<i32>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn aggregate<N, I, V>(name: N, args: I) -> Self
     where
         N: Into<String>,
@@ -854,6 +880,12 @@ impl QueryValue {
     }
 
     /// Builds an aggregate function call that uses `*`, such as `count(*)`.
+    ///
+    /// ```rust,ignore
+    /// let total = kite_sql::orm::QueryValue::aggregate_all("count").alias("total");
+    /// let row = database.from::<User>().project_value(total).get::<i32>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn aggregate_all(name: impl Into<String>) -> Self {
         Self::function_with_args(name, [FunctionArgExpr::Wildcard])
     }
@@ -913,6 +945,19 @@ impl QueryValue {
     }
 
     /// Builds a simple `CASE value WHEN ... THEN ... ELSE ... END` expression.
+    ///
+    /// ```rust,ignore
+    /// let label = kite_sql::orm::QueryValue::simple_case(
+    ///     User::status(),
+    ///     [("active", "enabled"), ("disabled", "blocked")],
+    ///     "other",
+    /// );
+    /// let rows = database
+    ///     .from::<User>()
+    ///     .project_tuple((User::id(), label.alias("status_label")))
+    ///     .fetch::<(i32, String)>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn simple_case<O, I, W, R, E>(operand: O, conditions: I, else_result: E) -> Self
     where
         O: Into<QueryValue>,
@@ -1049,6 +1094,12 @@ impl QueryValue {
     }
 
     /// Casts this expression using a SQL type string such as `"BIGINT"`.
+    ///
+    /// ```rust,ignore
+    /// let expr = User::id().cast("BIGINT")?;
+    /// let row = database.from::<User>().eq(expr, 1_i64).get()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn cast(self, data_type: &str) -> Result<QueryValue, DatabaseError> {
         ValueExpressionOps::cast_value(self, data_type)
     }
@@ -1083,11 +1134,27 @@ impl QueryValue {
     }
 
     /// Builds `expr IN (subquery)`.
+    ///
+    /// ```rust,ignore
+    /// let expr = User::id().in_subquery(
+    ///     database.from::<Order>().project_value(Order::user_id()),
+    /// );
+    /// let users = database.from::<User>().filter(expr).fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn in_subquery<S: SubquerySource>(self, subquery: S) -> QueryExpr {
         ValueExpressionOps::in_subquery_expr(self, subquery)
     }
 
     /// Builds `expr NOT IN (subquery)`.
+    ///
+    /// ```rust,ignore
+    /// let expr = User::id().not_in_subquery(
+    ///     database.from::<Order>().project_value(Order::user_id()),
+    /// );
+    /// let users = database.from::<User>().filter(expr).fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn not_in_subquery<S: SubquerySource>(self, subquery: S) -> QueryExpr {
         ValueExpressionOps::not_in_subquery_expr(self, subquery)
     }
@@ -1375,6 +1442,18 @@ pub trait ProjectionSpec<M: Model> {
 /// Declares a struct-backed ORM projection used by [`FromBuilder::project`].
 ///
 /// This trait is typically derived with `#[derive(Projection)]`.
+///
+/// ```rust,ignore
+/// #[derive(Default, kite_sql::Projection)]
+/// struct UserSummary {
+///     id: i32,
+///     #[projection(rename = "user_name")]
+///     display_name: String,
+/// }
+///
+/// let rows = database.from::<User>().project::<UserSummary>().fetch()?;
+/// # Ok::<(), kite_sql::errors::DatabaseError>(())
+/// ```
 pub trait Projection: for<'a> From<(&'a SchemaRef, Tuple)> {
     /// Returns the projected select-list items for model `M`.
     fn projected_values<M: Model>(relation: &str) -> Vec<ProjectedValue>;
@@ -2007,16 +2086,40 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     }
 
     /// Appends `left AND right` to the current filter state.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .and(User::age().gte(18), User::name().like("A%"))
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn and(self, left: QueryExpr, right: QueryExpr) -> Self {
         Self::from_inner(self.inner.and(left, right))
     }
 
     /// Appends `left OR right` to the current filter state.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .or(User::name().like("A%"), User::name().like("B%"))
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn or(self, left: QueryExpr, right: QueryExpr) -> Self {
         Self::from_inner(self.inner.or(left, right))
     }
 
     /// Replaces the current filter with `NOT expr`.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .not(User::name().like("A%"))
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn not(self, expr: QueryExpr) -> Self {
         Self::from_inner(self.inner.not(expr))
     }
@@ -2040,6 +2143,19 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     }
 
     /// Replaces the current filter with `NOT EXISTS (subquery)`.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .where_not_exists(
+    ///         database
+    ///             .from::<Order>()
+    ///             .project_value(Order::id())
+    ///             .eq(Order::user_id(), User::id()),
+    ///     )
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn where_not_exists<S: SubquerySource>(self, subquery: S) -> Self {
         Self::from_inner(self.inner.where_not_exists(subquery))
     }
@@ -2059,6 +2175,16 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     }
 
     /// Sets the `HAVING` predicate.
+    ///
+    /// ```rust,ignore
+    /// let rows = database
+    ///     .from::<EventLog>()
+    ///     .project_tuple((EventLog::category(), kite_sql::orm::count(EventLog::id())))
+    ///     .group_by(EventLog::category())
+    ///     .having(kite_sql::orm::count(EventLog::id()).gt(10))
+    ///     .fetch::<(String, i32)>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn having(self, expr: QueryExpr) -> Self {
         Self::from_inner(self.inner.having(expr))
     }
@@ -2110,56 +2236,120 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     }
 
     /// Appends `left = right` to the filter state.
+    ///
+    /// ```rust,ignore
+    /// let user = database.from::<User>().eq(User::id(), 1).get()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn eq<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         Self::from_inner(self.inner.eq(left, right))
     }
 
     /// Appends `left <> right` to the filter state.
+    ///
+    /// ```rust,ignore
+    /// let users = database.from::<User>().ne(User::id(), 1).fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn ne<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         Self::from_inner(self.inner.ne(left, right))
     }
 
     /// Appends `left > right` to the filter state.
+    ///
+    /// ```rust,ignore
+    /// let adults = database.from::<User>().gt(User::age(), 18).fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn gt<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         Self::from_inner(self.inner.gt(left, right))
     }
 
     /// Appends `left >= right` to the filter state.
+    ///
+    /// ```rust,ignore
+    /// let adults = database.from::<User>().gte(User::age(), 18).fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn gte<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         Self::from_inner(self.inner.gte(left, right))
     }
 
     /// Appends `left < right` to the filter state.
+    ///
+    /// ```rust,ignore
+    /// let younger = database.from::<User>().lt(User::age(), 18).fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn lt<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         Self::from_inner(self.inner.lt(left, right))
     }
 
     /// Appends `left <= right` to the filter state.
+    ///
+    /// ```rust,ignore
+    /// let users = database.from::<User>().lte(User::id(), 10).fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn lte<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
         Self::from_inner(self.inner.lte(left, right))
     }
 
     /// Appends `value IS NULL` to the filter state.
+    ///
+    /// ```rust,ignore
+    /// let users = database.from::<User>().is_null(User::age()).fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn is_null<V: Into<QueryValue>>(self, value: V) -> Self {
         Self::from_inner(self.inner.is_null(value))
     }
 
     /// Appends `value IS NOT NULL` to the filter state.
+    ///
+    /// ```rust,ignore
+    /// let users = database.from::<User>().is_not_null(User::age()).fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn is_not_null<V: Into<QueryValue>>(self, value: V) -> Self {
         Self::from_inner(self.inner.is_not_null(value))
     }
 
     /// Appends `value LIKE pattern` to the filter state.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .like(User::name(), "A%")
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn like<L: Into<QueryValue>, R: Into<QueryValue>>(self, value: L, pattern: R) -> Self {
         Self::from_inner(self.inner.like(value, pattern))
     }
 
     /// Appends `value NOT LIKE pattern` to the filter state.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .not_like(User::name(), "A%")
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn not_like<L: Into<QueryValue>, R: Into<QueryValue>>(self, value: L, pattern: R) -> Self {
         Self::from_inner(self.inner.not_like(value, pattern))
     }
 
     /// Appends `left IN (...)` to the filter state.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .in_list(User::id(), [1, 2, 3])
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn in_list<L, I, V>(self, left: L, values: I) -> Self
     where
         L: Into<QueryValue>,
@@ -2170,6 +2360,14 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     }
 
     /// Appends `left NOT IN (...)` to the filter state.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .not_in_list(User::id(), [1, 2, 3])
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn not_in_list<L, I, V>(self, left: L, values: I) -> Self
     where
         L: Into<QueryValue>,
@@ -2180,6 +2378,14 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     }
 
     /// Appends `expr BETWEEN low AND high` to the filter state.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .between(User::age(), 18, 30)
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn between<L, Low, High>(self, expr: L, low: Low, high: High) -> Self
     where
         L: Into<QueryValue>,
@@ -2190,6 +2396,14 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     }
 
     /// Appends `expr NOT BETWEEN low AND high` to the filter state.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .not_between(User::age(), 18, 30)
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn not_between<L, Low, High>(self, expr: L, low: Low, high: High) -> Self
     where
         L: Into<QueryValue>,
@@ -2200,11 +2414,33 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     }
 
     /// Appends `left IN (subquery)` to the filter state.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .in_subquery(
+    ///         User::id(),
+    ///         database.from::<Order>().project_value(Order::user_id()),
+    ///     )
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn in_subquery<L: Into<QueryValue>, S: SubquerySource>(self, left: L, subquery: S) -> Self {
         Self::from_inner(self.inner.in_subquery(left, subquery))
     }
 
     /// Appends `left NOT IN (subquery)` to the filter state.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .not_in_subquery(
+    ///         User::id(),
+    ///         database.from::<Order>().project_value(Order::user_id()),
+    ///     )
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn not_in_subquery<L: Into<QueryValue>, S: SubquerySource>(
         self,
         left: L,
@@ -2353,7 +2589,7 @@ impl<Q: StatementSource, M: Model> SetQueryBuilder<Q, M, ModelProjection> {
         Ok(self.raw()?.orm::<M>())
     }
 
-    /// Executes the set query and decodes one model row.
+    /// Executes the set query with `LIMIT 1` semantics and decodes one model row.
     ///
     /// ```rust,ignore
     /// let user = database
@@ -2363,7 +2599,7 @@ impl<Q: StatementSource, M: Model> SetQueryBuilder<Q, M, ModelProjection> {
     /// # Ok::<(), kite_sql::errors::DatabaseError>(())
     /// ```
     pub fn get(self) -> Result<Option<M>, DatabaseError> {
-        extract_optional_model(self.raw()?)
+        extract_optional_model(self.limit(1).raw()?)
     }
 }
 
@@ -2382,7 +2618,7 @@ impl<Q: StatementSource, M: Model> SetQueryBuilder<Q, M, ValueProjection> {
         Ok(ProjectValueIter::new(self.raw()?))
     }
 
-    /// Executes the set query and decodes one value.
+    /// Executes the set query with `LIMIT 1` semantics and decodes one value.
     ///
     /// ```rust,ignore
     /// let id = database
@@ -2394,7 +2630,7 @@ impl<Q: StatementSource, M: Model> SetQueryBuilder<Q, M, ValueProjection> {
     /// # Ok::<(), kite_sql::errors::DatabaseError>(())
     /// ```
     pub fn get<T: FromDataValue>(self) -> Result<Option<T>, DatabaseError> {
-        extract_optional_value(self.raw()?)
+        extract_optional_value(self.limit(1).raw()?)
     }
 }
 
@@ -2413,7 +2649,7 @@ impl<Q: StatementSource, M: Model> SetQueryBuilder<Q, M, TupleProjection> {
         Ok(ProjectTupleIter::new(self.raw()?))
     }
 
-    /// Executes the set query and decodes one tuple row.
+    /// Executes the set query with `LIMIT 1` semantics and decodes one tuple row.
     ///
     /// ```rust,ignore
     /// let row = database
@@ -2424,7 +2660,7 @@ impl<Q: StatementSource, M: Model> SetQueryBuilder<Q, M, TupleProjection> {
     /// # Ok::<(), kite_sql::errors::DatabaseError>(())
     /// ```
     pub fn get<T: FromQueryTuple>(self) -> Result<Option<T>, DatabaseError> {
-        extract_optional_tuple(self.raw()?)
+        extract_optional_tuple(self.limit(1).raw()?)
     }
 }
 
@@ -2450,7 +2686,7 @@ impl<Q: StatementSource, M: Model, T: Projection> SetQueryBuilder<Q, M, StructPr
         Ok(self.raw()?.orm::<T>())
     }
 
-    /// Executes the set query and decodes one projected row.
+    /// Executes the set query with `LIMIT 1` semantics and decodes one projected row.
     ///
     /// ```rust,ignore
     /// #[derive(Default, kite_sql::Projection)]
@@ -2468,7 +2704,7 @@ impl<Q: StatementSource, M: Model, T: Projection> SetQueryBuilder<Q, M, StructPr
     /// # Ok::<(), kite_sql::errors::DatabaseError>(())
     /// ```
     pub fn get(self) -> Result<Option<T>, DatabaseError> {
-        extract_optional_row(self.raw()?)
+        extract_optional_row(self.limit(1).raw()?)
     }
 }
 
@@ -3800,7 +4036,18 @@ pub trait Model: Sized + for<'a> From<(&'a SchemaRef, Tuple)> {
 /// Conversion trait from [`DataValue`] into Rust values for ORM mapping.
 ///
 /// This trait is mainly intended for framework internals and derive-generated
-/// code.
+/// code, but it also powers scalar projections such as [`FromBuilder::project_value`].
+///
+/// Built-in scalar types already implement this trait, so most users only need
+/// to pick the target type when decoding:
+///
+/// ```rust,ignore
+/// let ids = database
+///     .from::<User>()
+///     .project_value(User::id())
+///     .fetch::<i32>()?;
+/// # Ok::<(), kite_sql::errors::DatabaseError>(())
+/// ```
 pub trait FromDataValue: Sized {
     /// Returns the logical SQL type used for conversion, when one is required.
     fn logical_type() -> Option<LogicalType>;
@@ -3812,6 +4059,14 @@ pub trait FromDataValue: Sized {
 /// Conversion trait from a projected result tuple into a Rust value.
 ///
 /// This is implemented for tuples such as `(i32, String)` by the ORM itself.
+///
+/// ```rust,ignore
+/// let rows = database
+///     .from::<User>()
+///     .project_tuple((User::id(), User::name()))
+///     .fetch::<(i32, String)>()?;
+/// # Ok::<(), kite_sql::errors::DatabaseError>(())
+/// ```
 pub trait FromQueryTuple: Sized {
     /// Decodes one projected tuple into `Self`.
     fn from_query_tuple(tuple: Tuple) -> Result<Self, DatabaseError>;
@@ -3819,7 +4074,19 @@ pub trait FromQueryTuple: Sized {
 
 /// Typed adapter over a [`ResultIter`] that yields projected values instead of raw tuples.
 ///
-/// This is returned by `project_value(...).fetch::<T>()`.
+/// This is returned by [`FromBuilder::project_value`] followed by `fetch::<T>()`.
+///
+/// ```rust,ignore
+/// let mut ids = database
+///     .from::<User>()
+///     .project_value(User::id())
+///     .fetch::<i32>()?;
+///
+/// let first = ids.next().transpose()?;
+/// ids.done()?;
+/// # let _ = first;
+/// # Ok::<(), kite_sql::errors::DatabaseError>(())
+/// ```
 pub struct ProjectValueIter<I, T> {
     inner: I,
     _marker: PhantomData<T>,
@@ -3837,7 +4104,10 @@ where
         }
     }
 
-    /// Finishes the underlying raw iterator.
+    /// Finishes the underlying raw iterator explicitly.
+    ///
+    /// This is useful when you stop iterating early and want to release the
+    /// underlying result stream.
     pub fn done(self) -> Result<(), DatabaseError> {
         self.inner.done()
     }
@@ -3845,7 +4115,19 @@ where
 
 /// Typed adapter over a [`ResultIter`] that yields projected tuples.
 ///
-/// This is returned by `project_tuple(...).fetch::<T>()`.
+/// This is returned by [`FromBuilder::project_tuple`] followed by `fetch::<T>()`.
+///
+/// ```rust,ignore
+/// let mut rows = database
+///     .from::<User>()
+///     .project_tuple((User::id(), User::name()))
+///     .fetch::<(i32, String)>()?;
+///
+/// let first = rows.next().transpose()?;
+/// rows.done()?;
+/// # let _ = first;
+/// # Ok::<(), kite_sql::errors::DatabaseError>(())
+/// ```
 pub struct ProjectTupleIter<I, T> {
     inner: I,
     _marker: PhantomData<T>,
@@ -3863,7 +4145,10 @@ where
         }
     }
 
-    /// Finishes the underlying raw iterator.
+    /// Finishes the underlying raw iterator explicitly.
+    ///
+    /// This is useful when you stop iterating early and want to release the
+    /// underlying result stream.
     pub fn done(self) -> Result<(), DatabaseError> {
         self.inner.done()
     }
@@ -3902,7 +4187,8 @@ where
 /// Conversion trait from Rust values into [`DataValue`] for ORM parameters.
 ///
 /// This trait is mainly intended for framework internals and derive-generated
-/// code.
+/// code. It is what allows model fields, filter values, and primary keys to be
+/// passed into prepared ORM statements.
 pub trait ToDataValue {
     /// Converts the value into a [`DataValue`].
     fn to_data_value(&self) -> DataValue;
@@ -3913,6 +4199,9 @@ pub trait ToDataValue {
 /// `#[derive(Model)]` relies on this trait to build `CREATE TABLE` statements.
 /// Most built-in scalar types already implement it, and custom types can opt in
 /// by implementing this trait together with [`FromDataValue`] and [`ToDataValue`].
+///
+/// This trait only affects ORM-generated DDL. Query decoding still goes through
+/// [`FromDataValue`], and bound parameters still go through [`ToDataValue`].
 pub trait ModelColumnType {
     /// Returns the SQL type name used in ORM-generated DDL.
     fn ddl_type() -> String;
@@ -3926,12 +4215,16 @@ pub trait ModelColumnType {
 /// Marker trait for string-like model fields that support `#[model(varchar = N)]`
 /// and `#[model(char = N)]`.
 ///
-/// This is mainly used by the `Model` derive macro.
+/// This is mainly used by the `Model` derive macro and usually does not need to
+/// be implemented manually unless you are introducing a custom string wrapper
+/// type.
 pub trait StringType {}
 
 /// Marker trait for decimal-like model fields that support precision/scale DDL attributes.
 ///
-/// This is mainly used by the `Model` derive macro.
+/// This is mainly used by the `Model` derive macro and usually does not need to
+/// be implemented manually unless you are introducing a custom decimal wrapper
+/// type.
 pub trait DecimalType {}
 
 #[doc(hidden)]

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -17,11 +17,11 @@ use sqlparser::ast::{
     BinaryOperator as SqlBinaryOperator, CaseWhen, CastKind, CharLengthUnits, ColumnDef,
     ColumnOption, ColumnOptionDef, CreateIndex, CreateTable, DataType, Delete, Distinct, Expr,
     FromTable, Function, FunctionArg, FunctionArgExpr, FunctionArgumentList, FunctionArguments,
-    GroupByExpr, HiveDistributionStyle, Ident, IndexColumn, Insert, KeyOrIndexDisplay, LimitClause,
-    NullsDistinctOption, ObjectName, ObjectType, Offset, OffsetRows, OrderBy, OrderByExpr,
-    OrderByKind, OrderByOptions, PrimaryKeyConstraint, Query, Select, SelectFlavor, SelectItem,
-    SetExpr, TableAlias, TableFactor, TableObject, TableWithJoins, TimezoneInfo, UniqueConstraint,
-    Update, Value, Values,
+    GroupByExpr, HiveDistributionStyle, Ident, IndexColumn, Insert, Join, JoinConstraint,
+    JoinOperator, KeyOrIndexDisplay, LimitClause, NullsDistinctOption, ObjectName, ObjectType,
+    Offset, OffsetRows, OrderBy, OrderByExpr, OrderByKind, OrderByOptions, PrimaryKeyConstraint,
+    Query, Select, SelectFlavor, SelectItem, SetExpr, TableAlias, TableFactor, TableObject,
+    TableWithJoins, TimezoneInfo, UniqueConstraint, Update, Value, Values,
 };
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
@@ -122,6 +122,19 @@ struct QuerySource {
     alias: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+struct JoinSpec {
+    source: QuerySource,
+    kind: JoinKind,
+    on: QueryExpr,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JoinKind {
+    Inner,
+    Left,
+}
+
 impl QuerySource {
     fn model<M: Model>() -> Self {
         Self {
@@ -130,15 +143,29 @@ impl QuerySource {
         }
     }
 
-    fn aliased<M: Model>(alias: impl Into<String>) -> Self {
-        Self {
-            table_name: M::table_name().to_string(),
-            alias: Some(alias.into()),
-        }
-    }
-
     fn relation_name(&self) -> &str {
         self.alias.as_deref().unwrap_or(&self.table_name)
+    }
+
+    fn with_alias(mut self, alias: impl Into<String>) -> Self {
+        self.alias = Some(alias.into());
+        self
+    }
+}
+
+impl JoinSpec {
+    fn into_ast(self) -> Join {
+        let constraint = JoinConstraint::On(self.on.into_expr());
+        let join_operator = match self.kind {
+            JoinKind::Inner => JoinOperator::Inner(constraint),
+            JoinKind::Left => JoinOperator::Left(constraint),
+        };
+
+        Join {
+            relation: source_table_factor(&self.source),
+            global: false,
+            join_operator,
+        }
     }
 }
 
@@ -374,7 +401,8 @@ impl<M, T> Field<M, T> {
     ///
     /// ```rust,ignore
     /// let user = database
-    ///     .from_alias::<User>("u")
+    ///     .from::<User>()
+    ///     .alias("u")
     ///     .eq(User::id().qualify("u"), 1)
     ///     .get()?;
     /// # Ok::<(), kite_sql::errors::DatabaseError>(())
@@ -1164,6 +1192,13 @@ pub struct FromBuilder<Q: StatementSource, M: Model, P = ModelProjection> {
 }
 
 #[doc(hidden)]
+pub struct JoinOnBuilder<Q: StatementSource, M: Model, P> {
+    inner: QueryBuilder<Q, M, P>,
+    join_source: QuerySource,
+    join_kind: JoinKind,
+}
+
+#[doc(hidden)]
 pub struct ModelProjection;
 
 #[doc(hidden)]
@@ -1184,6 +1219,7 @@ pub struct StructProjection<T> {
 struct BuilderState<Q: StatementSource, M: Model> {
     source: Q,
     query_source: QuerySource,
+    joins: Vec<JoinSpec>,
     distinct: bool,
     filter: Option<QueryExpr>,
     group_bys: Vec<QueryValue>,
@@ -1199,6 +1235,7 @@ impl<Q: StatementSource, M: Model> BuilderState<Q, M> {
         Self {
             source,
             query_source,
+            joins: Vec::new(),
             distinct: false,
             filter: None,
             group_bys: Vec::new(),
@@ -1234,6 +1271,11 @@ impl<Q: StatementSource, M: Model> BuilderState<Q, M> {
         self.distinct = true;
         self
     }
+
+    fn push_join(mut self, join: JoinSpec) -> Self {
+        self.joins.push(join);
+        self
+    }
 }
 
 #[doc(hidden)]
@@ -1255,8 +1297,8 @@ pub trait IntoProjectedTuple {
 }
 
 impl<M: Model> ProjectionSpec<M> for ModelProjection {
-    fn into_select_items(self, _relation: &str) -> Vec<SelectItem> {
-        select_projection(M::fields())
+    fn into_select_items(self, relation: &str) -> Vec<SelectItem> {
+        select_projection(M::fields(), relation)
     }
 }
 
@@ -1298,13 +1340,6 @@ impl<Q: StatementSource, M: Model> QueryBuilder<Q, M, ModelProjection> {
             projection: ModelProjection,
         }
     }
-
-    fn aliased(source: Q, alias: impl Into<String>) -> Self {
-        Self {
-            state: BuilderState::new(source, QuerySource::aliased::<M>(alias)),
-            projection: ModelProjection,
-        }
-    }
 }
 
 impl<Q: StatementSource, M: Model, P> QueryBuilder<Q, M, P> {
@@ -1313,6 +1348,11 @@ impl<Q: StatementSource, M: Model, P> QueryBuilder<Q, M, P> {
             state: self.state,
             projection,
         }
+    }
+
+    fn with_alias(mut self, alias: impl Into<String>) -> Self {
+        self.state.query_source = self.state.query_source.with_alias(alias);
+        self
     }
 }
 
@@ -1323,6 +1363,34 @@ impl<Q: StatementSource, M: Model, P> FromBuilder<Q, M, P> {
 
     fn with_projection<P2>(self, projection: P2) -> FromBuilder<Q, M, P2> {
         FromBuilder::from_inner(self.inner.with_projection(projection))
+    }
+
+    /// Applies a relation alias to the current source.
+    pub fn alias(self, alias: impl Into<String>) -> Self {
+        FromBuilder::from_inner(self.inner.with_alias(alias))
+    }
+}
+
+impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> JoinOnBuilder<Q, M, P> {
+    /// Applies a relation alias to the pending join source.
+    pub fn alias(mut self, alias: impl Into<String>) -> Self {
+        self.join_source = self.join_source.with_alias(alias);
+        self
+    }
+
+    /// Completes a pending join with an `ON` condition.
+    ///
+    /// ```rust,ignore
+    /// let rows = database
+    ///     .from::<User>()
+    ///     .inner_join::<Order>()
+    ///     .on(User::id().eq(Order::user_id()))
+    ///     .project_tuple((User::name(), Order::amount()))
+    ///     .fetch::<(String, i32)>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
+    pub fn on(self, expr: QueryExpr) -> FromBuilder<Q, M, P> {
+        FromBuilder::from_inner(self.inner.join(self.join_source, self.join_kind, expr))
     }
 }
 
@@ -1394,6 +1462,30 @@ impl<Q: StatementSource, M: Model> FromBuilder<Q, M, ModelProjection> {
 }
 
 impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
+    /// Starts an `INNER JOIN` against another model source.
+    ///
+    /// Call `.on(...)` to supply the join condition. Use `.alias(...)` only
+    /// when explicit qualification is needed, such as self-joins.
+    pub fn inner_join<J: Model>(self) -> JoinOnBuilder<Q, M, P> {
+        JoinOnBuilder {
+            inner: self.inner,
+            join_source: QuerySource::model::<J>(),
+            join_kind: JoinKind::Inner,
+        }
+    }
+
+    /// Starts a `LEFT JOIN` against another model source.
+    ///
+    /// Call `.on(...)` to supply the join condition. Use `.alias(...)` only
+    /// when explicit qualification is needed, such as self-joins.
+    pub fn left_join<J: Model>(self) -> JoinOnBuilder<Q, M, P> {
+        JoinOnBuilder {
+            inner: self.inner,
+            join_source: QuerySource::model::<J>(),
+            join_kind: JoinKind::Left,
+        }
+    }
+
     /// Replaces the current `WHERE` predicate.
     pub fn filter(self, expr: QueryExpr) -> Self {
         Self::from_inner(self.inner.filter(expr))
@@ -1632,6 +1724,17 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         }
     }
 
+    fn join(self, join_source: QuerySource, join_kind: JoinKind, on: QueryExpr) -> Self {
+        Self {
+            state: self.state.push_join(JoinSpec {
+                source: join_source,
+                kind: join_kind,
+                on,
+            }),
+            projection: self.projection,
+        }
+    }
+
     fn filter(mut self, expr: QueryExpr) -> Self {
         self.state.filter = Some(expr);
         self
@@ -1725,6 +1828,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
                 BuilderState {
                     source: _,
                     query_source,
+                    joins,
                     distinct,
                     filter,
                     group_bys,
@@ -1739,6 +1843,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
 
         select_query(
             &query_source,
+            joins,
             projection.into_select_items(query_source.relation_name()),
             distinct,
             filter,
@@ -1756,6 +1861,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
                 BuilderState {
                     source,
                     query_source,
+                    joins,
                     distinct,
                     filter,
                     group_bys,
@@ -1770,6 +1876,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
 
         let statement = Statement::Query(Box::new(select_query(
             &query_source,
+            joins,
             projection.into_select_items(query_source.relation_name()),
             distinct,
             filter,
@@ -1926,10 +2033,11 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         let BuilderState {
             source,
             query_source,
+            joins,
             filter,
             ..
         } = self.state;
-        let statement = orm_count_statement(&query_source, filter);
+        let statement = orm_count_statement(&query_source, joins, filter);
         let mut iter = source.execute_statement(&statement, &[])?;
         let count = match iter.next().transpose()? {
             Some(tuple) => match tuple.values.first() {
@@ -2043,22 +2151,25 @@ fn table_with_joins(table_name: &str) -> TableWithJoins {
     }
 }
 
-fn source_table_with_joins(source: &QuerySource) -> TableWithJoins {
+fn source_table_with_joins(source: &QuerySource, joins: Vec<JoinSpec>) -> TableWithJoins {
     TableWithJoins {
         relation: source_table_factor(source),
-        joins: vec![],
+        joins: joins.into_iter().map(JoinSpec::into_ast).collect(),
     }
 }
 
-fn select_projection(fields: &[OrmField]) -> Vec<SelectItem> {
+fn select_projection(fields: &[OrmField], relation: &str) -> Vec<SelectItem> {
     fields
         .iter()
-        .map(|field| SelectItem::UnnamedExpr(Expr::Identifier(ident(field.column))))
+        .map(|field| {
+            SelectItem::UnnamedExpr(qualified_column_value(relation, field.column).into_expr())
+        })
         .collect()
 }
 
 fn select_query(
     source: &QuerySource,
+    joins: Vec<JoinSpec>,
     projection: Vec<SelectItem>,
     distinct: bool,
     filter: Option<QueryExpr>,
@@ -2080,7 +2191,7 @@ fn select_query(
             projection,
             exclude: None,
             into: None,
-            from: vec![source_table_with_joins(source)],
+            from: vec![source_table_with_joins(source, joins)],
             lateral_views: vec![],
             prewhere: None,
             selection: filter.map(QueryExpr::into_expr),
@@ -2200,7 +2311,8 @@ pub fn orm_select_statement(table_name: &str, fields: &[OrmField]) -> Statement 
             table_name: table_name.to_string(),
             alias: None,
         },
-        select_projection(fields),
+        vec![],
+        select_projection(fields, table_name),
         false,
         None,
         vec![],
@@ -2307,7 +2419,7 @@ pub fn orm_find_statement(
             select_modifiers: None,
             top: None,
             top_before_distinct: false,
-            projection: select_projection(fields),
+            projection: select_projection(fields, table_name),
             exclude: None,
             into: None,
             from: vec![table_with_joins(table_name)],
@@ -2474,9 +2586,14 @@ pub fn orm_analyze_statement(table_name: &str) -> Statement {
     })
 }
 
-fn orm_count_statement(source: &QuerySource, filter: Option<QueryExpr>) -> Statement {
+fn orm_count_statement(
+    source: &QuerySource,
+    joins: Vec<JoinSpec>,
+    filter: Option<QueryExpr>,
+) -> Statement {
     Statement::Query(Box::new(select_query(
         source,
+        joins,
         vec![SelectItem::UnnamedExpr(Expr::Function(Function {
             name: object_name("count"),
             uses_odbc_syntax: false,

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -20,8 +20,9 @@ use sqlparser::ast::{
     GroupByExpr, HiveDistributionStyle, Ident, IndexColumn, Insert, Join, JoinConstraint,
     JoinOperator, KeyOrIndexDisplay, LimitClause, NullsDistinctOption, ObjectName, ObjectType,
     Offset, OffsetRows, OrderBy, OrderByExpr, OrderByKind, OrderByOptions, PrimaryKeyConstraint,
-    Query, Select, SelectFlavor, SelectItem, SetExpr, TableAlias, TableFactor, TableObject,
-    TableWithJoins, TimezoneInfo, UniqueConstraint, Update, Value, Values,
+    Query, Select, SelectFlavor, SelectItem, SetExpr, SetOperator, SetQuantifier, TableAlias,
+    TableFactor, TableObject, TableWithJoins, TimezoneInfo, UniqueConstraint, Update, Value,
+    Values,
 };
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
@@ -1273,6 +1274,13 @@ pub struct FromBuilder<Q: StatementSource, M: Model, P = ModelProjection> {
 }
 
 #[doc(hidden)]
+pub struct SetQueryBuilder<Q: StatementSource, M: Model, P = ModelProjection> {
+    source: Q,
+    query: Query,
+    _marker: PhantomData<(M, P)>,
+}
+
+#[doc(hidden)]
 pub struct JoinOnBuilder<Q: StatementSource, M: Model, P> {
     inner: QueryBuilder<Q, M, P>,
     join_source: QuerySource,
@@ -1382,6 +1390,52 @@ pub trait IntoJoinColumns {
     fn into_join_columns(self) -> Vec<ObjectName>;
 }
 
+#[doc(hidden)]
+pub trait QueryOperand: private::Sealed + Sized {
+    type Source: StatementSource;
+    type Model: Model;
+    type Projection;
+    type Shape;
+
+    fn into_query_parts(self) -> (Self::Source, Query);
+
+    fn into_query(self) -> Query {
+        self.into_query_parts().1
+    }
+
+    fn union<R>(self, rhs: R) -> SetQueryBuilder<Self::Source, Self::Model, Self::Projection>
+    where
+        R: QueryOperand<Source = Self::Source, Projection = Self::Projection, Shape = Self::Shape>,
+    {
+        let (source, left_query) = self.into_query_parts();
+        SetQueryBuilder::new(
+            source,
+            set_operation_query(
+                left_query,
+                rhs.into_query(),
+                SetOperator::Union,
+                SetQuantifier::Distinct,
+            ),
+        )
+    }
+
+    fn except<R>(self, rhs: R) -> SetQueryBuilder<Self::Source, Self::Model, Self::Projection>
+    where
+        R: QueryOperand<Source = Self::Source, Projection = Self::Projection, Shape = Self::Shape>,
+    {
+        let (source, left_query) = self.into_query_parts();
+        SetQueryBuilder::new(
+            source,
+            set_operation_query(
+                left_query,
+                rhs.into_query(),
+                SetOperator::Except,
+                SetQuantifier::Distinct,
+            ),
+        )
+    }
+}
+
 impl<M, T> IntoJoinColumns for Field<M, T> {
     fn into_join_columns(self) -> Vec<ObjectName> {
         vec![object_name(self.column)]
@@ -1475,6 +1529,45 @@ impl<Q: StatementSource, M: Model, P> QueryBuilder<Q, M, P> {
         self.state.query_source = self.state.query_source.with_alias(alias);
         self
     }
+
+    fn into_query_parts(self) -> (Q, Query)
+    where
+        P: ProjectionSpec<M>,
+    {
+        let QueryBuilder {
+            state:
+                BuilderState {
+                    source,
+                    query_source,
+                    joins,
+                    distinct,
+                    filter,
+                    group_bys,
+                    having,
+                    order_bys,
+                    limit,
+                    offset,
+                    ..
+                },
+            projection,
+        } = self;
+
+        (
+            source,
+            select_query(
+                &query_source,
+                joins,
+                projection.into_select_items(query_source.relation_name()),
+                distinct,
+                filter,
+                group_bys,
+                having,
+                order_bys,
+                limit,
+                offset,
+            ),
+        )
+    }
 }
 
 impl<Q: StatementSource, M: Model, P> FromBuilder<Q, M, P> {
@@ -1498,6 +1591,81 @@ impl<Q: StatementSource, M: Model, P> FromBuilder<Q, M, P> {
     /// ```
     pub fn alias(self, alias: impl Into<String>) -> Self {
         FromBuilder::from_inner(self.inner.with_alias(alias))
+    }
+
+    /// Builds a `UNION` set query with another query of the same shape.
+    pub fn union<R>(self, rhs: R) -> SetQueryBuilder<Q, M, P>
+    where
+        Self: QueryOperand<Source = Q, Model = M, Projection = P>,
+        R: QueryOperand<Source = Q, Projection = P, Shape = <Self as QueryOperand>::Shape>,
+    {
+        QueryOperand::union(self, rhs)
+    }
+
+    /// Builds an `EXCEPT` set query with another query of the same shape.
+    pub fn except<R>(self, rhs: R) -> SetQueryBuilder<Q, M, P>
+    where
+        Self: QueryOperand<Source = Q, Model = M, Projection = P>,
+        R: QueryOperand<Source = Q, Projection = P, Shape = <Self as QueryOperand>::Shape>,
+    {
+        QueryOperand::except(self, rhs)
+    }
+}
+
+impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
+    fn new(source: Q, query: Query) -> Self {
+        Self {
+            source,
+            query,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Marks the preceding set operation as `ALL`.
+    pub fn all(mut self) -> Self {
+        set_query_quantifier(&mut self.query, SetQuantifier::All);
+        self
+    }
+
+    /// Executes the set query and returns the raw result iterator.
+    pub fn raw(self) -> Result<Q::Iter, DatabaseError> {
+        self.source
+            .execute_statement(&Statement::Query(Box::new(self.query)), &[])
+    }
+
+    /// Returns whether the set query produces at least one row.
+    pub fn exists(self) -> Result<bool, DatabaseError> {
+        let mut iter = self.raw()?;
+        Ok(iter.next().transpose()?.is_some())
+    }
+
+    /// Returns the row count of the set query result.
+    pub fn count(self) -> Result<usize, DatabaseError> {
+        let mut iter = self.raw()?;
+        let mut count = 0usize;
+        while iter.next().transpose()?.is_some() {
+            count += 1;
+        }
+        iter.done()?;
+        Ok(count)
+    }
+
+    /// Appends `UNION` to the current set query.
+    pub fn union<R>(self, rhs: R) -> Self
+    where
+        Self: QueryOperand<Source = Q, Model = M, Projection = P>,
+        R: QueryOperand<Source = Q, Projection = P, Shape = <Self as QueryOperand>::Shape>,
+    {
+        QueryOperand::union(self, rhs)
+    }
+
+    /// Appends `EXCEPT` to the current set query.
+    pub fn except<R>(self, rhs: R) -> Self
+    where
+        Self: QueryOperand<Source = Q, Model = M, Projection = P>,
+        R: QueryOperand<Source = Q, Projection = P, Shape = <Self as QueryOperand>::Shape>,
+    {
+        QueryOperand::except(self, rhs)
     }
 }
 
@@ -1958,6 +2126,54 @@ impl<Q: StatementSource, M: Model, T: Projection> FromBuilder<Q, M, StructProjec
     }
 }
 
+impl<Q: StatementSource, M: Model> SetQueryBuilder<Q, M, ModelProjection> {
+    /// Executes the set query and decodes rows into the model type.
+    pub fn fetch(self) -> Result<OrmIter<Q::Iter, M>, DatabaseError> {
+        Ok(self.raw()?.orm::<M>())
+    }
+
+    /// Executes the set query and decodes one model row.
+    pub fn get(self) -> Result<Option<M>, DatabaseError> {
+        extract_optional_model(self.raw()?)
+    }
+}
+
+impl<Q: StatementSource, M: Model> SetQueryBuilder<Q, M, ValueProjection> {
+    /// Executes the set query and decodes each row into `T`.
+    pub fn fetch<T: FromDataValue>(self) -> Result<ProjectValueIter<Q::Iter, T>, DatabaseError> {
+        Ok(ProjectValueIter::new(self.raw()?))
+    }
+
+    /// Executes the set query and decodes one value.
+    pub fn get<T: FromDataValue>(self) -> Result<Option<T>, DatabaseError> {
+        extract_optional_value(self.raw()?)
+    }
+}
+
+impl<Q: StatementSource, M: Model> SetQueryBuilder<Q, M, TupleProjection> {
+    /// Executes the set query and decodes each row into `T`.
+    pub fn fetch<T: FromQueryTuple>(self) -> Result<ProjectTupleIter<Q::Iter, T>, DatabaseError> {
+        Ok(ProjectTupleIter::new(self.raw()?))
+    }
+
+    /// Executes the set query and decodes one tuple row.
+    pub fn get<T: FromQueryTuple>(self) -> Result<Option<T>, DatabaseError> {
+        extract_optional_tuple(self.raw()?)
+    }
+}
+
+impl<Q: StatementSource, M: Model, T: Projection> SetQueryBuilder<Q, M, StructProjection<T>> {
+    /// Executes the set query and decodes rows into the struct projection type.
+    pub fn fetch(self) -> Result<OrmIter<Q::Iter, T>, DatabaseError> {
+        Ok(self.raw()?.orm::<T>())
+    }
+
+    /// Executes the set query and decodes one projected row.
+    pub fn get(self) -> Result<Option<T>, DatabaseError> {
+        extract_optional_row(self.raw()?)
+    }
+}
+
 impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
     fn push_filter(self, expr: QueryExpr, mode: FilterMode) -> Self {
         Self {
@@ -2308,9 +2524,109 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
 
 impl<Q: StatementSource, M: Model, P> private::Sealed for FromBuilder<Q, M, P> {}
 
+impl<Q: StatementSource, M: Model, P> private::Sealed for SetQueryBuilder<Q, M, P> {}
+
 impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> SubquerySource for FromBuilder<Q, M, P> {
     fn into_subquery(self) -> Query {
         self.inner.build_query()
+    }
+}
+
+impl<Q: StatementSource, M: Model, P> SubquerySource for SetQueryBuilder<Q, M, P> {
+    fn into_subquery(self) -> Query {
+        self.query
+    }
+}
+
+impl<Q: StatementSource, M: Model> QueryOperand for FromBuilder<Q, M, ModelProjection> {
+    type Source = Q;
+    type Model = M;
+    type Projection = ModelProjection;
+    type Shape = M;
+
+    fn into_query_parts(self) -> (Self::Source, Query) {
+        self.inner.into_query_parts()
+    }
+}
+
+impl<Q: StatementSource, M: Model> QueryOperand for FromBuilder<Q, M, ValueProjection> {
+    type Source = Q;
+    type Model = M;
+    type Projection = ValueProjection;
+    type Shape = ValueProjection;
+
+    fn into_query_parts(self) -> (Self::Source, Query) {
+        self.inner.into_query_parts()
+    }
+}
+
+impl<Q: StatementSource, M: Model> QueryOperand for FromBuilder<Q, M, TupleProjection> {
+    type Source = Q;
+    type Model = M;
+    type Projection = TupleProjection;
+    type Shape = TupleProjection;
+
+    fn into_query_parts(self) -> (Self::Source, Query) {
+        self.inner.into_query_parts()
+    }
+}
+
+impl<Q: StatementSource, M: Model, T: Projection> QueryOperand
+    for FromBuilder<Q, M, StructProjection<T>>
+{
+    type Source = Q;
+    type Model = M;
+    type Projection = StructProjection<T>;
+    type Shape = T;
+
+    fn into_query_parts(self) -> (Self::Source, Query) {
+        self.inner.into_query_parts()
+    }
+}
+
+impl<Q: StatementSource, M: Model> QueryOperand for SetQueryBuilder<Q, M, ModelProjection> {
+    type Source = Q;
+    type Model = M;
+    type Projection = ModelProjection;
+    type Shape = M;
+
+    fn into_query_parts(self) -> (Self::Source, Query) {
+        (self.source, self.query)
+    }
+}
+
+impl<Q: StatementSource, M: Model> QueryOperand for SetQueryBuilder<Q, M, ValueProjection> {
+    type Source = Q;
+    type Model = M;
+    type Projection = ValueProjection;
+    type Shape = ValueProjection;
+
+    fn into_query_parts(self) -> (Self::Source, Query) {
+        (self.source, self.query)
+    }
+}
+
+impl<Q: StatementSource, M: Model> QueryOperand for SetQueryBuilder<Q, M, TupleProjection> {
+    type Source = Q;
+    type Model = M;
+    type Projection = TupleProjection;
+    type Shape = TupleProjection;
+
+    fn into_query_parts(self) -> (Self::Source, Query) {
+        (self.source, self.query)
+    }
+}
+
+impl<Q: StatementSource, M: Model, T: Projection> QueryOperand
+    for SetQueryBuilder<Q, M, StructProjection<T>>
+{
+    type Source = Q;
+    type Model = M;
+    type Projection = StructProjection<T>;
+    type Shape = T;
+
+    fn into_query_parts(self) -> (Self::Source, Query) {
+        (self.source, self.query)
     }
 }
 
@@ -2479,6 +2795,41 @@ fn select_query(
         settings: None,
         format_clause: None,
         pipe_operators: vec![],
+    }
+}
+
+fn set_operation_query(
+    left: Query,
+    right: Query,
+    op: SetOperator,
+    set_quantifier: SetQuantifier,
+) -> Query {
+    Query {
+        with: None,
+        body: Box::new(SetExpr::SetOperation {
+            op,
+            set_quantifier,
+            left: Box::new(SetExpr::Query(Box::new(left))),
+            right: Box::new(SetExpr::Query(Box::new(right))),
+        }),
+        order_by: None,
+        limit_clause: None,
+        fetch: None,
+        locks: vec![],
+        for_clause: None,
+        settings: None,
+        format_clause: None,
+        pipe_operators: vec![],
+    }
+}
+
+fn set_query_quantifier(query: &mut Query, set_quantifier: SetQuantifier) {
+    if let SetExpr::SetOperation {
+        set_quantifier: current,
+        ..
+    } = query.body.as_mut()
+    {
+        *current = set_quantifier;
     }
 }
 

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -403,6 +403,16 @@ impl<M, T> Field<M, T> {
         qualified_column_value(self.table, self.column)
     }
 
+    fn orm_field(self) -> &'static OrmField
+    where
+        M: Model,
+    {
+        M::fields()
+            .iter()
+            .find(|field| field.column == self.column)
+            .expect("ORM field metadata must exist for generated model fields")
+    }
+
     /// Re-qualifies this field with a different source name such as a table alias.
     ///
     /// ```rust,ignore
@@ -1347,6 +1357,15 @@ pub struct SetQueryBuilder<Q: StatementSource, M: Model, P = ModelProjection> {
     _marker: PhantomData<(M, P)>,
 }
 
+/// ORM update builder produced from [`FromBuilder::update`].
+///
+/// This builder currently supports single-table updates with optional `WHERE`
+/// filters inherited from [`FromBuilder`].
+pub struct UpdateBuilder<Q: StatementSource, M: Model> {
+    state: BuilderState<Q, M>,
+    assignments: Vec<UpdateAssignment>,
+}
+
 #[doc(hidden)]
 pub struct JoinOnBuilder<Q: StatementSource, M: Model, P> {
     inner: QueryBuilder<Q, M, P>,
@@ -1384,6 +1403,23 @@ struct BuilderState<Q: StatementSource, M: Model> {
     limit: Option<usize>,
     offset: Option<usize>,
     _marker: PhantomData<M>,
+}
+
+struct UpdateAssignment {
+    column: &'static str,
+    placeholder: &'static str,
+    value: UpdateAssignmentValue,
+}
+
+enum UpdateAssignmentValue {
+    Param(DataValue),
+    Expr(QueryValue),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MutationKind {
+    Update,
+    Delete,
 }
 
 impl<Q: StatementSource, M: Model> BuilderState<Q, M> {
@@ -1431,6 +1467,45 @@ impl<Q: StatementSource, M: Model> BuilderState<Q, M> {
     fn push_join(mut self, join: JoinSpec) -> Self {
         self.joins.push(join);
         self
+    }
+}
+
+impl MutationKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            MutationKind::Update => "update",
+            MutationKind::Delete => "delete",
+        }
+    }
+}
+
+impl UpdateAssignment {
+    fn new(column: &'static str, placeholder: &'static str, value: UpdateAssignmentValue) -> Self {
+        Self {
+            column,
+            placeholder,
+            value,
+        }
+    }
+
+    fn into_parts(self) -> (Assignment, Option<(&'static str, DataValue)>) {
+        let placeholder = self.placeholder;
+        match self.value {
+            UpdateAssignmentValue::Param(value) => (
+                Assignment {
+                    target: AssignmentTarget::ColumnName(object_name(self.column)),
+                    value: placeholder_expr(placeholder),
+                },
+                Some((placeholder, value)),
+            ),
+            UpdateAssignmentValue::Expr(value) => (
+                Assignment {
+                    target: AssignmentTarget::ColumnName(object_name(self.column)),
+                    value: value.into_expr(),
+                },
+                None,
+            ),
+        }
     }
 }
 
@@ -1882,6 +1957,105 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
     }
 }
 
+impl<Q: StatementSource, M: Model> UpdateBuilder<Q, M> {
+    fn new(state: BuilderState<Q, M>) -> Self {
+        Self {
+            state,
+            assignments: Vec::new(),
+        }
+    }
+
+    fn with_assignment(
+        mut self,
+        column: &'static str,
+        placeholder: &'static str,
+        value: UpdateAssignmentValue,
+    ) -> Self {
+        let assignment = UpdateAssignment::new(column, placeholder, value);
+        if let Some(existing) = self
+            .assignments
+            .iter_mut()
+            .find(|existing| existing.column == column)
+        {
+            *existing = assignment;
+        } else {
+            self.assignments.push(assignment);
+        }
+        self
+    }
+
+    /// Assigns a constant value to a model field.
+    ///
+    /// ```rust,ignore
+    /// database
+    ///     .from::<User>()
+    ///     .eq(User::id(), 1)
+    ///     .update()
+    ///     .set(User::name(), "Bob")
+    ///     .set(User::age(), Some(20))
+    ///     .execute()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
+    pub fn set<T, V: ToDataValue>(self, field: Field<M, T>, value: V) -> Self {
+        let orm_field = field.orm_field();
+        self.with_assignment(
+            orm_field.column,
+            orm_field.placeholder,
+            UpdateAssignmentValue::Param(value.to_data_value()),
+        )
+    }
+
+    /// Assigns a computed SQL expression to a model field.
+    ///
+    /// ```rust,ignore
+    /// database
+    ///     .from::<User>()
+    ///     .eq(User::id(), 1)
+    ///     .update()
+    ///     .set_expr(User::age(), User::age().add(1))
+    ///     .execute()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
+    pub fn set_expr<T, V: Into<QueryValue>>(self, field: Field<M, T>, value: V) -> Self {
+        let orm_field = field.orm_field();
+        self.with_assignment(
+            orm_field.column,
+            orm_field.placeholder,
+            UpdateAssignmentValue::Expr(value.into()),
+        )
+    }
+
+    /// Executes the update statement.
+    pub fn execute(self) -> Result<(), DatabaseError> {
+        if self.assignments.is_empty() {
+            return Err(DatabaseError::ColumnsEmpty);
+        }
+
+        validate_mutation_state(&self.state, MutationKind::Update)?;
+
+        let UpdateBuilder { state, assignments } = self;
+        let BuilderState {
+            source,
+            query_source,
+            filter,
+            ..
+        } = state;
+
+        let mut statement_assignments = Vec::with_capacity(assignments.len());
+        let mut params = Vec::new();
+        for assignment in assignments {
+            let (assignment, param) = assignment.into_parts();
+            statement_assignments.push(assignment);
+            if let Some(param) = param {
+                params.push(param);
+            }
+        }
+
+        let statement = orm_update_builder_statement(&query_source, filter, statement_assignments);
+        source.execute_statement(&statement, params)?.done()
+    }
+}
+
 impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> JoinOnBuilder<Q, M, P> {
     /// Applies a relation alias to the pending join source.
     ///
@@ -1932,6 +2106,37 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> JoinOnBuilder<Q, M, P> 
 }
 
 impl<Q: StatementSource, M: Model> FromBuilder<Q, M, ModelProjection> {
+    /// Starts a single-table `UPDATE` builder for the current model source.
+    ///
+    /// Chain one or more `.set(...)` or `.set_expr(...)` calls, then finish
+    /// with `.execute()`.
+    ///
+    /// ```rust,ignore
+    /// database
+    ///     .from::<User>()
+    ///     .eq(User::id(), 1)
+    ///     .update()
+    ///     .set(User::name(), "Bob")
+    ///     .execute()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
+    pub fn update(self) -> UpdateBuilder<Q, M> {
+        UpdateBuilder::new(self.inner.state)
+    }
+
+    /// Executes a single-table `DELETE` for the current filtered source.
+    ///
+    /// ```rust,ignore
+    /// database
+    ///     .from::<User>()
+    ///     .eq(User::id(), 1)
+    ///     .delete()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
+    pub fn delete(self) -> Result<(), DatabaseError> {
+        self.inner.delete()
+    }
+
     /// Switches the query into a struct projection.
     ///
     /// ```rust,ignore
@@ -3057,6 +3262,21 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         iter.done()?;
         Ok(count)
     }
+
+    fn delete(self) -> Result<(), DatabaseError> {
+        validate_mutation_state(&self.state, MutationKind::Delete)?;
+
+        let BuilderState {
+            source,
+            query_source,
+            filter,
+            ..
+        } = self.state;
+
+        source
+            .execute_statement(&orm_delete_builder_statement(&query_source, filter), &[])?
+            .done()
+    }
 }
 
 impl<Q: StatementSource, M: Model, P> private::Sealed for FromBuilder<Q, M, P> {}
@@ -3258,6 +3478,51 @@ fn source_table_with_joins(source: &QuerySource, joins: Vec<JoinSpec>) -> TableW
     }
 }
 
+fn validate_mutation_state<Q: StatementSource, M: Model>(
+    state: &BuilderState<Q, M>,
+    kind: MutationKind,
+) -> Result<(), DatabaseError> {
+    let operation = kind.as_str();
+
+    if !state.joins.is_empty() {
+        return Err(DatabaseError::UnsupportedStmt(format!(
+            "ORM {operation} builder does not support joins"
+        )));
+    }
+    if state.distinct {
+        return Err(DatabaseError::UnsupportedStmt(format!(
+            "ORM {operation} builder does not support distinct"
+        )));
+    }
+    if !state.group_bys.is_empty() {
+        return Err(DatabaseError::UnsupportedStmt(format!(
+            "ORM {operation} builder does not support group by"
+        )));
+    }
+    if state.having.is_some() {
+        return Err(DatabaseError::UnsupportedStmt(format!(
+            "ORM {operation} builder does not support having"
+        )));
+    }
+    if !state.order_bys.is_empty() {
+        return Err(DatabaseError::UnsupportedStmt(format!(
+            "ORM {operation} builder does not support order by"
+        )));
+    }
+    if state.limit.is_some() {
+        return Err(DatabaseError::UnsupportedStmt(format!(
+            "ORM {operation} builder does not support limit"
+        )));
+    }
+    if state.offset.is_some() {
+        return Err(DatabaseError::UnsupportedStmt(format!(
+            "ORM {operation} builder does not support offset"
+        )));
+    }
+
+    Ok(())
+}
+
 fn select_projection(fields: &[OrmField], relation: &str) -> Vec<SelectItem> {
     fields
         .iter()
@@ -3441,6 +3706,38 @@ fn execute_query<Q: StatementSource>(source: Q, query: Query) -> Result<Q::Iter,
     source.execute_statement(&Statement::Query(Box::new(query)), &[])
 }
 
+fn orm_update_builder_statement(
+    source: &QuerySource,
+    filter: Option<QueryExpr>,
+    assignments: Vec<Assignment>,
+) -> Statement {
+    Statement::Update(Update {
+        update_token: AttachedToken::empty(),
+        optimizer_hint: None,
+        table: source_table_with_joins(source, vec![]),
+        assignments,
+        from: None,
+        selection: filter.map(QueryExpr::into_expr),
+        returning: None,
+        or: None,
+        limit: None,
+    })
+}
+
+fn orm_delete_builder_statement(source: &QuerySource, filter: Option<QueryExpr>) -> Statement {
+    Statement::Delete(Delete {
+        delete_token: AttachedToken::empty(),
+        optimizer_hint: None,
+        tables: vec![],
+        from: FromTable::WithFromKeyword(vec![source_table_with_joins(source, vec![])]),
+        using: None,
+        selection: filter.map(QueryExpr::into_expr),
+        returning: None,
+        order_by: vec![],
+        limit: None,
+    })
+}
+
 fn query_exists<Q: StatementSource>(source: Q, mut query: Query) -> Result<bool, DatabaseError> {
     query_set_limit(&mut query, 1);
     let mut iter = execute_query(source, query)?;
@@ -3574,55 +3871,6 @@ pub fn orm_insert_statement(table_name: &str, fields: &[OrmField]) -> Statement 
         insert_alias: None,
         settings: None,
         format_clause: None,
-    })
-}
-
-#[doc(hidden)]
-pub fn orm_update_statement(
-    table_name: &str,
-    fields: &[OrmField],
-    primary_key: &OrmField,
-) -> Statement {
-    Statement::Update(Update {
-        update_token: AttachedToken::empty(),
-        optimizer_hint: None,
-        table: table_with_joins(table_name),
-        assignments: fields
-            .iter()
-            .filter(|field| !field.primary_key)
-            .map(|field| Assignment {
-                target: AssignmentTarget::ColumnName(object_name(field.column)),
-                value: placeholder_expr(field.placeholder),
-            })
-            .collect(),
-        from: None,
-        selection: Some(Expr::BinaryOp {
-            left: Box::new(Expr::Identifier(ident(primary_key.column))),
-            op: SqlBinaryOperator::Eq,
-            right: Box::new(placeholder_expr(primary_key.placeholder)),
-        }),
-        returning: None,
-        or: None,
-        limit: None,
-    })
-}
-
-#[doc(hidden)]
-pub fn orm_delete_statement(table_name: &str, primary_key: &OrmField) -> Statement {
-    Statement::Delete(Delete {
-        delete_token: AttachedToken::empty(),
-        optimizer_hint: None,
-        tables: vec![],
-        from: FromTable::WithFromKeyword(vec![table_with_joins(table_name)]),
-        using: None,
-        selection: Some(Expr::BinaryOp {
-            left: Box::new(Expr::Identifier(ident(primary_key.column))),
-            op: SqlBinaryOperator::Eq,
-            right: Box::new(placeholder_expr(primary_key.placeholder)),
-        }),
-        returning: None,
-        order_by: vec![],
-        limit: None,
     })
 }
 
@@ -3949,13 +4197,12 @@ fn orm_add_column_statement(
 ///
 /// In normal usage you should derive this trait with `#[derive(Model)]` rather
 /// than implementing it by hand. The derive macro generates tuple mapping,
-/// cached CRUD/DDL statements and model metadata.
+/// cached model/DDL statements and model metadata.
 pub trait Model: Sized + for<'a> From<(&'a SchemaRef, Tuple)> {
     /// Rust type used as the model primary key.
     ///
     /// This associated type lets APIs such as
-    /// [`Database::get`](crate::orm::Database::get) and
-    /// [`Database::delete_by_id`](crate::orm::Database::delete_by_id)
+    /// [`Database::get`](crate::orm::Database::get)
     /// infer the key type directly from the model, so callers only need to
     /// write `database.get::<User>(&id)`.
     type PrimaryKey: ToDataValue;
@@ -3985,12 +4232,6 @@ pub trait Model: Sized + for<'a> From<(&'a SchemaRef, Tuple)> {
 
     /// Returns the cached `INSERT` statement for the model.
     fn insert_statement() -> &'static Statement;
-
-    /// Returns the cached `UPDATE` statement for the model.
-    fn update_statement() -> &'static Statement;
-
-    /// Returns the cached `DELETE` statement for the model.
-    fn delete_statement() -> &'static Statement;
 
     /// Returns the cached `SELECT .. WHERE primary_key = ...` statement.
     fn find_statement() -> &'static Statement;
@@ -4652,22 +4893,6 @@ fn orm_analyze<E: StatementSource, M: Model>(executor: E) -> Result<(), Database
 fn orm_insert<E: StatementSource, M: Model>(executor: E, model: &M) -> Result<(), DatabaseError> {
     executor
         .execute_statement(M::insert_statement(), model.params())?
-        .done()
-}
-
-fn orm_update<E: StatementSource, M: Model>(executor: E, model: &M) -> Result<(), DatabaseError> {
-    executor
-        .execute_statement(M::update_statement(), model.params())?
-        .done()
-}
-
-fn orm_delete_by_id<E: StatementSource, M: Model>(
-    executor: E,
-    key: &M::PrimaryKey,
-) -> Result<(), DatabaseError> {
-    let params = [(M::primary_key_field().placeholder, key.to_data_value())];
-    executor
-        .execute_statement(M::delete_statement(), params)?
         .done()
 }
 

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -610,6 +610,15 @@ where
 }
 
 /// Builds `count(expr)`.
+///
+/// ```rust,ignore
+/// let grouped = database
+///     .from::<EventLog>()
+///     .project_tuple((EventLog::category(), kite_sql::orm::count(EventLog::id())))
+///     .group_by(EventLog::category())
+///     .fetch::<(String, i32)>()?;
+/// # Ok::<(), kite_sql::errors::DatabaseError>(())
+/// ```
 pub fn count<V: Into<QueryValue>>(value: V) -> QueryValue {
     QueryValue::aggregate("count", [value.into()])
 }
@@ -628,6 +637,14 @@ pub fn count_all() -> QueryValue {
 }
 
 /// Builds `sum(expr)`.
+///
+/// ```rust,ignore
+/// let totals = database
+///     .from::<Order>()
+///     .project_value(kite_sql::orm::sum(Order::amount()))
+///     .get::<i32>()?;
+/// # Ok::<(), kite_sql::errors::DatabaseError>(())
+/// ```
 pub fn sum<V: Into<QueryValue>>(value: V) -> QueryValue {
     QueryValue::aggregate("sum", [value.into()])
 }
@@ -667,6 +684,19 @@ where
 }
 
 /// Builds a simple `CASE value WHEN ... THEN ... ELSE ... END` expression.
+///
+/// ```rust,ignore
+/// let label = kite_sql::orm::case_value(
+///     User::age(),
+///     [(18, "adult"), (30, "senior")],
+///     "other",
+/// );
+/// let rows = database
+///     .from::<User>()
+///     .project_tuple((User::id(), label.alias("age_label")))
+///     .fetch::<(i32, String)>()?;
+/// # Ok::<(), kite_sql::errors::DatabaseError>(())
+/// ```
 pub fn case_value<O, I, W, R, E>(operand: O, conditions: I, else_result: E) -> QueryValue
 where
     O: Into<QueryValue>,
@@ -688,6 +718,12 @@ impl QueryExpr {
     }
 
     /// Combines two predicates with `AND`.
+    ///
+    /// ```rust,ignore
+    /// let expr = User::age().gte(18).and(User::name().like("A%"));
+    /// let users = database.from::<User>().filter(expr).fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn and(self, rhs: QueryExpr) -> QueryExpr {
         QueryExpr::from_expr(Expr::BinaryOp {
             left: Box::new(nested_expr(self.into_expr())),
@@ -730,6 +766,14 @@ impl QueryExpr {
     }
 
     /// Builds a `NOT EXISTS (subquery)` predicate.
+    ///
+    /// ```rust,ignore
+    /// let expr = kite_sql::orm::QueryExpr::not_exists(
+    ///     database.from::<Order>().project_value(Order::id()).eq(Order::user_id(), User::id()),
+    /// );
+    /// let users = database.from::<User>().filter(expr).fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn not_exists<S: SubquerySource>(subquery: S) -> QueryExpr {
         QueryExpr::from_expr(Expr::Exists {
             subquery: Box::new(subquery.into_subquery()),
@@ -808,6 +852,15 @@ impl QueryValue {
     }
 
     /// Assigns a select-list alias to this value expression.
+    ///
+    /// ```rust,ignore
+    /// let rows = database
+    ///     .from::<Order>()
+    ///     .project_value(kite_sql::orm::sum(Order::amount()).alias("total_amount"))
+    ///     .raw()?;
+    /// # rows.done()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn alias(self, alias: &str) -> ProjectedValue {
         ProjectedValue {
             item: SelectItem::ExprWithAlias {
@@ -818,6 +871,18 @@ impl QueryValue {
     }
 
     /// Builds a searched `CASE WHEN ... THEN ... ELSE ... END` expression.
+    ///
+    /// ```rust,ignore
+    /// let label = kite_sql::orm::QueryValue::searched_case(
+    ///     [(User::age().is_null(), "unknown"), (User::age().lt(18), "minor")],
+    ///     "adult",
+    /// );
+    /// let rows = database
+    ///     .from::<User>()
+    ///     .project_tuple((User::name(), label.alias("age_group")))
+    ///     .fetch::<(String, String)>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn searched_case<I, C, R, E>(conditions: I, else_result: E) -> Self
     where
         I: IntoIterator<Item = (C, R)>,
@@ -995,6 +1060,17 @@ impl QueryValue {
     }
 
     /// Wraps a query builder as a scalar subquery expression.
+    ///
+    /// ```rust,ignore
+    /// let max_amount = kite_sql::orm::QueryValue::subquery(
+    ///     database.from::<Order>().project_value(kite_sql::orm::max(Order::amount())),
+    /// );
+    /// let row = database
+    ///     .from::<Order>()
+    ///     .eq(Order::amount(), max_amount)
+    ///     .get()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn subquery<S: SubquerySource>(query: S) -> QueryValue {
         QueryValue::from_expr(Expr::Subquery(Box::new(query.into_subquery())))
     }
@@ -1405,6 +1481,15 @@ impl<Q: StatementSource, M: Model, P> FromBuilder<Q, M, P> {
     }
 
     /// Applies a relation alias to the current source.
+    ///
+    /// ```rust,ignore
+    /// let user = database
+    ///     .from::<User>()
+    ///     .alias("u")
+    ///     .eq(User::id().qualify("u"), 1)
+    ///     .get()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn alias(self, alias: impl Into<String>) -> Self {
         FromBuilder::from_inner(self.inner.with_alias(alias))
     }
@@ -1412,6 +1497,9 @@ impl<Q: StatementSource, M: Model, P> FromBuilder<Q, M, P> {
 
 impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> JoinOnBuilder<Q, M, P> {
     /// Applies a relation alias to the pending join source.
+    ///
+    /// This is mainly useful for self-joins or when you want explicit source
+    /// names in projected columns.
     pub fn alias(mut self, alias: impl Into<String>) -> Self {
         self.join_source = self.join_source.with_alias(alias);
         self
@@ -1549,6 +1637,14 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     }
 
     /// Replaces the current `WHERE` predicate.
+    ///
+    /// ```rust,ignore
+    /// let adults = database
+    ///     .from::<User>()
+    ///     .filter(User::age().gte(18))
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn filter(self, expr: QueryExpr) -> Self {
         Self::from_inner(self.inner.filter(expr))
     }
@@ -1583,6 +1679,19 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     }
 
     /// Replaces the current filter with `EXISTS (subquery)`.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .where_exists(
+    ///         database
+    ///             .from::<Order>()
+    ///             .project_value(Order::id())
+    ///             .eq(Order::user_id(), User::id()),
+    ///     )
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn where_exists<S: SubquerySource>(self, subquery: S) -> Self {
         Self::from_inner(self.inner.where_exists(subquery))
     }
@@ -1593,6 +1702,15 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     }
 
     /// Appends a `GROUP BY` expression.
+    ///
+    /// ```rust,ignore
+    /// let rows = database
+    ///     .from::<EventLog>()
+    ///     .project_tuple((EventLog::category(), kite_sql::orm::count(EventLog::id())))
+    ///     .group_by(EventLog::category())
+    ///     .fetch::<(String, i32)>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn group_by<V: Into<QueryValue>>(self, value: V) -> Self {
         Self::from_inner(self.inner.group_by(value))
     }
@@ -1603,6 +1721,14 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     }
 
     /// Appends an ascending sort key.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .asc(User::name())
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn asc<V: Into<QueryValue>>(self, value: V) -> Self {
         Self::from_inner(self.inner.asc(value))
     }
@@ -1727,16 +1853,29 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     }
 
     /// Executes the query and returns the raw result iterator.
+    ///
+    /// This is mainly useful when you want access to the raw tuple/schema pair
+    /// instead of ORM decoding.
     pub fn raw(self) -> Result<Q::Iter, DatabaseError> {
         self.inner.raw()
     }
 
     /// Returns whether the query produces at least one row.
+    ///
+    /// ```rust,ignore
+    /// let found = database.from::<User>().eq(User::id(), 1).exists()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn exists(self) -> Result<bool, DatabaseError> {
         self.inner.exists()
     }
 
     /// Returns the row count for the current query shape.
+    ///
+    /// ```rust,ignore
+    /// let adult_count = database.from::<User>().gte(User::age(), 18).count()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn count(self) -> Result<usize, DatabaseError> {
         self.inner.count()
     }

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -16,8 +16,8 @@ use sqlparser::ast::{
     AlterColumnOperation, AlterTable, AlterTableOperation, Analyze, Assignment, AssignmentTarget,
     BinaryOperator as SqlBinaryOperator, CaseWhen, CastKind, CharLengthUnits, ColumnDef,
     ColumnOption, ColumnOptionDef, CreateIndex, CreateTable, DataType, Delete, Expr, FromTable,
-    Function, FunctionArg, FunctionArgExpr, FunctionArgumentList, FunctionArguments, GroupByExpr,
-    HiveDistributionStyle, Ident, IndexColumn, Insert, KeyOrIndexDisplay, LimitClause,
+    Distinct, Function, FunctionArg, FunctionArgExpr, FunctionArgumentList, FunctionArguments,
+    GroupByExpr, HiveDistributionStyle, Ident, IndexColumn, Insert, KeyOrIndexDisplay, LimitClause,
     NullsDistinctOption, ObjectName, ObjectType, Offset, OffsetRows, OrderBy, OrderByExpr,
     OrderByKind, OrderByOptions, PrimaryKeyConstraint, Query, Select, SelectFlavor, SelectItem,
     SetExpr, TableFactor, TableObject, TableWithJoins, TimezoneInfo, UniqueConstraint, Update,
@@ -1044,6 +1044,7 @@ pub struct StructProjection<T> {
 
 struct BuilderState<Q: StatementSource, M: Model> {
     source: Q,
+    distinct: bool,
     filter: Option<QueryExpr>,
     group_bys: Vec<QueryValue>,
     having: Option<QueryExpr>,
@@ -1057,6 +1058,7 @@ impl<Q: StatementSource, M: Model> BuilderState<Q, M> {
     fn new(source: Q) -> Self {
         Self {
             source,
+            distinct: false,
             filter: None,
             group_bys: Vec::new(),
             having: None,
@@ -1084,6 +1086,11 @@ impl<Q: StatementSource, M: Model> BuilderState<Q, M> {
 
     fn push_group_by(mut self, expr: QueryValue) -> Self {
         self.group_bys.push(expr);
+        self
+    }
+
+    fn with_distinct(mut self) -> Self {
+        self.distinct = true;
         self
     }
 }
@@ -1242,6 +1249,20 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     /// Replaces the current `WHERE` predicate.
     pub fn filter(self, expr: QueryExpr) -> Self {
         Self::from_inner(self.inner.filter(expr))
+    }
+
+    /// Applies `SELECT DISTINCT` to the current query.
+    ///
+    /// ```rust,ignore
+    /// let categories = database
+    ///     .from::<EventLog>()
+    ///     .distinct()
+    ///     .project_value(EventLog::category())
+    ///     .fetch::<String>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
+    pub fn distinct(self) -> Self {
+        Self::from_inner(self.inner.distinct())
     }
 
     /// Appends `left AND right` to the current filter state.
@@ -1468,6 +1489,13 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         self
     }
 
+    fn distinct(self) -> Self {
+        Self {
+            state: self.state.with_distinct(),
+            projection: self.projection,
+        }
+    }
+
     fn and(self, left: QueryExpr, right: QueryExpr) -> Self {
         Self {
             state: self.state.push_filter(left.and(right), FilterMode::And),
@@ -1548,6 +1576,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
             state:
                 BuilderState {
                     source: _,
+                    distinct,
                     filter,
                     group_bys,
                     having,
@@ -1562,6 +1591,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         select_query(
             M::table_name(),
             projection.into_select_items(),
+            distinct,
             filter,
             group_bys,
             having,
@@ -1576,6 +1606,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
             state:
                 BuilderState {
                     source,
+                    distinct,
                     filter,
                     group_bys,
                     having,
@@ -1590,6 +1621,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         let statement = Statement::Query(Box::new(select_query(
             M::table_name(),
             projection.into_select_items(),
+            distinct,
             filter,
             group_bys,
             having,
@@ -1726,8 +1758,12 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
     }
 
     fn count(self) -> Result<usize, DatabaseError> {
-        let has_grouping = !self.state.group_bys.is_empty() || self.state.having.is_some();
-        if has_grouping {
+        let is_shape_sensitive = self.state.distinct
+            || !self.state.group_bys.is_empty()
+            || self.state.having.is_some()
+            || self.state.limit.is_some()
+            || self.state.offset.is_some();
+        if is_shape_sensitive {
             let mut iter = self.raw()?;
             let mut count = 0usize;
             while iter.next().transpose()?.is_some() {
@@ -1836,6 +1872,7 @@ fn select_projection(fields: &[OrmField]) -> Vec<SelectItem> {
 fn select_query(
     table_name: &str,
     projection: Vec<SelectItem>,
+    distinct: bool,
     filter: Option<QueryExpr>,
     group_bys: Vec<QueryValue>,
     having: Option<QueryExpr>,
@@ -1848,7 +1885,7 @@ fn select_query(
         body: Box::new(SetExpr::Select(Box::new(Select {
             select_token: AttachedToken::empty(),
             optimizer_hint: None,
-            distinct: None,
+            distinct: distinct.then_some(Distinct::Distinct),
             select_modifiers: None,
             top: None,
             top_before_distinct: false,
@@ -1973,6 +2010,7 @@ pub fn orm_select_statement(table_name: &str, fields: &[OrmField]) -> Statement 
     Statement::Query(Box::new(select_query(
         table_name,
         select_projection(fields),
+        false,
         None,
         vec![],
         None,
@@ -2262,6 +2300,7 @@ fn orm_count_statement(table_name: &str, filter: Option<QueryExpr>) -> Statement
             over: None,
             within_group: vec![],
         }))],
+        false,
         filter,
         vec![],
         None,

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -796,6 +796,8 @@ pub struct ValueProjection {
 struct BuilderState<Q: StatementSource, M: Model> {
     source: Q,
     filter: Option<QueryExpr>,
+    group_bys: Vec<QueryValue>,
+    having: Option<QueryExpr>,
     order_bys: Vec<SortExpr>,
     limit: Option<usize>,
     offset: Option<usize>,
@@ -807,6 +809,8 @@ impl<Q: StatementSource, M: Model> BuilderState<Q, M> {
         Self {
             source,
             filter: None,
+            group_bys: Vec::new(),
+            having: None,
             order_bys: Vec::new(),
             limit: None,
             offset: None,
@@ -826,6 +830,11 @@ impl<Q: StatementSource, M: Model> BuilderState<Q, M> {
 
     fn push_order(mut self, order: SortExpr) -> Self {
         self.order_bys.push(order);
+        self
+    }
+
+    fn push_group_by(mut self, expr: QueryValue) -> Self {
+        self.group_bys.push(expr);
         self
     }
 }
@@ -972,6 +981,18 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> SelectBuilder<Q, M, P> 
         }
     }
 
+    pub fn group_by<V: Into<QueryValue>>(self, value: V) -> Self {
+        Self {
+            state: self.state.push_group_by(value.into()),
+            projection: self.projection,
+        }
+    }
+
+    pub fn having(mut self, expr: QueryExpr) -> Self {
+        self.state.having = Some(expr);
+        self
+    }
+
     pub fn asc<V: Into<QueryValue>>(self, value: V) -> Self {
         Self {
             state: self.state.push_order(value.into().asc()),
@@ -1002,6 +1023,8 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> SelectBuilder<Q, M, P> 
                 BuilderState {
                     source: _,
                     filter,
+                    group_bys,
+                    having,
                     order_bys,
                     limit,
                     offset,
@@ -1014,6 +1037,8 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> SelectBuilder<Q, M, P> 
             M::table_name(),
             projection.into_select_items(),
             filter,
+            group_bys,
+            having,
             order_bys,
             limit,
             offset,
@@ -1026,6 +1051,8 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> SelectBuilder<Q, M, P> 
                 BuilderState {
                     source,
                     filter,
+                    group_bys,
+                    having,
                     order_bys,
                     limit,
                     offset,
@@ -1038,6 +1065,8 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> SelectBuilder<Q, M, P> 
             M::table_name(),
             projection.into_select_items(),
             filter,
+            group_bys,
+            having,
             order_bys,
             limit,
             offset,
@@ -1141,6 +1170,17 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> SelectBuilder<Q, M, P> 
     }
 
     pub fn count(self) -> Result<usize, DatabaseError> {
+        let has_grouping = !self.state.group_bys.is_empty() || self.state.having.is_some();
+        if has_grouping {
+            let mut iter = self.raw()?;
+            let mut count = 0usize;
+            while iter.next().transpose()?.is_some() {
+                count += 1;
+            }
+            iter.done()?;
+            return Ok(count);
+        }
+
         let BuilderState { source, filter, .. } = self.state;
         let statement = orm_count_statement(M::table_name(), filter);
         let mut iter = source.execute_statement(&statement, &[])?;
@@ -1244,6 +1284,8 @@ fn select_query(
     table_name: &str,
     projection: Vec<SelectItem>,
     filter: Option<QueryExpr>,
+    group_bys: Vec<QueryValue>,
+    having: Option<QueryExpr>,
     order_bys: Vec<SortExpr>,
     limit: Option<usize>,
     offset: Option<usize>,
@@ -1265,11 +1307,14 @@ fn select_query(
             prewhere: None,
             selection: filter.map(QueryExpr::into_ast),
             connect_by: vec![],
-            group_by: GroupByExpr::Expressions(vec![], vec![]),
+            group_by: GroupByExpr::Expressions(
+                group_bys.into_iter().map(QueryValue::into_ast).collect(),
+                vec![],
+            ),
             cluster_by: vec![],
             distribute_by: vec![],
             sort_by: vec![],
-            having: None,
+            having: having.map(QueryExpr::into_ast),
             named_window: vec![],
             qualify: None,
             window_before_qualify: false,
@@ -1375,6 +1420,8 @@ pub fn orm_select_statement(table_name: &str, fields: &[OrmField]) -> Statement 
     Statement::Query(Box::new(select_query(
         table_name,
         select_projection(fields),
+        None,
+        vec![],
         None,
         vec![],
         None,
@@ -1663,6 +1710,8 @@ fn orm_count_statement(table_name: &str, filter: Option<QueryExpr>) -> Statement
             within_group: vec![],
         }))],
         filter,
+        vec![],
+        None,
         vec![],
         None,
         None,

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -1969,6 +1969,9 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
 
     /// Applies `NULLS FIRST` to the most recently added sort key.
     ///
+    /// Tips: call this immediately after `asc(...)` or `desc(...)`.
+    /// Without a preceding sort key, this method is a no-op.
+    ///
     /// ```rust,ignore
     /// let ids = database
     ///     .from::<User>()
@@ -2001,6 +2004,9 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
     }
 
     /// Applies `NULLS LAST` to the most recently added sort key.
+    ///
+    /// Tips: call this immediately after `asc(...)` or `desc(...)`.
+    /// Without a preceding sort key, this method is a no-op.
     ///
     /// ```rust,ignore
     /// let ids = database
@@ -2074,6 +2080,7 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
     ///     .project_value(User::id())
     ///     .union(database.from::<Order>().project_value(Order::user_id()))
     ///     .explain()?;
+    /// assert!(plan.contains("Union"));
     /// # let _ = plan;
     /// # Ok::<(), kite_sql::errors::DatabaseError>(())
     /// ```
@@ -2690,6 +2697,9 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
 
     /// Applies `NULLS FIRST` to the most recently added sort key.
     ///
+    /// Tips: call this immediately after `asc(...)` or `desc(...)`.
+    /// Without a preceding sort key, this method is a no-op.
+    ///
     /// ```rust,ignore
     /// let users = database
     ///     .from::<User>()
@@ -2704,6 +2714,9 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     }
 
     /// Applies `NULLS LAST` to the most recently added sort key.
+    ///
+    /// Tips: call this immediately after `asc(...)` or `desc(...)`.
+    /// Without a preceding sort key, this method is a no-op.
     ///
     /// ```rust,ignore
     /// let users = database
@@ -2987,6 +3000,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     ///     .eq(User::id(), 1)
     ///     .project_value(User::name())
     ///     .explain()?;
+    /// assert!(plan.contains("TableScan"));
     /// # let _ = plan;
     /// # Ok::<(), kite_sql::errors::DatabaseError>(())
     /// ```

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -92,90 +92,44 @@ impl<M, T> Field<M, T> {
         }
     }
 
-    pub fn eq<V: ToDataValue>(self, value: V) -> QueryExpr {
-        QueryExpr::Compare {
-            left: self.value(),
-            op: CompareOp::Eq,
-            right: QueryValue::Param(value.to_data_value()),
-        }
+    pub fn eq<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        self.value().eq(value)
     }
 
-    pub fn ne<V: ToDataValue>(self, value: V) -> QueryExpr {
-        QueryExpr::Compare {
-            left: self.value(),
-            op: CompareOp::Ne,
-            right: QueryValue::Param(value.to_data_value()),
-        }
+    pub fn ne<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        self.value().ne(value)
     }
 
-    pub fn gt<V: ToDataValue>(self, value: V) -> QueryExpr {
-        QueryExpr::Compare {
-            left: self.value(),
-            op: CompareOp::Gt,
-            right: QueryValue::Param(value.to_data_value()),
-        }
+    pub fn gt<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        self.value().gt(value)
     }
 
-    pub fn gte<V: ToDataValue>(self, value: V) -> QueryExpr {
-        QueryExpr::Compare {
-            left: self.value(),
-            op: CompareOp::Gte,
-            right: QueryValue::Param(value.to_data_value()),
-        }
+    pub fn gte<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        self.value().gte(value)
     }
 
-    pub fn lt<V: ToDataValue>(self, value: V) -> QueryExpr {
-        QueryExpr::Compare {
-            left: self.value(),
-            op: CompareOp::Lt,
-            right: QueryValue::Param(value.to_data_value()),
-        }
+    pub fn lt<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        self.value().lt(value)
     }
 
-    pub fn lte<V: ToDataValue>(self, value: V) -> QueryExpr {
-        QueryExpr::Compare {
-            left: self.value(),
-            op: CompareOp::Lte,
-            right: QueryValue::Param(value.to_data_value()),
-        }
+    pub fn lte<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        self.value().lte(value)
     }
 
     pub fn is_null(self) -> QueryExpr {
-        QueryExpr::IsNull {
-            value: self.value(),
-            negated: false,
-        }
+        self.value().is_null()
     }
 
     pub fn is_not_null(self) -> QueryExpr {
-        QueryExpr::IsNull {
-            value: self.value(),
-            negated: true,
-        }
+        self.value().is_not_null()
     }
 
-    pub fn like<V: ToDataValue>(self, pattern: V) -> QueryExpr {
-        QueryExpr::Like {
-            value: self.value(),
-            pattern: QueryValue::Param(pattern.to_data_value()),
-            negated: false,
-        }
+    pub fn like<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
+        self.value().like(pattern)
     }
 
-    pub fn not_like<V: ToDataValue>(self, pattern: V) -> QueryExpr {
-        QueryExpr::Like {
-            value: self.value(),
-            pattern: QueryValue::Param(pattern.to_data_value()),
-            negated: true,
-        }
-    }
-
-    pub fn asc(self) -> OrderBy {
-        OrderBy::new(self.table, self.column, false)
-    }
-
-    pub fn desc(self) -> OrderBy {
-        OrderBy::new(self.table, self.column, true)
+    pub fn not_like<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
+        self.value().not_like(pattern)
     }
 }
 
@@ -186,6 +140,10 @@ pub enum QueryValue {
         column: &'static str,
     },
     Param(DataValue),
+    Function {
+        name: String,
+        args: Vec<QueryValue>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -217,6 +175,15 @@ pub enum QueryExpr {
     And(Box<QueryExpr>, Box<QueryExpr>),
     Or(Box<QueryExpr>, Box<QueryExpr>),
     Not(Box<QueryExpr>),
+}
+
+pub fn func<N, I, V>(name: N, args: I) -> QueryValue
+where
+    N: Into<String>,
+    I: IntoIterator<Item = V>,
+    V: Into<QueryValue>,
+{
+    QueryValue::function(name, args)
 }
 
 impl QueryExpr {
@@ -262,34 +229,147 @@ impl QueryExpr {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct OrderBy {
-    table: &'static str,
-    column: &'static str,
+#[derive(Debug, Clone, PartialEq)]
+struct SortExpr {
+    value: QueryValue,
     desc: bool,
 }
 
-impl OrderBy {
-    const fn new(table: &'static str, column: &'static str, desc: bool) -> Self {
-        Self {
-            table,
-            column,
-            desc,
-        }
+impl SortExpr {
+    fn new(value: QueryValue, desc: bool) -> Self {
+        Self { value, desc }
     }
 
     fn to_sql(&self) -> String {
         let direction = if self.desc { "desc" } else { "asc" };
-        format!("{}.{} {}", self.table, self.column, direction)
+        format!("{} {}", self.value.to_sql(), direction)
     }
 }
 
 impl QueryValue {
+    pub fn function<N, I, V>(name: N, args: I) -> Self
+    where
+        N: Into<String>,
+        I: IntoIterator<Item = V>,
+        V: Into<QueryValue>,
+    {
+        Self::Function {
+            name: name.into(),
+            args: args.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    pub fn eq<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        QueryExpr::Compare {
+            left: self,
+            op: CompareOp::Eq,
+            right: value.into(),
+        }
+    }
+
+    pub fn ne<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        QueryExpr::Compare {
+            left: self,
+            op: CompareOp::Ne,
+            right: value.into(),
+        }
+    }
+
+    pub fn gt<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        QueryExpr::Compare {
+            left: self,
+            op: CompareOp::Gt,
+            right: value.into(),
+        }
+    }
+
+    pub fn gte<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        QueryExpr::Compare {
+            left: self,
+            op: CompareOp::Gte,
+            right: value.into(),
+        }
+    }
+
+    pub fn lt<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        QueryExpr::Compare {
+            left: self,
+            op: CompareOp::Lt,
+            right: value.into(),
+        }
+    }
+
+    pub fn lte<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
+        QueryExpr::Compare {
+            left: self,
+            op: CompareOp::Lte,
+            right: value.into(),
+        }
+    }
+
+    pub fn is_null(self) -> QueryExpr {
+        QueryExpr::IsNull {
+            value: self,
+            negated: false,
+        }
+    }
+
+    pub fn is_not_null(self) -> QueryExpr {
+        QueryExpr::IsNull {
+            value: self,
+            negated: true,
+        }
+    }
+
+    pub fn like<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
+        QueryExpr::Like {
+            value: self,
+            pattern: pattern.into(),
+            negated: false,
+        }
+    }
+
+    pub fn not_like<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
+        QueryExpr::Like {
+            value: self,
+            pattern: pattern.into(),
+            negated: true,
+        }
+    }
+
+    fn asc(self) -> SortExpr {
+        SortExpr::new(self, false)
+    }
+
+    fn desc(self) -> SortExpr {
+        SortExpr::new(self, true)
+    }
+
     fn to_sql(&self) -> String {
         match self {
             QueryValue::Column { table, column } => format!("{}.{}", table, column),
             QueryValue::Param(value) => data_value_to_sql(value),
+            QueryValue::Function { name, args } => format!(
+                "{}({})",
+                name,
+                args.iter()
+                    .map(QueryValue::to_sql)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
         }
+    }
+}
+
+impl<M, T> From<Field<M, T>> for QueryValue {
+    fn from(value: Field<M, T>) -> Self {
+        value.value()
+    }
+}
+
+impl<T: ToDataValue> From<T> for QueryValue {
+    fn from(value: T) -> Self {
+        QueryValue::Param(value.to_data_value())
     }
 }
 
@@ -409,10 +489,47 @@ impl<'a, 'tx, S: Storage> SelectSource for TransactionSelectSource<'a, 'tx, S> {
 pub struct SelectBuilder<Q: SelectSource, M: Model> {
     source: Q,
     filter: Option<QueryExpr>,
-    order_bys: Vec<OrderBy>,
+    order_bys: Vec<SortExpr>,
     limit: Option<usize>,
     offset: Option<usize>,
     _marker: PhantomData<M>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FilterMode {
+    Replace,
+    And,
+    Or,
+}
+
+macro_rules! impl_select_builder_compare_methods {
+    ($($name:ident),+ $(,)?) => {
+        $(
+            pub fn $name<L: Into<QueryValue>, R: Into<QueryValue>>(self, left: L, right: R) -> Self {
+                self.push_filter(left.into().$name(right), FilterMode::Replace)
+            }
+        )+
+    };
+}
+
+macro_rules! impl_select_builder_null_methods {
+    ($($name:ident),+ $(,)?) => {
+        $(
+            pub fn $name<V: Into<QueryValue>>(self, value: V) -> Self {
+                self.push_filter(value.into().$name(), FilterMode::Replace)
+            }
+        )+
+    };
+}
+
+macro_rules! impl_select_builder_like_methods {
+    ($($name:ident),+ $(,)?) => {
+        $(
+            pub fn $name<L: Into<QueryValue>, R: Into<QueryValue>>(self, value: L, pattern: R) -> Self {
+                self.push_filter(value.into().$name(pattern), FilterMode::Replace)
+            }
+        )+
+    };
 }
 
 impl<Q: SelectSource, M: Model> SelectBuilder<Q, M> {
@@ -427,22 +544,44 @@ impl<Q: SelectSource, M: Model> SelectBuilder<Q, M> {
         }
     }
 
+    fn push_filter(mut self, expr: QueryExpr, mode: FilterMode) -> Self {
+        self.filter = Some(match (mode, self.filter.take()) {
+            (FilterMode::Replace, _) => expr,
+            (FilterMode::And, Some(current)) => current.and(expr),
+            (FilterMode::Or, Some(current)) => current.or(expr),
+            (_, None) => expr,
+        });
+        self
+    }
+
     pub fn filter(mut self, expr: QueryExpr) -> Self {
         self.filter = Some(expr);
         self
     }
 
-    pub fn and_filter(mut self, expr: QueryExpr) -> Self {
-        self.filter = Some(match self.filter.take() {
-            Some(current) => current.and(expr),
-            None => expr,
-        });
+    pub fn and(self, left: QueryExpr, right: QueryExpr) -> Self {
+        self.push_filter(left.and(right), FilterMode::And)
+    }
+
+    pub fn or(self, left: QueryExpr, right: QueryExpr) -> Self {
+        self.push_filter(left.or(right), FilterMode::Or)
+    }
+
+    pub fn not(self, expr: QueryExpr) -> Self {
+        self.push_filter(expr.not(), FilterMode::Replace)
+    }
+
+    fn push_order(mut self, order: SortExpr) -> Self {
+        self.order_bys.push(order);
         self
     }
 
-    pub fn order_by(mut self, order: OrderBy) -> Self {
-        self.order_bys.push(order);
-        self
+    pub fn asc<V: Into<QueryValue>>(self, value: V) -> Self {
+        self.push_order(value.into().asc())
+    }
+
+    pub fn desc<V: Into<QueryValue>>(self, value: V) -> Self {
+        self.push_order(value.into().desc())
     }
 
     pub fn limit(mut self, limit: usize) -> Self {
@@ -482,7 +621,7 @@ impl<Q: SelectSource, M: Model> SelectBuilder<Q, M> {
                 &self
                     .order_bys
                     .iter()
-                    .map(OrderBy::to_sql)
+                    .map(SortExpr::to_sql)
                     .collect::<Vec<_>>()
                     .join(", "),
             );
@@ -499,6 +638,12 @@ impl<Q: SelectSource, M: Model> SelectBuilder<Q, M> {
     fn build_sql(&self) -> String {
         self.append_filter_order_limit(self.base_select_sql())
     }
+
+    impl_select_builder_compare_methods!(eq, ne, gt, gte, lt, lte);
+
+    impl_select_builder_null_methods!(is_null, is_not_null);
+
+    impl_select_builder_like_methods!(like, not_like);
 
     pub fn raw(self) -> Result<Q::Iter, DatabaseError> {
         let sql = self.build_sql();

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -1545,6 +1545,11 @@ pub trait IntoJoinColumns {
 }
 
 #[doc(hidden)]
+pub trait IntoInsertColumns<T: Model> {
+    fn into_insert_columns(self) -> Vec<Ident>;
+}
+
+#[doc(hidden)]
 pub trait QueryOperand: private::Sealed + Sized {
     type Source: StatementSource;
     type Model: Model;
@@ -1596,6 +1601,12 @@ impl<M, T> IntoJoinColumns for Field<M, T> {
     }
 }
 
+impl<M: Model, T> IntoInsertColumns<M> for Field<M, T> {
+    fn into_insert_columns(self) -> Vec<Ident> {
+        vec![ident(self.column)]
+    }
+}
+
 macro_rules! impl_into_join_columns {
     ($(($($name:ident),+)),+ $(,)?) => {
         $(
@@ -1616,6 +1627,35 @@ macro_rules! impl_into_join_columns {
 }
 
 impl_into_join_columns!(
+    (A, B),
+    (A, B, C),
+    (A, B, C, D),
+    (A, B, C, D, E),
+    (A, B, C, D, E, F),
+    (A, B, C, D, E, F, G),
+    (A, B, C, D, E, F, G, H),
+);
+
+macro_rules! impl_into_insert_columns {
+    ($(($($name:ident),+)),+ $(,)?) => {
+        $(
+            impl<Target: Model, $($name),+> IntoInsertColumns<Target> for ($($name,)+)
+            where
+                $($name: IntoInsertColumns<Target>,)+
+            {
+                #[allow(non_snake_case)]
+                fn into_insert_columns(self) -> Vec<Ident> {
+                    let ($($name,)+) = self;
+                    let mut columns = Vec::new();
+                    $(columns.extend($name.into_insert_columns());)+
+                    columns
+                }
+            }
+        )+
+    };
+}
+
+impl_into_insert_columns!(
     (A, B),
     (A, B, C),
     (A, B, C, D),
@@ -1781,6 +1821,60 @@ impl<Q: StatementSource, M: Model, P> FromBuilder<Q, M, P> {
         R: QueryOperand<Source = Q, Projection = P, Shape = <Self as QueryOperand>::Shape>,
     {
         QueryOperand::except(self, rhs)
+    }
+
+    /// Inserts the current query result into a target model table.
+    ///
+    /// Use this when the query output is a partial projection and you want to
+    /// choose the destination columns explicitly.
+    ///
+    /// ```rust,ignore
+    /// database
+    ///     .from::<ArchivedUser>()
+    ///     .project_tuple((ArchivedUser::id(), ArchivedUser::name()))
+    ///     .insert_into::<User, _>((User::id(), User::name()))?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
+    pub fn insert_into<Target: Model, C: IntoInsertColumns<Target>>(
+        self,
+        columns: C,
+    ) -> Result<(), DatabaseError>
+    where
+        Self: QueryOperand<Source = Q, Model = M, Projection = P>,
+    {
+        let (source, query) = QueryOperand::into_query_parts(self);
+        execute_insert_query(
+            source,
+            orm_insert_query_statement(
+                Target::table_name(),
+                columns.into_insert_columns(),
+                query,
+                false,
+            ),
+        )
+    }
+
+    /// Inserts the current query result with `INSERT OVERWRITE` semantics.
+    ///
+    /// Use this when the query output is a partial projection and you want to
+    /// choose the destination columns explicitly.
+    pub fn overwrite_into<Target: Model, C: IntoInsertColumns<Target>>(
+        self,
+        columns: C,
+    ) -> Result<(), DatabaseError>
+    where
+        Self: QueryOperand<Source = Q, Model = M, Projection = P>,
+    {
+        let (source, query) = QueryOperand::into_query_parts(self);
+        execute_insert_query(
+            source,
+            orm_insert_query_statement(
+                Target::table_name(),
+                columns.into_insert_columns(),
+                query,
+                true,
+            ),
+        )
     }
 }
 
@@ -1955,6 +2049,60 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
     {
         QueryOperand::except(self, rhs)
     }
+
+    /// Inserts the current query result into a target model table.
+    ///
+    /// Use this when the query output is a partial projection and you want to
+    /// choose the destination columns explicitly.
+    ///
+    /// ```rust,ignore
+    /// database
+    ///     .from::<ArchivedUser>()
+    ///     .project_tuple((ArchivedUser::id(), ArchivedUser::name()))
+    ///     .insert_into::<User, _>((User::id(), User::name()))?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
+    pub fn insert_into<Target: Model, C: IntoInsertColumns<Target>>(
+        self,
+        columns: C,
+    ) -> Result<(), DatabaseError>
+    where
+        Self: QueryOperand<Source = Q, Model = M, Projection = P>,
+    {
+        let (source, query) = QueryOperand::into_query_parts(self);
+        execute_insert_query(
+            source,
+            orm_insert_query_statement(
+                Target::table_name(),
+                columns.into_insert_columns(),
+                query,
+                false,
+            ),
+        )
+    }
+
+    /// Inserts the current set-query result with `INSERT OVERWRITE` semantics.
+    ///
+    /// Use this when the query output is a partial projection and you want to
+    /// choose the destination columns explicitly.
+    pub fn overwrite_into<Target: Model, C: IntoInsertColumns<Target>>(
+        self,
+        columns: C,
+    ) -> Result<(), DatabaseError>
+    where
+        Self: QueryOperand<Source = Q, Model = M, Projection = P>,
+    {
+        let (source, query) = QueryOperand::into_query_parts(self);
+        execute_insert_query(
+            source,
+            orm_insert_query_statement(
+                Target::table_name(),
+                columns.into_insert_columns(),
+                query,
+                true,
+            ),
+        )
+    }
 }
 
 impl<Q: StatementSource, M: Model> UpdateBuilder<Q, M> {
@@ -2106,6 +2254,42 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> JoinOnBuilder<Q, M, P> 
 }
 
 impl<Q: StatementSource, M: Model> FromBuilder<Q, M, ModelProjection> {
+    /// Inserts full-row query results into another model table.
+    ///
+    /// This is the query-builder form of `INSERT INTO ... SELECT ...` when the
+    /// source query already yields all destination columns in order.
+    ///
+    /// ```rust,ignore
+    /// database.from::<ArchivedUser>().insert::<User>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
+    pub fn insert<Target: Model>(self) -> Result<(), DatabaseError> {
+        let (source, query) = QueryOperand::into_query_parts(self);
+        execute_insert_query(
+            source,
+            orm_insert_query_statement(
+                Target::table_name(),
+                model_insert_columns::<Target>(),
+                query,
+                false,
+            ),
+        )
+    }
+
+    /// Inserts the current full-row query result with `INSERT OVERWRITE` semantics.
+    pub fn overwrite<Target: Model>(self) -> Result<(), DatabaseError> {
+        let (source, query) = QueryOperand::into_query_parts(self);
+        execute_insert_query(
+            source,
+            orm_insert_query_statement(
+                Target::table_name(),
+                model_insert_columns::<Target>(),
+                query,
+                true,
+            ),
+        )
+    }
+
     /// Starts a single-table `UPDATE` builder for the current model source.
     ///
     /// Chain one or more `.set(...)` or `.set_expr(...)` calls, then finish
@@ -2781,6 +2965,42 @@ impl<Q: StatementSource, M: Model, T: Projection> FromBuilder<Q, M, StructProjec
 }
 
 impl<Q: StatementSource, M: Model> SetQueryBuilder<Q, M, ModelProjection> {
+    /// Inserts full-row set-query results into another model table.
+    ///
+    /// ```rust,ignore
+    /// database
+    ///     .from::<ArchivedUser>()
+    ///     .union(database.from::<LegacyUser>())
+    ///     .insert::<User>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
+    pub fn insert<Target: Model>(self) -> Result<(), DatabaseError> {
+        let (source, query) = QueryOperand::into_query_parts(self);
+        execute_insert_query(
+            source,
+            orm_insert_query_statement(
+                Target::table_name(),
+                model_insert_columns::<Target>(),
+                query,
+                false,
+            ),
+        )
+    }
+
+    /// Inserts the current full-row set-query result with `INSERT OVERWRITE` semantics.
+    pub fn overwrite<Target: Model>(self) -> Result<(), DatabaseError> {
+        let (source, query) = QueryOperand::into_query_parts(self);
+        execute_insert_query(
+            source,
+            orm_insert_query_statement(
+                Target::table_name(),
+                model_insert_columns::<Target>(),
+                query,
+                true,
+            ),
+        )
+    }
+
     /// Executes the set query and decodes rows into the model type.
     ///
     /// ```rust,ignore
@@ -3532,6 +3752,13 @@ fn select_projection(fields: &[OrmField], relation: &str) -> Vec<SelectItem> {
         .collect()
 }
 
+fn model_insert_columns<M: Model>() -> Vec<Ident> {
+    M::fields()
+        .iter()
+        .map(|field| ident(field.column))
+        .collect()
+}
+
 fn select_query(
     source: &QuerySource,
     joins: Vec<JoinSpec>,
@@ -3706,6 +3933,13 @@ fn execute_query<Q: StatementSource>(source: Q, query: Query) -> Result<Q::Iter,
     source.execute_statement(&Statement::Query(Box::new(query)), &[])
 }
 
+fn execute_insert_query<Q: StatementSource>(
+    source: Q,
+    statement: Statement,
+) -> Result<(), DatabaseError> {
+    source.execute_statement(&statement, &[])?.done()
+}
+
 fn orm_update_builder_statement(
     source: &QuerySource,
     filter: Option<QueryExpr>,
@@ -3721,6 +3955,37 @@ fn orm_update_builder_statement(
         returning: None,
         or: None,
         limit: None,
+    })
+}
+
+fn orm_insert_query_statement(
+    table_name: &str,
+    columns: Vec<Ident>,
+    query: Query,
+    overwrite: bool,
+) -> Statement {
+    Statement::Insert(Insert {
+        insert_token: AttachedToken::empty(),
+        optimizer_hint: None,
+        or: None,
+        ignore: false,
+        into: true,
+        table: TableObject::TableName(object_name(table_name)),
+        table_alias: None,
+        columns,
+        overwrite,
+        source: Some(Box::new(query)),
+        assignments: vec![],
+        partitioned: None,
+        after_columns: vec![],
+        has_table_keyword: false,
+        on: None,
+        returning: None,
+        replace_into: false,
+        priority: None,
+        insert_alias: None,
+        settings: None,
+        format_clause: None,
     })
 }
 

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -1968,6 +1968,17 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
     }
 
     /// Applies `NULLS FIRST` to the most recently added sort key.
+    ///
+    /// ```rust,ignore
+    /// let ids = database
+    ///     .from::<User>()
+    ///     .project_value(User::age())
+    ///     .asc(User::age())
+    ///     .nulls_first()
+    ///     .fetch::<Option<i32>>()?;
+    /// # let _ = ids;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn nulls_first(mut self) -> Self {
         query_set_last_order_nulls(&mut self.query, true);
         self
@@ -1990,6 +2001,17 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
     }
 
     /// Applies `NULLS LAST` to the most recently added sort key.
+    ///
+    /// ```rust,ignore
+    /// let ids = database
+    ///     .from::<User>()
+    ///     .project_value(User::age())
+    ///     .desc(User::age())
+    ///     .nulls_last()
+    ///     .fetch::<Option<i32>>()?;
+    /// # let _ = ids;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn nulls_last(mut self) -> Self {
         query_set_last_order_nulls(&mut self.query, false);
         self
@@ -2045,6 +2067,16 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
     }
 
     /// Returns the logical plan text for the current set query.
+    ///
+    /// ```rust,ignore
+    /// let plan = database
+    ///     .from::<User>()
+    ///     .project_value(User::id())
+    ///     .union(database.from::<Order>().project_value(Order::user_id()))
+    ///     .explain()?;
+    /// # let _ = plan;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn explain(self) -> Result<String, DatabaseError> {
         query_explain(self.source, self.query)
     }
@@ -2657,11 +2689,31 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     }
 
     /// Applies `NULLS FIRST` to the most recently added sort key.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .asc(User::age())
+    ///     .nulls_first()
+    ///     .fetch()?;
+    /// # let _ = users;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn nulls_first(self) -> Self {
         Self::from_inner(self.inner.nulls_first())
     }
 
     /// Applies `NULLS LAST` to the most recently added sort key.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .desc(User::age())
+    ///     .nulls_last()
+    ///     .fetch()?;
+    /// # let _ = users;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn nulls_last(self) -> Self {
         Self::from_inner(self.inner.nulls_last())
     }
@@ -2928,6 +2980,16 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     }
 
     /// Returns the logical plan text for the current query.
+    ///
+    /// ```rust,ignore
+    /// let plan = database
+    ///     .from::<User>()
+    ///     .eq(User::id(), 1)
+    ///     .project_value(User::name())
+    ///     .explain()?;
+    /// # let _ = plan;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn explain(self) -> Result<String, DatabaseError> {
         self.inner.explain()
     }

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -11,7 +11,19 @@ use crate::types::value::DataValue;
 use crate::types::LogicalType;
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use rust_decimal::Decimal;
-use sqlparser::ast::CharLengthUnits;
+use sqlparser::ast::helpers::attached_token::AttachedToken;
+use sqlparser::ast::{
+    AlterColumnOperation, AlterTable, AlterTableOperation, Analyze, Assignment, AssignmentTarget,
+    BinaryOperator as SqlBinaryOperator, CharLengthUnits, ColumnDef, ColumnOption, ColumnOptionDef,
+    CreateIndex, CreateTable, DataType, Delete, Expr, FromTable, Function, FunctionArg,
+    FunctionArgExpr, FunctionArgumentList, FunctionArguments, GroupByExpr, HiveDistributionStyle,
+    Ident, IndexColumn, Insert, KeyOrIndexDisplay, LimitClause, NullsDistinctOption, ObjectName,
+    ObjectType, Offset, OffsetRows, OrderBy, OrderByExpr, OrderByKind, OrderByOptions,
+    PrimaryKeyConstraint, Query, Select, SelectFlavor, SelectItem, SetExpr, TableFactor,
+    TableObject, TableWithJoins, TimezoneInfo, UniqueConstraint, Update, Value, Values,
+};
+use sqlparser::dialect::PostgreSqlDialect;
+use sqlparser::parser::Parser;
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -65,6 +77,50 @@ impl OrmColumn {
         }
 
         column_def
+    }
+
+    fn column_def(&self) -> Result<ColumnDef, DatabaseError> {
+        let mut options = Vec::new();
+
+        if self.primary_key {
+            options.push(column_option(ColumnOption::PrimaryKey(
+                PrimaryKeyConstraint {
+                    name: None,
+                    index_name: None,
+                    index_type: None,
+                    columns: vec![],
+                    index_options: vec![],
+                    characteristics: None,
+                },
+            )));
+        } else {
+            if !self.nullable {
+                options.push(column_option(ColumnOption::NotNull));
+            }
+            if self.unique {
+                options.push(column_option(ColumnOption::Unique(UniqueConstraint {
+                    name: None,
+                    index_name: None,
+                    index_type_display: KeyOrIndexDisplay::None,
+                    index_type: None,
+                    columns: vec![],
+                    index_options: vec![],
+                    characteristics: None,
+                    nulls_distinct: NullsDistinctOption::None,
+                })));
+            }
+        }
+        if let Some(default_expr) = self.default_expr {
+            options.push(column_option(ColumnOption::Default(parse_expr_fragment(
+                default_expr,
+            )?)));
+        }
+
+        Ok(ColumnDef {
+            name: ident(self.name),
+            data_type: parse_data_type_fragment(&self.ddl_type)?,
+            options,
+        })
     }
 }
 
@@ -199,32 +255,45 @@ impl QueryExpr {
         QueryExpr::Not(Box::new(self))
     }
 
-    fn to_sql(&self) -> String {
+    fn to_ast(&self) -> Expr {
         match self {
-            QueryExpr::Compare { left, op, right } => {
-                format!("({} {} {})", left.to_sql(), op.as_sql(), right.to_sql())
-            }
+            QueryExpr::Compare { left, op, right } => Expr::BinaryOp {
+                left: Box::new(left.to_ast()),
+                op: op.as_ast(),
+                right: Box::new(right.to_ast()),
+            },
             QueryExpr::IsNull { value, negated } => {
                 if *negated {
-                    format!("({} is not null)", value.to_sql())
+                    Expr::IsNotNull(Box::new(value.to_ast()))
                 } else {
-                    format!("({} is null)", value.to_sql())
+                    Expr::IsNull(Box::new(value.to_ast()))
                 }
             }
             QueryExpr::Like {
                 value,
                 pattern,
                 negated,
-            } => {
-                if *negated {
-                    format!("({} not like {})", value.to_sql(), pattern.to_sql())
-                } else {
-                    format!("({} like {})", value.to_sql(), pattern.to_sql())
-                }
-            }
-            QueryExpr::And(left, right) => format!("({} and {})", left.to_sql(), right.to_sql()),
-            QueryExpr::Or(left, right) => format!("({} or {})", left.to_sql(), right.to_sql()),
-            QueryExpr::Not(inner) => format!("(not {})", inner.to_sql()),
+            } => Expr::Like {
+                negated: *negated,
+                expr: Box::new(value.to_ast()),
+                pattern: Box::new(pattern.to_ast()),
+                escape_char: None,
+                any: false,
+            },
+            QueryExpr::And(left, right) => Expr::BinaryOp {
+                left: Box::new(nested_expr(left.to_ast())),
+                op: SqlBinaryOperator::And,
+                right: Box::new(nested_expr(right.to_ast())),
+            },
+            QueryExpr::Or(left, right) => Expr::BinaryOp {
+                left: Box::new(nested_expr(left.to_ast())),
+                op: SqlBinaryOperator::Or,
+                right: Box::new(nested_expr(right.to_ast())),
+            },
+            QueryExpr::Not(inner) => Expr::UnaryOp {
+                op: sqlparser::ast::UnaryOperator::Not,
+                expr: Box::new(nested_expr(inner.to_ast())),
+            },
         }
     }
 }
@@ -240,9 +309,15 @@ impl SortExpr {
         Self { value, desc }
     }
 
-    fn to_sql(&self) -> String {
-        let direction = if self.desc { "desc" } else { "asc" };
-        format!("{} {}", self.value.to_sql(), direction)
+    fn to_ast(&self) -> OrderByExpr {
+        OrderByExpr {
+            expr: self.value.to_ast(),
+            options: OrderByOptions {
+                asc: Some(!self.desc),
+                nulls_first: None,
+            },
+            with_fill: None,
+        }
     }
 }
 
@@ -345,18 +420,31 @@ impl QueryValue {
         SortExpr::new(self, true)
     }
 
-    fn to_sql(&self) -> String {
+    fn to_ast(&self) -> Expr {
         match self {
-            QueryValue::Column { table, column } => format!("{}.{}", table, column),
-            QueryValue::Param(value) => data_value_to_sql(value),
-            QueryValue::Function { name, args } => format!(
-                "{}({})",
-                name,
-                args.iter()
-                    .map(QueryValue::to_sql)
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ),
+            QueryValue::Column { table, column } => {
+                Expr::CompoundIdentifier(vec![ident(*table), ident(*column)])
+            }
+            QueryValue::Param(value) => data_value_to_ast_expr(value),
+            QueryValue::Function { name, args } => Expr::Function(Function {
+                name: object_name(name),
+                uses_odbc_syntax: false,
+                parameters: FunctionArguments::None,
+                args: FunctionArguments::List(FunctionArgumentList {
+                    duplicate_treatment: None,
+                    args: args
+                        .iter()
+                        .map(QueryValue::to_ast)
+                        .map(FunctionArgExpr::Expr)
+                        .map(FunctionArg::Unnamed)
+                        .collect(),
+                    clauses: vec![],
+                }),
+                filter: None,
+                null_treatment: None,
+                over: None,
+                within_group: vec![],
+            }),
         }
     }
 }
@@ -374,52 +462,15 @@ impl<T: ToDataValue> From<T> for QueryValue {
 }
 
 impl CompareOp {
-    fn as_sql(&self) -> &'static str {
+    fn as_ast(&self) -> SqlBinaryOperator {
         match self {
-            CompareOp::Eq => "=",
-            CompareOp::Ne => "!=",
-            CompareOp::Gt => ">",
-            CompareOp::Gte => ">=",
-            CompareOp::Lt => "<",
-            CompareOp::Lte => "<=",
+            CompareOp::Eq => SqlBinaryOperator::Eq,
+            CompareOp::Ne => SqlBinaryOperator::NotEq,
+            CompareOp::Gt => SqlBinaryOperator::Gt,
+            CompareOp::Gte => SqlBinaryOperator::GtEq,
+            CompareOp::Lt => SqlBinaryOperator::Lt,
+            CompareOp::Lte => SqlBinaryOperator::LtEq,
         }
-    }
-}
-
-fn escape_sql_string(value: &str) -> String {
-    value.replace('\'', "''")
-}
-
-fn data_value_to_sql(value: &DataValue) -> String {
-    match value {
-        DataValue::Null => "null".to_string(),
-        DataValue::Boolean(value) => value.to_string(),
-        DataValue::Float32(value) => value.to_string(),
-        DataValue::Float64(value) => value.to_string(),
-        DataValue::Int8(value) => value.to_string(),
-        DataValue::Int16(value) => value.to_string(),
-        DataValue::Int32(value) => value.to_string(),
-        DataValue::Int64(value) => value.to_string(),
-        DataValue::UInt8(value) => value.to_string(),
-        DataValue::UInt16(value) => value.to_string(),
-        DataValue::UInt32(value) => value.to_string(),
-        DataValue::UInt64(value) => value.to_string(),
-        DataValue::Utf8 { value, .. } => format!("'{}'", escape_sql_string(value)),
-        DataValue::Date32(_)
-        | DataValue::Date64(_)
-        | DataValue::Time32(..)
-        | DataValue::Time64(..) => {
-            format!("'{}'", value)
-        }
-        DataValue::Decimal(value) => value.to_string(),
-        DataValue::Tuple(values, ..) => format!(
-            "({})",
-            values
-                .iter()
-                .map(data_value_to_sql)
-                .collect::<Vec<_>>()
-                .join(", ")
-        ),
     }
 }
 
@@ -457,36 +508,8 @@ impl<'a, 'tx, S: Storage> StatementSource for &'a mut DBTransaction<'tx, S> {
     }
 }
 
-pub trait SelectSource {
-    type Iter: ResultIter;
-
-    fn run_select(self, sql: String) -> Result<Self::Iter, DatabaseError>;
-}
-
-#[doc(hidden)]
-pub struct DatabaseSelectSource<'a, S: Storage>(pub &'a Database<S>);
-
-impl<'a, S: Storage> SelectSource for DatabaseSelectSource<'a, S> {
-    type Iter = DatabaseIter<'a, S>;
-
-    fn run_select(self, sql: String) -> Result<Self::Iter, DatabaseError> {
-        self.0.run(sql)
-    }
-}
-
-#[doc(hidden)]
-pub struct TransactionSelectSource<'a, 'tx, S: Storage>(pub &'a mut DBTransaction<'tx, S>);
-
-impl<'a, 'tx, S: Storage> SelectSource for TransactionSelectSource<'a, 'tx, S> {
-    type Iter = TransactionIter<'a>;
-
-    fn run_select(self, sql: String) -> Result<Self::Iter, DatabaseError> {
-        self.0.run(sql)
-    }
-}
-
 /// Lightweight single-table query builder for ORM models.
-pub struct SelectBuilder<Q: SelectSource, M: Model> {
+pub struct SelectBuilder<Q: StatementSource, M: Model> {
     source: Q,
     filter: Option<QueryExpr>,
     order_bys: Vec<SortExpr>,
@@ -532,7 +555,7 @@ macro_rules! impl_select_builder_like_methods {
     };
 }
 
-impl<Q: SelectSource, M: Model> SelectBuilder<Q, M> {
+impl<Q: StatementSource, M: Model> SelectBuilder<Q, M> {
     fn new(source: Q) -> Self {
         Self {
             source,
@@ -594,49 +617,15 @@ impl<Q: SelectSource, M: Model> SelectBuilder<Q, M> {
         self
     }
 
-    fn select_columns_sql() -> String {
-        M::fields()
-            .iter()
-            .map(|field| field.column)
-            .collect::<Vec<_>>()
-            .join(", ")
-    }
-
-    fn base_select_sql(&self) -> String {
-        format!(
-            "select {} from {}",
-            Self::select_columns_sql(),
-            M::table_name()
+    fn statement(&self) -> Statement {
+        orm_select_query_statement(
+            M::table_name(),
+            M::fields(),
+            self.filter.as_ref(),
+            &self.order_bys,
+            self.limit,
+            self.offset,
         )
-    }
-
-    fn append_filter_order_limit(&self, mut sql: String) -> String {
-        if let Some(filter) = &self.filter {
-            sql.push_str(" where ");
-            sql.push_str(&filter.to_sql());
-        }
-        if !self.order_bys.is_empty() {
-            sql.push_str(" order by ");
-            sql.push_str(
-                &self
-                    .order_bys
-                    .iter()
-                    .map(SortExpr::to_sql)
-                    .collect::<Vec<_>>()
-                    .join(", "),
-            );
-        }
-        if let Some(limit) = self.limit {
-            sql.push_str(&format!(" limit {}", limit));
-        }
-        if let Some(offset) = self.offset {
-            sql.push_str(&format!(" offset {}", offset));
-        }
-        sql
-    }
-
-    fn build_sql(&self) -> String {
-        self.append_filter_order_limit(self.base_select_sql())
     }
 
     impl_select_builder_compare_methods!(eq, ne, gt, gte, lt, lte);
@@ -646,8 +635,8 @@ impl<Q: SelectSource, M: Model> SelectBuilder<Q, M> {
     impl_select_builder_like_methods!(like, not_like);
 
     pub fn raw(self) -> Result<Q::Iter, DatabaseError> {
-        let sql = self.build_sql();
-        self.source.run_select(sql)
+        let statement = self.statement();
+        self.source.execute_statement(&statement, &[])
     }
 
     pub fn fetch(self) -> Result<OrmIter<Q::Iter, M>, DatabaseError> {
@@ -664,12 +653,8 @@ impl<Q: SelectSource, M: Model> SelectBuilder<Q, M> {
     }
 
     pub fn count(self) -> Result<usize, DatabaseError> {
-        let mut sql = format!("select count(*) from {}", M::table_name());
-        if let Some(filter) = &self.filter {
-            sql.push_str(" where ");
-            sql.push_str(&filter.to_sql());
-        }
-        let mut iter = self.source.run_select(sql)?;
+        let statement = orm_count_statement(M::table_name(), self.filter.as_ref());
+        let mut iter = self.source.execute_statement(&statement, &[])?;
         let count = match iter.next().transpose()? {
             Some(tuple) => match tuple.values.first() {
                 Some(DataValue::Int32(value)) => *value as usize,
@@ -688,6 +673,623 @@ impl<Q: SelectSource, M: Model> SelectBuilder<Q, M> {
         iter.done()?;
         Ok(count)
     }
+}
+
+fn ident(value: impl Into<String>) -> Ident {
+    Ident::new(value)
+}
+
+fn object_name(value: &str) -> ObjectName {
+    value.split('.').map(ident).collect::<Vec<_>>().into()
+}
+
+fn nested_expr(expr: Expr) -> Expr {
+    Expr::Nested(Box::new(expr))
+}
+
+fn number_expr(value: impl ToString) -> Expr {
+    Expr::Value(Value::Number(value.to_string(), false).with_empty_span())
+}
+
+fn string_expr(value: impl Into<String>) -> Expr {
+    Expr::Value(Value::SingleQuotedString(value.into()).with_empty_span())
+}
+
+fn placeholder_expr(value: &str) -> Expr {
+    Expr::Value(Value::Placeholder(value.to_string()).with_empty_span())
+}
+
+fn typed_string_expr(data_type: DataType, value: impl Into<String>) -> Expr {
+    Expr::TypedString(sqlparser::ast::TypedString {
+        data_type,
+        value: Value::SingleQuotedString(value.into()).with_empty_span(),
+        uses_odbc_syntax: false,
+    })
+}
+
+fn column_option(option: ColumnOption) -> ColumnOptionDef {
+    ColumnOptionDef { name: None, option }
+}
+
+fn table_factor(table_name: &str) -> TableFactor {
+    TableFactor::Table {
+        name: object_name(table_name),
+        alias: None,
+        args: None,
+        with_hints: vec![],
+        version: None,
+        with_ordinality: false,
+        partitions: vec![],
+        json_path: None,
+        sample: None,
+        index_hints: vec![],
+    }
+}
+
+fn table_with_joins(table_name: &str) -> TableWithJoins {
+    TableWithJoins {
+        relation: table_factor(table_name),
+        joins: vec![],
+    }
+}
+
+fn select_projection(fields: &[OrmField]) -> Vec<SelectItem> {
+    fields
+        .iter()
+        .map(|field| SelectItem::UnnamedExpr(Expr::Identifier(ident(field.column))))
+        .collect()
+}
+
+fn select_query(
+    table_name: &str,
+    projection: Vec<SelectItem>,
+    filter: Option<&QueryExpr>,
+    order_bys: &[SortExpr],
+    limit: Option<usize>,
+    offset: Option<usize>,
+) -> Query {
+    Query {
+        with: None,
+        body: Box::new(SetExpr::Select(Box::new(Select {
+            select_token: AttachedToken::empty(),
+            optimizer_hint: None,
+            distinct: None,
+            select_modifiers: None,
+            top: None,
+            top_before_distinct: false,
+            projection,
+            exclude: None,
+            into: None,
+            from: vec![table_with_joins(table_name)],
+            lateral_views: vec![],
+            prewhere: None,
+            selection: filter.map(QueryExpr::to_ast),
+            connect_by: vec![],
+            group_by: GroupByExpr::Expressions(vec![], vec![]),
+            cluster_by: vec![],
+            distribute_by: vec![],
+            sort_by: vec![],
+            having: None,
+            named_window: vec![],
+            qualify: None,
+            window_before_qualify: false,
+            value_table_mode: None,
+            flavor: SelectFlavor::Standard,
+        }))),
+        order_by: (!order_bys.is_empty()).then(|| OrderBy {
+            kind: OrderByKind::Expressions(order_bys.iter().map(SortExpr::to_ast).collect()),
+            interpolate: None,
+        }),
+        limit_clause: if limit.is_some() || offset.is_some() {
+            Some(LimitClause::LimitOffset {
+                limit: limit.map(number_expr),
+                offset: offset.map(|offset| Offset {
+                    value: number_expr(offset),
+                    rows: OffsetRows::None,
+                }),
+                limit_by: vec![],
+            })
+        } else {
+            None
+        },
+        fetch: None,
+        locks: vec![],
+        for_clause: None,
+        settings: None,
+        format_clause: None,
+        pipe_operators: vec![],
+    }
+}
+
+fn values_query(values: Vec<Expr>) -> Query {
+    Query {
+        with: None,
+        body: Box::new(SetExpr::Values(Values {
+            explicit_row: false,
+            value_keyword: false,
+            rows: vec![values],
+        })),
+        order_by: None,
+        limit_clause: None,
+        fetch: None,
+        locks: vec![],
+        for_clause: None,
+        settings: None,
+        format_clause: None,
+        pipe_operators: vec![],
+    }
+}
+
+fn parse_expr_fragment(value: &str) -> Result<Expr, DatabaseError> {
+    let dialect = PostgreSqlDialect {};
+    let mut parser = Parser::new(&dialect).try_with_sql(value)?;
+    parser.parse_expr().map_err(Into::into)
+}
+
+fn parse_data_type_fragment(value: &str) -> Result<DataType, DatabaseError> {
+    let dialect = PostgreSqlDialect {};
+    let mut parser = Parser::new(&dialect).try_with_sql(value)?;
+    parser.parse_data_type().map_err(Into::into)
+}
+
+fn data_value_to_ast_expr(value: &DataValue) -> Expr {
+    match value {
+        DataValue::Null => Expr::Value(Value::Null.with_empty_span()),
+        DataValue::Boolean(value) => Expr::Value(Value::Boolean(*value).with_empty_span()),
+        DataValue::Float32(value) => number_expr(value),
+        DataValue::Float64(value) => number_expr(value),
+        DataValue::Int8(value) => number_expr(value),
+        DataValue::Int16(value) => number_expr(value),
+        DataValue::Int32(value) => number_expr(value),
+        DataValue::Int64(value) => number_expr(value),
+        DataValue::UInt8(value) => number_expr(value),
+        DataValue::UInt16(value) => number_expr(value),
+        DataValue::UInt32(value) => number_expr(value),
+        DataValue::UInt64(value) => number_expr(value),
+        DataValue::Utf8 { value, .. } => string_expr(value),
+        DataValue::Date32(_) => typed_string_expr(DataType::Date, value.to_string()),
+        DataValue::Date64(_) => typed_string_expr(DataType::Datetime(None), value.to_string()),
+        DataValue::Time32(..) => {
+            typed_string_expr(DataType::Time(None, TimezoneInfo::None), value.to_string())
+        }
+        DataValue::Time64(_, _, zone) => typed_string_expr(
+            DataType::Timestamp(
+                None,
+                if *zone {
+                    TimezoneInfo::WithTimeZone
+                } else {
+                    TimezoneInfo::None
+                },
+            ),
+            value.to_string(),
+        ),
+        DataValue::Decimal(value) => number_expr(value),
+        DataValue::Tuple(values, ..) => {
+            Expr::Tuple(values.iter().map(data_value_to_ast_expr).collect())
+        }
+    }
+}
+
+#[doc(hidden)]
+pub fn orm_select_statement(table_name: &str, fields: &[OrmField]) -> Statement {
+    Statement::Query(Box::new(select_query(
+        table_name,
+        select_projection(fields),
+        None,
+        &[],
+        None,
+        None,
+    )))
+}
+
+#[doc(hidden)]
+pub fn orm_insert_statement(table_name: &str, fields: &[OrmField]) -> Statement {
+    Statement::Insert(Insert {
+        insert_token: AttachedToken::empty(),
+        optimizer_hint: None,
+        or: None,
+        ignore: false,
+        into: true,
+        table: TableObject::TableName(object_name(table_name)),
+        table_alias: None,
+        columns: fields.iter().map(|field| ident(field.column)).collect(),
+        overwrite: false,
+        source: Some(Box::new(values_query(
+            fields
+                .iter()
+                .map(|field| placeholder_expr(field.placeholder))
+                .collect(),
+        ))),
+        assignments: vec![],
+        partitioned: None,
+        after_columns: vec![],
+        has_table_keyword: false,
+        on: None,
+        returning: None,
+        replace_into: false,
+        priority: None,
+        insert_alias: None,
+        settings: None,
+        format_clause: None,
+    })
+}
+
+#[doc(hidden)]
+pub fn orm_update_statement(
+    table_name: &str,
+    fields: &[OrmField],
+    primary_key: &OrmField,
+) -> Statement {
+    Statement::Update(Update {
+        update_token: AttachedToken::empty(),
+        optimizer_hint: None,
+        table: table_with_joins(table_name),
+        assignments: fields
+            .iter()
+            .filter(|field| !field.primary_key)
+            .map(|field| Assignment {
+                target: AssignmentTarget::ColumnName(object_name(field.column)),
+                value: placeholder_expr(field.placeholder),
+            })
+            .collect(),
+        from: None,
+        selection: Some(Expr::BinaryOp {
+            left: Box::new(Expr::Identifier(ident(primary_key.column))),
+            op: SqlBinaryOperator::Eq,
+            right: Box::new(placeholder_expr(primary_key.placeholder)),
+        }),
+        returning: None,
+        or: None,
+        limit: None,
+    })
+}
+
+#[doc(hidden)]
+pub fn orm_delete_statement(table_name: &str, primary_key: &OrmField) -> Statement {
+    Statement::Delete(Delete {
+        delete_token: AttachedToken::empty(),
+        optimizer_hint: None,
+        tables: vec![],
+        from: FromTable::WithFromKeyword(vec![table_with_joins(table_name)]),
+        using: None,
+        selection: Some(Expr::BinaryOp {
+            left: Box::new(Expr::Identifier(ident(primary_key.column))),
+            op: SqlBinaryOperator::Eq,
+            right: Box::new(placeholder_expr(primary_key.placeholder)),
+        }),
+        returning: None,
+        order_by: vec![],
+        limit: None,
+    })
+}
+
+#[doc(hidden)]
+pub fn orm_find_statement(
+    table_name: &str,
+    fields: &[OrmField],
+    primary_key: &OrmField,
+) -> Statement {
+    Statement::Query(Box::new(Query {
+        with: None,
+        body: Box::new(SetExpr::Select(Box::new(Select {
+            select_token: AttachedToken::empty(),
+            optimizer_hint: None,
+            distinct: None,
+            select_modifiers: None,
+            top: None,
+            top_before_distinct: false,
+            projection: select_projection(fields),
+            exclude: None,
+            into: None,
+            from: vec![table_with_joins(table_name)],
+            lateral_views: vec![],
+            prewhere: None,
+            selection: Some(Expr::BinaryOp {
+                left: Box::new(Expr::Identifier(ident(primary_key.column))),
+                op: SqlBinaryOperator::Eq,
+                right: Box::new(placeholder_expr(primary_key.placeholder)),
+            }),
+            connect_by: vec![],
+            group_by: GroupByExpr::Expressions(vec![], vec![]),
+            cluster_by: vec![],
+            distribute_by: vec![],
+            sort_by: vec![],
+            having: None,
+            named_window: vec![],
+            qualify: None,
+            window_before_qualify: false,
+            value_table_mode: None,
+            flavor: SelectFlavor::Standard,
+        }))),
+        order_by: None,
+        limit_clause: None,
+        fetch: None,
+        locks: vec![],
+        for_clause: None,
+        settings: None,
+        format_clause: None,
+        pipe_operators: vec![],
+    }))
+}
+
+#[doc(hidden)]
+pub fn orm_create_table_statement(
+    table_name: &str,
+    columns: &[OrmColumn],
+    if_not_exists: bool,
+) -> Result<Statement, DatabaseError> {
+    Ok(Statement::CreateTable(CreateTable {
+        or_replace: false,
+        temporary: false,
+        external: false,
+        dynamic: false,
+        global: None,
+        if_not_exists,
+        transient: false,
+        volatile: false,
+        iceberg: false,
+        name: object_name(table_name),
+        columns: columns
+            .iter()
+            .map(OrmColumn::column_def)
+            .collect::<Result<Vec<_>, _>>()?,
+        constraints: vec![],
+        hive_distribution: HiveDistributionStyle::NONE,
+        hive_formats: None,
+        table_options: Default::default(),
+        file_format: None,
+        location: None,
+        query: None,
+        without_rowid: false,
+        like: None,
+        clone: None,
+        version: None,
+        comment: None,
+        on_commit: None,
+        on_cluster: None,
+        primary_key: None,
+        order_by: None,
+        partition_by: None,
+        cluster_by: None,
+        clustered_by: None,
+        inherits: None,
+        partition_of: None,
+        for_values: None,
+        strict: false,
+        copy_grants: false,
+        enable_schema_evolution: None,
+        change_tracking: None,
+        data_retention_time_in_days: None,
+        max_data_extension_time_in_days: None,
+        default_ddl_collation: None,
+        with_aggregation_policy: None,
+        with_row_access_policy: None,
+        with_tags: None,
+        external_volume: None,
+        base_location: None,
+        catalog: None,
+        catalog_sync: None,
+        storage_serialization_policy: None,
+        target_lag: None,
+        warehouse: None,
+        refresh_mode: None,
+        initialize: None,
+        require_user: false,
+    }))
+}
+
+#[doc(hidden)]
+pub fn orm_create_index_statement(
+    table_name: &str,
+    index_name: &str,
+    columns: &[&str],
+    unique: bool,
+    if_not_exists: bool,
+) -> Statement {
+    Statement::CreateIndex(CreateIndex {
+        name: Some(object_name(index_name)),
+        table_name: object_name(table_name),
+        using: None,
+        columns: columns.iter().copied().map(IndexColumn::from).collect(),
+        unique,
+        concurrently: false,
+        if_not_exists,
+        include: vec![],
+        nulls_distinct: None,
+        with: vec![],
+        predicate: None,
+        index_options: vec![],
+        alter_options: vec![],
+    })
+}
+
+#[doc(hidden)]
+pub fn orm_drop_table_statement(table_name: &str, if_exists: bool) -> Statement {
+    Statement::Drop {
+        object_type: ObjectType::Table,
+        if_exists,
+        names: vec![object_name(table_name)],
+        cascade: false,
+        restrict: false,
+        purge: false,
+        temporary: false,
+        table: None,
+    }
+}
+
+#[doc(hidden)]
+pub fn orm_drop_index_statement(table_name: &str, index_name: &str, if_exists: bool) -> Statement {
+    Statement::Drop {
+        object_type: ObjectType::Index,
+        if_exists,
+        names: vec![object_name(&format!("{table_name}.{index_name}"))],
+        cascade: false,
+        restrict: false,
+        purge: false,
+        temporary: false,
+        table: None,
+    }
+}
+
+#[doc(hidden)]
+pub fn orm_analyze_statement(table_name: &str) -> Statement {
+    Statement::Analyze(Analyze {
+        table_name: Some(object_name(table_name)),
+        partitions: None,
+        for_columns: false,
+        columns: vec![],
+        cache_metadata: false,
+        noscan: false,
+        compute_statistics: false,
+        has_table_keyword: true,
+    })
+}
+
+fn orm_select_query_statement(
+    table_name: &str,
+    fields: &[OrmField],
+    filter: Option<&QueryExpr>,
+    order_bys: &[SortExpr],
+    limit: Option<usize>,
+    offset: Option<usize>,
+) -> Statement {
+    Statement::Query(Box::new(select_query(
+        table_name,
+        select_projection(fields),
+        filter,
+        order_bys,
+        limit,
+        offset,
+    )))
+}
+
+fn orm_count_statement(table_name: &str, filter: Option<&QueryExpr>) -> Statement {
+    Statement::Query(Box::new(select_query(
+        table_name,
+        vec![SelectItem::UnnamedExpr(Expr::Function(Function {
+            name: object_name("count"),
+            uses_odbc_syntax: false,
+            parameters: FunctionArguments::None,
+            args: FunctionArguments::List(FunctionArgumentList {
+                duplicate_treatment: None,
+                args: vec![FunctionArg::Unnamed(FunctionArgExpr::Wildcard)],
+                clauses: vec![],
+            }),
+            filter: None,
+            null_treatment: None,
+            over: None,
+            within_group: vec![],
+        }))],
+        filter,
+        &[],
+        None,
+        None,
+    )))
+}
+
+fn orm_alter_table_statement(table_name: &str, operation: AlterTableOperation) -> Statement {
+    Statement::AlterTable(AlterTable {
+        name: object_name(table_name),
+        if_exists: false,
+        only: false,
+        operations: vec![operation],
+        location: None,
+        on_cluster: None,
+        table_type: None,
+        end_token: AttachedToken::empty(),
+    })
+}
+
+fn orm_alter_column_type_statement(
+    table_name: &str,
+    column_name: &str,
+    ddl_type: &str,
+) -> Result<Statement, DatabaseError> {
+    Ok(orm_alter_table_statement(
+        table_name,
+        AlterTableOperation::AlterColumn {
+            column_name: ident(column_name),
+            op: AlterColumnOperation::SetDataType {
+                data_type: parse_data_type_fragment(ddl_type)?,
+                using: None,
+                had_set: false,
+            },
+        },
+    ))
+}
+
+fn orm_alter_column_default_statement(
+    table_name: &str,
+    column_name: &str,
+    default_expr: Option<&str>,
+) -> Result<Statement, DatabaseError> {
+    Ok(orm_alter_table_statement(
+        table_name,
+        AlterTableOperation::AlterColumn {
+            column_name: ident(column_name),
+            op: match default_expr {
+                Some(default_expr) => AlterColumnOperation::SetDefault {
+                    value: parse_expr_fragment(default_expr)?,
+                },
+                None => AlterColumnOperation::DropDefault,
+            },
+        },
+    ))
+}
+
+fn orm_alter_column_nullability_statement(
+    table_name: &str,
+    column_name: &str,
+    nullable: bool,
+) -> Statement {
+    orm_alter_table_statement(
+        table_name,
+        AlterTableOperation::AlterColumn {
+            column_name: ident(column_name),
+            op: if nullable {
+                AlterColumnOperation::DropNotNull
+            } else {
+                AlterColumnOperation::SetNotNull
+            },
+        },
+    )
+}
+
+fn orm_rename_column_statement(table_name: &str, old_name: &str, new_name: &str) -> Statement {
+    orm_alter_table_statement(
+        table_name,
+        AlterTableOperation::RenameColumn {
+            old_column_name: ident(old_name),
+            new_column_name: ident(new_name),
+        },
+    )
+}
+
+fn orm_drop_column_statement(table_name: &str, column_name: &str) -> Statement {
+    orm_alter_table_statement(
+        table_name,
+        AlterTableOperation::DropColumn {
+            has_column_keyword: true,
+            column_names: vec![ident(column_name)],
+            if_exists: false,
+            drop_behavior: None,
+        },
+    )
+}
+
+fn orm_add_column_statement(
+    table_name: &str,
+    column: &OrmColumn,
+) -> Result<Statement, DatabaseError> {
+    Ok(orm_alter_table_statement(
+        table_name,
+        AlterTableOperation::AddColumn {
+            column_keyword: true,
+            if_not_exists: false,
+            column_def: column.column_def()?,
+            column_position: None,
+        },
+    ))
 }
 
 /// Trait implemented by ORM models.

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -807,6 +807,16 @@ impl ProjectedValue {
     }
 }
 
+#[doc(hidden)]
+pub fn projection_value<M: Model>(column: &'static str, alias: &'static str) -> ProjectedValue {
+    Field::<M, ()>::new(M::table_name(), column).alias(alias)
+}
+
+#[doc(hidden)]
+pub fn projection_column<M: Model>(column: &'static str) -> ProjectedValue {
+    ProjectedValue::from(Field::<M, ()>::new(M::table_name(), column))
+}
+
 impl<V: Into<QueryValue>> From<V> for ProjectedValue {
     fn from(value: V) -> Self {
         Self {
@@ -942,6 +952,11 @@ pub struct TupleProjection {
     values: Vec<ProjectedValue>,
 }
 
+#[doc(hidden)]
+pub struct StructProjection<T> {
+    _marker: PhantomData<T>,
+}
+
 struct BuilderState<Q: StatementSource, M: Model> {
     source: Q,
     filter: Option<QueryExpr>,
@@ -993,6 +1008,13 @@ pub trait ProjectionSpec<M: Model> {
     fn into_select_items(self) -> Vec<SelectItem>;
 }
 
+/// Declares a struct-backed ORM projection used by [`FromBuilder::project`].
+///
+/// This trait is typically derived with `#[derive(Projection)]`.
+pub trait Projection: for<'a> From<(&'a SchemaRef, Tuple)> {
+    fn projected_values<M: Model>() -> Vec<ProjectedValue>;
+}
+
 #[doc(hidden)]
 pub trait IntoProjectedTuple {
     fn into_projected_values(self) -> Vec<ProjectedValue>;
@@ -1013,6 +1035,15 @@ impl<M: Model> ProjectionSpec<M> for ValueProjection {
 impl<M: Model> ProjectionSpec<M> for TupleProjection {
     fn into_select_items(self) -> Vec<SelectItem> {
         self.values
+            .into_iter()
+            .map(ProjectedValue::into_select_item)
+            .collect()
+    }
+}
+
+impl<M: Model, T: Projection> ProjectionSpec<M> for StructProjection<T> {
+    fn into_select_items(self) -> Vec<SelectItem> {
+        T::projected_values::<M>()
             .into_iter()
             .map(ProjectedValue::into_select_item)
             .collect()
@@ -1055,6 +1086,12 @@ impl<Q: StatementSource, M: Model, P> FromBuilder<Q, M, P> {
 }
 
 impl<Q: StatementSource, M: Model> FromBuilder<Q, M, ModelProjection> {
+    pub fn project<T: Projection>(self) -> ProjectionBuilder<Q, M, StructProjection<T>> {
+        self.with_projection(StructProjection {
+            _marker: PhantomData,
+        })
+    }
+
     pub fn project_value<V: Into<ProjectedValue>>(
         self,
         value: V,
@@ -1248,6 +1285,16 @@ impl<Q: StatementSource, M: Model> FromBuilder<Q, M, TupleProjection> {
 
     pub fn get<T: FromQueryTuple>(self) -> Result<Option<T>, DatabaseError> {
         extract_optional_tuple(self.limit(1).raw()?)
+    }
+}
+
+impl<Q: StatementSource, M: Model, T: Projection> FromBuilder<Q, M, StructProjection<T>> {
+    pub fn fetch(self) -> Result<OrmIter<Q::Iter, T>, DatabaseError> {
+        Ok(self.raw()?.orm::<T>())
+    }
+
+    pub fn get(self) -> Result<Option<T>, DatabaseError> {
+        extract_optional_row(self.limit(1).raw()?)
     }
 }
 
@@ -2716,15 +2763,23 @@ fn model_column_rename_compatible(model: &OrmColumn, column: &ColumnRef) -> bool
         && model_column_default(model) == catalog_column_default(column)
 }
 
-fn extract_optional_model<I, M>(mut iter: I) -> Result<Option<M>, DatabaseError>
+fn extract_optional_model<I, M>(iter: I) -> Result<Option<M>, DatabaseError>
 where
     I: ResultIter,
     M: Model,
 {
+    extract_optional_row(iter)
+}
+
+fn extract_optional_row<I, T>(mut iter: I) -> Result<Option<T>, DatabaseError>
+where
+    I: ResultIter,
+    T: for<'a> From<(&'a SchemaRef, Tuple)>,
+{
     let schema = iter.schema().clone();
 
     Ok(match iter.next() {
-        Some(tuple) => Some(M::from((&schema, tuple?))),
+        Some(tuple) => Some(T::from((&schema, tuple?))),
         None => None,
     })
 }

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -14,9 +14,9 @@ use rust_decimal::Decimal;
 use sqlparser::ast::helpers::attached_token::AttachedToken;
 use sqlparser::ast::{
     AlterColumnOperation, AlterTable, AlterTableOperation, Analyze, Assignment, AssignmentTarget,
-    BinaryOperator as SqlBinaryOperator, CastKind, CharLengthUnits, ColumnDef, ColumnOption,
-    ColumnOptionDef, CreateIndex, CreateTable, DataType, Delete, Expr, FromTable, Function,
-    FunctionArg, FunctionArgExpr, FunctionArgumentList, FunctionArguments, GroupByExpr,
+    BinaryOperator as SqlBinaryOperator, CaseWhen, CastKind, CharLengthUnits, ColumnDef,
+    ColumnOption, ColumnOptionDef, CreateIndex, CreateTable, DataType, Delete, Expr, FromTable,
+    Function, FunctionArg, FunctionArgExpr, FunctionArgumentList, FunctionArguments, GroupByExpr,
     HiveDistributionStyle, Ident, IndexColumn, Insert, KeyOrIndexDisplay, LimitClause,
     NullsDistinctOption, ObjectName, ObjectType, Offset, OffsetRows, OrderBy, OrderByExpr,
     OrderByKind, OrderByOptions, PrimaryKeyConstraint, Query, Select, SelectFlavor, SelectItem,
@@ -225,6 +225,10 @@ impl<M, T> Field<M, T> {
         self.value().cast_to(data_type)
     }
 
+    pub fn alias(self, alias: &str) -> ProjectedValue {
+        self.value().alias(alias)
+    }
+
     pub fn in_subquery<S: SubquerySource>(self, subquery: S) -> QueryExpr {
         self.value().in_subquery(subquery)
     }
@@ -238,6 +242,12 @@ impl<M, T> Field<M, T> {
 /// A lightweight ORM expression wrapper for value-producing SQL AST nodes.
 pub struct QueryValue {
     expr: Expr,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// A projected ORM expression, optionally carrying a select-list alias.
+pub struct ProjectedValue {
+    item: SelectItem,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -263,6 +273,51 @@ where
     V: Into<QueryValue>,
 {
     QueryValue::function(name, args)
+}
+
+pub fn count<V: Into<QueryValue>>(value: V) -> QueryValue {
+    QueryValue::aggregate("count", [value.into()])
+}
+
+pub fn count_all() -> QueryValue {
+    QueryValue::aggregate_all("count")
+}
+
+pub fn sum<V: Into<QueryValue>>(value: V) -> QueryValue {
+    QueryValue::aggregate("sum", [value.into()])
+}
+
+pub fn avg<V: Into<QueryValue>>(value: V) -> QueryValue {
+    QueryValue::aggregate("avg", [value.into()])
+}
+
+pub fn min<V: Into<QueryValue>>(value: V) -> QueryValue {
+    QueryValue::aggregate("min", [value.into()])
+}
+
+pub fn max<V: Into<QueryValue>>(value: V) -> QueryValue {
+    QueryValue::aggregate("max", [value.into()])
+}
+
+pub fn case_when<I, C, R, E>(conditions: I, else_result: E) -> QueryValue
+where
+    I: IntoIterator<Item = (C, R)>,
+    C: Into<QueryExpr>,
+    R: Into<QueryValue>,
+    E: Into<QueryValue>,
+{
+    QueryValue::searched_case(conditions, else_result)
+}
+
+pub fn case_value<O, I, W, R, E>(operand: O, conditions: I, else_result: E) -> QueryValue
+where
+    O: Into<QueryValue>,
+    I: IntoIterator<Item = (W, R)>,
+    W: Into<QueryValue>,
+    R: Into<QueryValue>,
+    E: Into<QueryValue>,
+{
+    QueryValue::simple_case(operand, conditions, else_result)
 }
 
 impl QueryExpr {
@@ -358,27 +413,80 @@ impl QueryValue {
         I: IntoIterator<Item = V>,
         V: Into<QueryValue>,
     {
-        let name = name.into();
-        Self::from_ast(Expr::Function(Function {
-            name: object_name(&name),
-            uses_odbc_syntax: false,
-            parameters: FunctionArguments::None,
-            args: FunctionArguments::List(FunctionArgumentList {
-                duplicate_treatment: None,
-                args: args
-                    .into_iter()
-                    .map(Into::into)
-                    .map(QueryValue::into_ast)
-                    .map(FunctionArgExpr::Expr)
-                    .map(FunctionArg::Unnamed)
-                    .collect(),
-                clauses: vec![],
-            }),
-            filter: None,
-            null_treatment: None,
-            over: None,
-            within_group: vec![],
-        }))
+        Self::function_with_args(
+            name,
+            args.into_iter()
+                .map(Into::into)
+                .map(QueryValue::into_ast)
+                .map(FunctionArgExpr::Expr),
+        )
+    }
+
+    pub fn aggregate<N, I, V>(name: N, args: I) -> Self
+    where
+        N: Into<String>,
+        I: IntoIterator<Item = V>,
+        V: Into<QueryValue>,
+    {
+        Self::function(name, args)
+    }
+
+    pub fn aggregate_all(name: impl Into<String>) -> Self {
+        Self::function_with_args(name, [FunctionArgExpr::Wildcard])
+    }
+
+    pub fn alias(self, alias: &str) -> ProjectedValue {
+        ProjectedValue {
+            item: SelectItem::ExprWithAlias {
+                expr: self.into_ast(),
+                alias: ident(alias),
+            },
+        }
+    }
+
+    pub fn searched_case<I, C, R, E>(conditions: I, else_result: E) -> Self
+    where
+        I: IntoIterator<Item = (C, R)>,
+        C: Into<QueryExpr>,
+        R: Into<QueryValue>,
+        E: Into<QueryValue>,
+    {
+        Self::from_ast(Expr::Case {
+            case_token: AttachedToken::empty(),
+            end_token: AttachedToken::empty(),
+            operand: None,
+            conditions: conditions
+                .into_iter()
+                .map(|(condition, result)| CaseWhen {
+                    condition: condition.into().into_ast(),
+                    result: result.into().into_ast(),
+                })
+                .collect(),
+            else_result: Some(Box::new(else_result.into().into_ast())),
+        })
+    }
+
+    pub fn simple_case<O, I, W, R, E>(operand: O, conditions: I, else_result: E) -> Self
+    where
+        O: Into<QueryValue>,
+        I: IntoIterator<Item = (W, R)>,
+        W: Into<QueryValue>,
+        R: Into<QueryValue>,
+        E: Into<QueryValue>,
+    {
+        Self::from_ast(Expr::Case {
+            case_token: AttachedToken::empty(),
+            end_token: AttachedToken::empty(),
+            operand: Some(Box::new(operand.into().into_ast())),
+            conditions: conditions
+                .into_iter()
+                .map(|(condition, result)| CaseWhen {
+                    condition: condition.into().into_ast(),
+                    result: result.into().into_ast(),
+                })
+                .collect(),
+            else_result: Some(Box::new(else_result.into().into_ast())),
+        })
     }
 
     pub fn eq<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
@@ -552,11 +660,47 @@ impl QueryValue {
     fn desc(self) -> SortExpr {
         SortExpr::new(self, true)
     }
+
+    fn function_with_args<N, I>(name: N, args: I) -> Self
+    where
+        N: Into<String>,
+        I: IntoIterator<Item = FunctionArgExpr>,
+    {
+        let name = name.into();
+        Self::from_ast(Expr::Function(Function {
+            name: object_name(&name),
+            uses_odbc_syntax: false,
+            parameters: FunctionArguments::None,
+            args: FunctionArguments::List(FunctionArgumentList {
+                duplicate_treatment: None,
+                args: args.into_iter().map(FunctionArg::Unnamed).collect(),
+                clauses: vec![],
+            }),
+            filter: None,
+            null_treatment: None,
+            over: None,
+            within_group: vec![],
+        }))
+    }
 }
 
 impl<M, T> From<Field<M, T>> for QueryValue {
     fn from(value: Field<M, T>) -> Self {
         value.value()
+    }
+}
+
+impl ProjectedValue {
+    fn into_select_item(self) -> SelectItem {
+        self.item
+    }
+}
+
+impl<V: Into<QueryValue>> From<V> for ProjectedValue {
+    fn from(value: V) -> Self {
+        Self {
+            item: SelectItem::UnnamedExpr(value.into().into_ast()),
+        }
     }
 }
 
@@ -646,7 +790,7 @@ pub type ProjectValueBuilder<Q, M> = SelectBuilder<Q, M, ValueProjection>;
 pub struct ModelProjection;
 
 pub struct ValueProjection {
-    value: QueryValue,
+    value: ProjectedValue,
 }
 
 struct BuilderState<Q: StatementSource, M: Model> {
@@ -699,7 +843,7 @@ impl<M: Model> ProjectionSpec<M> for ModelProjection {
 
 impl<M: Model> ProjectionSpec<M> for ValueProjection {
     fn into_select_items(self) -> Vec<SelectItem> {
-        vec![SelectItem::UnnamedExpr(self.value.into_ast())]
+        vec![self.value.into_select_item()]
     }
 }
 
@@ -758,7 +902,7 @@ impl<Q: StatementSource, M: Model> SelectBuilder<Q, M, ModelProjection> {
 }
 
 impl<Q: StatementSource, M: Model> SelectBuilder<Q, M, ValueProjection> {
-    fn new_value<V: Into<QueryValue>>(source: Q, value: V) -> Self {
+    fn new_value<V: Into<ProjectedValue>>(source: Q, value: V) -> Self {
         Self {
             state: BuilderState::new(source),
             projection: ValueProjection {

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -1594,6 +1594,15 @@ impl<Q: StatementSource, M: Model, P> FromBuilder<Q, M, P> {
     }
 
     /// Builds a `UNION` set query with another query of the same shape.
+    ///
+    /// ```rust,ignore
+    /// let ids = database
+    ///     .from::<User>()
+    ///     .project_value(User::id())
+    ///     .union(database.from::<Order>().project_value(Order::user_id()))
+    ///     .fetch::<i32>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn union<R>(self, rhs: R) -> SetQueryBuilder<Q, M, P>
     where
         Self: QueryOperand<Source = Q, Model = M, Projection = P>,
@@ -1603,6 +1612,15 @@ impl<Q: StatementSource, M: Model, P> FromBuilder<Q, M, P> {
     }
 
     /// Builds an `EXCEPT` set query with another query of the same shape.
+    ///
+    /// ```rust,ignore
+    /// let users_without_orders = database
+    ///     .from::<User>()
+    ///     .project_value(User::id())
+    ///     .except(database.from::<Order>().project_value(Order::user_id()))
+    ///     .fetch::<i32>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn except<R>(self, rhs: R) -> SetQueryBuilder<Q, M, P>
     where
         Self: QueryOperand<Source = Q, Model = M, Projection = P>,
@@ -1622,6 +1640,16 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
     }
 
     /// Marks the preceding set operation as `ALL`.
+    ///
+    /// ```rust,ignore
+    /// let total = database
+    ///     .from::<User>()
+    ///     .project_value(User::id())
+    ///     .union(database.from::<Order>().project_value(Order::user_id()))
+    ///     .all()
+    ///     .count()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn all(mut self) -> Self {
         set_query_quantifier(&mut self.query, SetQuantifier::All);
         self
@@ -1634,12 +1662,30 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
     }
 
     /// Returns whether the set query produces at least one row.
+    ///
+    /// ```rust,ignore
+    /// let has_ids = database
+    ///     .from::<User>()
+    ///     .project_value(User::id())
+    ///     .union(database.from::<Order>().project_value(Order::user_id()))
+    ///     .exists()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn exists(self) -> Result<bool, DatabaseError> {
         let mut iter = self.raw()?;
         Ok(iter.next().transpose()?.is_some())
     }
 
     /// Returns the row count of the set query result.
+    ///
+    /// ```rust,ignore
+    /// let total = database
+    ///     .from::<User>()
+    ///     .project_value(User::id())
+    ///     .union(database.from::<Order>().project_value(Order::user_id()))
+    ///     .count()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn count(self) -> Result<usize, DatabaseError> {
         let mut iter = self.raw()?;
         let mut count = 0usize;

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -1655,10 +1655,33 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
         self
     }
 
+    /// Appends an ascending sort key to the set query result.
+    pub fn asc<V: Into<QueryValue>>(mut self, value: V) -> Self {
+        query_push_order(&mut self.query, set_query_order_value(value.into()).asc());
+        self
+    }
+
+    /// Appends a descending sort key to the set query result.
+    pub fn desc<V: Into<QueryValue>>(mut self, value: V) -> Self {
+        query_push_order(&mut self.query, set_query_order_value(value.into()).desc());
+        self
+    }
+
+    /// Sets the set query `LIMIT`.
+    pub fn limit(mut self, limit: usize) -> Self {
+        query_set_limit(&mut self.query, limit);
+        self
+    }
+
+    /// Sets the set query `OFFSET`.
+    pub fn offset(mut self, offset: usize) -> Self {
+        query_set_offset(&mut self.query, offset);
+        self
+    }
+
     /// Executes the set query and returns the raw result iterator.
     pub fn raw(self) -> Result<Q::Iter, DatabaseError> {
-        self.source
-            .execute_statement(&Statement::Query(Box::new(self.query)), &[])
+        execute_query(self.source, self.query)
     }
 
     /// Returns whether the set query produces at least one row.
@@ -1672,8 +1695,7 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
     /// # Ok::<(), kite_sql::errors::DatabaseError>(())
     /// ```
     pub fn exists(self) -> Result<bool, DatabaseError> {
-        let mut iter = self.raw()?;
-        Ok(iter.next().transpose()?.is_some())
+        query_exists(self.source, self.query)
     }
 
     /// Returns the row count of the set query result.
@@ -1687,13 +1709,7 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
     /// # Ok::<(), kite_sql::errors::DatabaseError>(())
     /// ```
     pub fn count(self) -> Result<usize, DatabaseError> {
-        let mut iter = self.raw()?;
-        let mut count = 0usize;
-        while iter.next().transpose()?.is_some() {
-            count += 1;
-        }
-        iter.done()?;
-        Ok(count)
+        query_count(self.source, self.query)
     }
 
     /// Appends `UNION` to the current set query.
@@ -2515,7 +2531,10 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
 
     fn raw(self) -> Result<Q::Iter, DatabaseError> {
         let (source, statement) = self.into_statement();
-        source.execute_statement(&statement, &[])
+        match statement {
+            Statement::Query(query) => execute_query(source, *query),
+            _ => source.execute_statement(&statement, &[]),
+        }
     }
 
     fn exists(self) -> Result<bool, DatabaseError> {
@@ -2877,6 +2896,93 @@ fn set_query_quantifier(query: &mut Query, set_quantifier: SetQuantifier) {
     {
         *current = set_quantifier;
     }
+}
+
+fn set_query_order_value(value: QueryValue) -> QueryValue {
+    match value.into_expr() {
+        Expr::CompoundIdentifier(mut parts) => QueryValue::from_expr(Expr::Identifier(
+            parts.pop().expect("compound identifier must not be empty"),
+        )),
+        expr => QueryValue::from_expr(expr),
+    }
+}
+
+fn query_push_order(query: &mut Query, order: SortExpr) {
+    let order_expr = order.into_ast();
+    match query.order_by.as_mut() {
+        Some(order_by) => match &mut order_by.kind {
+            OrderByKind::Expressions(exprs) => exprs.push(order_expr),
+            OrderByKind::All(_) => {
+                order_by.kind = OrderByKind::Expressions(vec![order_expr]);
+            }
+        },
+        None => {
+            query.order_by = Some(OrderBy {
+                kind: OrderByKind::Expressions(vec![order_expr]),
+                interpolate: None,
+            });
+        }
+    }
+}
+
+fn query_set_limit(query: &mut Query, limit: usize) {
+    let offset = query_current_offset(query);
+    query.limit_clause = Some(LimitClause::LimitOffset {
+        limit: Some(number_expr(limit)),
+        offset,
+        limit_by: vec![],
+    });
+}
+
+fn query_set_offset(query: &mut Query, offset: usize) {
+    let limit = query_current_limit(query);
+    query.limit_clause = Some(LimitClause::LimitOffset {
+        limit,
+        offset: Some(Offset {
+            value: number_expr(offset),
+            rows: OffsetRows::None,
+        }),
+        limit_by: vec![],
+    });
+}
+
+fn query_current_limit(query: &Query) -> Option<Expr> {
+    match &query.limit_clause {
+        Some(LimitClause::LimitOffset { limit, .. }) => limit.clone(),
+        Some(LimitClause::OffsetCommaLimit { limit, .. }) => Some(limit.clone()),
+        None => None,
+    }
+}
+
+fn query_current_offset(query: &Query) -> Option<Offset> {
+    match &query.limit_clause {
+        Some(LimitClause::LimitOffset { offset, .. }) => offset.clone(),
+        Some(LimitClause::OffsetCommaLimit { offset, .. }) => Some(Offset {
+            value: offset.clone(),
+            rows: OffsetRows::None,
+        }),
+        None => None,
+    }
+}
+
+fn execute_query<Q: StatementSource>(source: Q, query: Query) -> Result<Q::Iter, DatabaseError> {
+    source.execute_statement(&Statement::Query(Box::new(query)), &[])
+}
+
+fn query_exists<Q: StatementSource>(source: Q, mut query: Query) -> Result<bool, DatabaseError> {
+    query_set_limit(&mut query, 1);
+    let mut iter = execute_query(source, query)?;
+    Ok(iter.next().transpose()?.is_some())
+}
+
+fn query_count<Q: StatementSource>(source: Q, query: Query) -> Result<usize, DatabaseError> {
+    let mut iter = execute_query(source, query)?;
+    let mut count = 0usize;
+    while iter.next().transpose()?.is_some() {
+        count += 1;
+    }
+    iter.done()?;
+    Ok(count)
 }
 
 fn values_query(values: Vec<Expr>) -> Query {

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -1656,30 +1656,82 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
     }
 
     /// Appends an ascending sort key to the set query result.
+    ///
+    /// ```rust,ignore
+    /// let ids = database
+    ///     .from::<User>()
+    ///     .project_value(User::id())
+    ///     .union(database.from::<Order>().project_value(Order::user_id()))
+    ///     .asc(User::id())
+    ///     .fetch::<i32>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn asc<V: Into<QueryValue>>(mut self, value: V) -> Self {
         query_push_order(&mut self.query, set_query_order_value(value.into()).asc());
         self
     }
 
     /// Appends a descending sort key to the set query result.
+    ///
+    /// ```rust,ignore
+    /// let ids = database
+    ///     .from::<User>()
+    ///     .project_value(User::id())
+    ///     .union(database.from::<Order>().project_value(Order::user_id()))
+    ///     .desc(User::id())
+    ///     .fetch::<i32>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn desc<V: Into<QueryValue>>(mut self, value: V) -> Self {
         query_push_order(&mut self.query, set_query_order_value(value.into()).desc());
         self
     }
 
     /// Sets the set query `LIMIT`.
+    ///
+    /// ```rust,ignore
+    /// let top_two = database
+    ///     .from::<User>()
+    ///     .project_value(User::id())
+    ///     .union(database.from::<Order>().project_value(Order::user_id()))
+    ///     .asc(User::id())
+    ///     .limit(2)
+    ///     .fetch::<i32>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn limit(mut self, limit: usize) -> Self {
         query_set_limit(&mut self.query, limit);
         self
     }
 
     /// Sets the set query `OFFSET`.
+    ///
+    /// ```rust,ignore
+    /// let skipped = database
+    ///     .from::<User>()
+    ///     .project_value(User::id())
+    ///     .union(database.from::<Order>().project_value(Order::user_id()))
+    ///     .asc(User::id())
+    ///     .offset(1)
+    ///     .fetch::<i32>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn offset(mut self, offset: usize) -> Self {
         query_set_offset(&mut self.query, offset);
         self
     }
 
     /// Executes the set query and returns the raw result iterator.
+    ///
+    /// ```rust,ignore
+    /// let rows = database
+    ///     .from::<User>()
+    ///     .project_value(User::id())
+    ///     .union(database.from::<Order>().project_value(Order::user_id()))
+    ///     .raw()?;
+    /// # rows.done()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn raw(self) -> Result<Q::Iter, DatabaseError> {
         execute_query(self.source, self.query)
     }
@@ -1713,6 +1765,16 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
     }
 
     /// Appends `UNION` to the current set query.
+    ///
+    /// ```rust,ignore
+    /// let ids = database
+    ///     .from::<User>()
+    ///     .project_value(User::id())
+    ///     .union(database.from::<Order>().project_value(Order::user_id()))
+    ///     .union(database.from::<Wallet>().project_value(Wallet::id()))
+    ///     .fetch::<i32>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn union<R>(self, rhs: R) -> Self
     where
         Self: QueryOperand<Source = Q, Model = M, Projection = P>,
@@ -1722,6 +1784,16 @@ impl<Q: StatementSource, M: Model, P> SetQueryBuilder<Q, M, P> {
     }
 
     /// Appends `EXCEPT` to the current set query.
+    ///
+    /// ```rust,ignore
+    /// let ids = database
+    ///     .from::<User>()
+    ///     .project_value(User::id())
+    ///     .union(database.from::<Order>().project_value(Order::user_id()))
+    ///     .except(database.from::<Wallet>().project_value(Wallet::id()))
+    ///     .fetch::<i32>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn except<R>(self, rhs: R) -> Self
     where
         Self: QueryOperand<Source = Q, Model = M, Projection = P>,
@@ -2005,16 +2077,34 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     }
 
     /// Appends a descending sort key.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .desc(User::id())
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn desc<V: Into<QueryValue>>(self, value: V) -> Self {
         Self::from_inner(self.inner.desc(value))
     }
 
     /// Sets the query `LIMIT`.
+    ///
+    /// ```rust,ignore
+    /// let first_two = database.from::<User>().asc(User::id()).limit(2).fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn limit(self, limit: usize) -> Self {
         Self::from_inner(self.inner.limit(limit))
     }
 
     /// Sets the query `OFFSET`.
+    ///
+    /// ```rust,ignore
+    /// let later_users = database.from::<User>().asc(User::id()).offset(1).fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn offset(self, offset: usize) -> Self {
         Self::from_inner(self.inner.offset(offset))
     }
@@ -2127,6 +2217,12 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     ///
     /// This is mainly useful when you want access to the raw tuple/schema pair
     /// instead of ORM decoding.
+    ///
+    /// ```rust,ignore
+    /// let rows = database.from::<User>().eq(User::id(), 1).raw()?;
+    /// # rows.done()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn raw(self) -> Result<Q::Iter, DatabaseError> {
         self.inner.raw()
     }
@@ -2154,11 +2250,25 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
 
 impl<Q: StatementSource, M: Model> FromBuilder<Q, M, ValueProjection> {
     /// Executes a single-value projection and decodes each row into `T`.
+    ///
+    /// ```rust,ignore
+    /// let ids = database.from::<User>().project_value(User::id()).fetch::<i32>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn fetch<T: FromDataValue>(self) -> Result<ProjectValueIter<Q::Iter, T>, DatabaseError> {
         Ok(ProjectValueIter::new(self.raw()?))
     }
 
     /// Executes a single-value projection and decodes one value.
+    ///
+    /// ```rust,ignore
+    /// let first_id = database
+    ///     .from::<User>()
+    ///     .project_value(User::id())
+    ///     .asc(User::id())
+    ///     .get::<i32>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn get<T: FromDataValue>(self) -> Result<Option<T>, DatabaseError> {
         extract_optional_value(self.limit(1).raw()?)
     }
@@ -2166,11 +2276,28 @@ impl<Q: StatementSource, M: Model> FromBuilder<Q, M, ValueProjection> {
 
 impl<Q: StatementSource, M: Model> FromBuilder<Q, M, TupleProjection> {
     /// Executes a tuple projection and decodes each row into `T`.
+    ///
+    /// ```rust,ignore
+    /// let rows = database
+    ///     .from::<User>()
+    ///     .project_tuple((User::id(), User::name()))
+    ///     .fetch::<(i32, String)>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn fetch<T: FromQueryTuple>(self) -> Result<ProjectTupleIter<Q::Iter, T>, DatabaseError> {
         Ok(ProjectTupleIter::new(self.raw()?))
     }
 
     /// Executes a tuple projection and decodes one row into `T`.
+    ///
+    /// ```rust,ignore
+    /// let row = database
+    ///     .from::<User>()
+    ///     .project_tuple((User::id(), User::name()))
+    ///     .asc(User::id())
+    ///     .get::<(i32, String)>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn get<T: FromQueryTuple>(self) -> Result<Option<T>, DatabaseError> {
         extract_optional_tuple(self.limit(1).raw()?)
     }
@@ -2178,11 +2305,35 @@ impl<Q: StatementSource, M: Model> FromBuilder<Q, M, TupleProjection> {
 
 impl<Q: StatementSource, M: Model, T: Projection> FromBuilder<Q, M, StructProjection<T>> {
     /// Executes a struct projection and decodes each row into `T`.
+    ///
+    /// ```rust,ignore
+    /// #[derive(Default, kite_sql::Projection)]
+    /// struct UserSummary {
+    ///     id: i32,
+    ///     #[projection(rename = "user_name")]
+    ///     display_name: String,
+    /// }
+    ///
+    /// let rows = database.from::<User>().project::<UserSummary>().fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn fetch(self) -> Result<OrmIter<Q::Iter, T>, DatabaseError> {
         Ok(self.raw()?.orm::<T>())
     }
 
     /// Executes a struct projection and decodes one row into `T`.
+    ///
+    /// ```rust,ignore
+    /// #[derive(Default, kite_sql::Projection)]
+    /// struct UserSummary {
+    ///     id: i32,
+    ///     #[projection(rename = "user_name")]
+    ///     display_name: String,
+    /// }
+    ///
+    /// let row = database.from::<User>().project::<UserSummary>().get()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn get(self) -> Result<Option<T>, DatabaseError> {
         extract_optional_row(self.limit(1).raw()?)
     }
@@ -2190,11 +2341,27 @@ impl<Q: StatementSource, M: Model, T: Projection> FromBuilder<Q, M, StructProjec
 
 impl<Q: StatementSource, M: Model> SetQueryBuilder<Q, M, ModelProjection> {
     /// Executes the set query and decodes rows into the model type.
+    ///
+    /// ```rust,ignore
+    /// let users = database
+    ///     .from::<User>()
+    ///     .union(database.from::<ArchivedUser>())
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn fetch(self) -> Result<OrmIter<Q::Iter, M>, DatabaseError> {
         Ok(self.raw()?.orm::<M>())
     }
 
     /// Executes the set query and decodes one model row.
+    ///
+    /// ```rust,ignore
+    /// let user = database
+    ///     .from::<User>()
+    ///     .union(database.from::<ArchivedUser>())
+    ///     .get()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn get(self) -> Result<Option<M>, DatabaseError> {
         extract_optional_model(self.raw()?)
     }
@@ -2202,11 +2369,30 @@ impl<Q: StatementSource, M: Model> SetQueryBuilder<Q, M, ModelProjection> {
 
 impl<Q: StatementSource, M: Model> SetQueryBuilder<Q, M, ValueProjection> {
     /// Executes the set query and decodes each row into `T`.
+    ///
+    /// ```rust,ignore
+    /// let ids = database
+    ///     .from::<User>()
+    ///     .project_value(User::id())
+    ///     .union(database.from::<Order>().project_value(Order::user_id()))
+    ///     .fetch::<i32>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn fetch<T: FromDataValue>(self) -> Result<ProjectValueIter<Q::Iter, T>, DatabaseError> {
         Ok(ProjectValueIter::new(self.raw()?))
     }
 
     /// Executes the set query and decodes one value.
+    ///
+    /// ```rust,ignore
+    /// let id = database
+    ///     .from::<User>()
+    ///     .project_value(User::id())
+    ///     .union(database.from::<Order>().project_value(Order::user_id()))
+    ///     .asc(User::id())
+    ///     .get::<i32>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn get<T: FromDataValue>(self) -> Result<Option<T>, DatabaseError> {
         extract_optional_value(self.raw()?)
     }
@@ -2214,11 +2400,29 @@ impl<Q: StatementSource, M: Model> SetQueryBuilder<Q, M, ValueProjection> {
 
 impl<Q: StatementSource, M: Model> SetQueryBuilder<Q, M, TupleProjection> {
     /// Executes the set query and decodes each row into `T`.
+    ///
+    /// ```rust,ignore
+    /// let rows = database
+    ///     .from::<User>()
+    ///     .project_tuple((User::id(), User::name()))
+    ///     .union(database.from::<ArchivedUser>().project_tuple((ArchivedUser::id(), ArchivedUser::name())))
+    ///     .fetch::<(i32, String)>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn fetch<T: FromQueryTuple>(self) -> Result<ProjectTupleIter<Q::Iter, T>, DatabaseError> {
         Ok(ProjectTupleIter::new(self.raw()?))
     }
 
     /// Executes the set query and decodes one tuple row.
+    ///
+    /// ```rust,ignore
+    /// let row = database
+    ///     .from::<User>()
+    ///     .project_tuple((User::id(), User::name()))
+    ///     .union(database.from::<ArchivedUser>().project_tuple((ArchivedUser::id(), ArchivedUser::name())))
+    ///     .get::<(i32, String)>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn get<T: FromQueryTuple>(self) -> Result<Option<T>, DatabaseError> {
         extract_optional_tuple(self.raw()?)
     }
@@ -2226,11 +2430,43 @@ impl<Q: StatementSource, M: Model> SetQueryBuilder<Q, M, TupleProjection> {
 
 impl<Q: StatementSource, M: Model, T: Projection> SetQueryBuilder<Q, M, StructProjection<T>> {
     /// Executes the set query and decodes rows into the struct projection type.
+    ///
+    /// ```rust,ignore
+    /// #[derive(Default, kite_sql::Projection)]
+    /// struct UserSummary {
+    ///     id: i32,
+    ///     #[projection(rename = "user_name")]
+    ///     display_name: String,
+    /// }
+    ///
+    /// let rows = database
+    ///     .from::<User>()
+    ///     .project::<UserSummary>()
+    ///     .union(database.from::<ArchivedUser>().project::<UserSummary>())
+    ///     .fetch()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn fetch(self) -> Result<OrmIter<Q::Iter, T>, DatabaseError> {
         Ok(self.raw()?.orm::<T>())
     }
 
     /// Executes the set query and decodes one projected row.
+    ///
+    /// ```rust,ignore
+    /// #[derive(Default, kite_sql::Projection)]
+    /// struct UserSummary {
+    ///     id: i32,
+    ///     #[projection(rename = "user_name")]
+    ///     display_name: String,
+    /// }
+    ///
+    /// let row = database
+    ///     .from::<User>()
+    ///     .project::<UserSummary>()
+    ///     .union(database.from::<ArchivedUser>().project::<UserSummary>())
+    ///     .get()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
     pub fn get(self) -> Result<Option<T>, DatabaseError> {
         extract_optional_row(self.raw()?)
     }

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -126,7 +126,7 @@ struct QuerySource {
 struct JoinSpec {
     source: QuerySource,
     kind: JoinKind,
-    on: QueryExpr,
+    constraint: JoinConstraint,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -155,10 +155,9 @@ impl QuerySource {
 
 impl JoinSpec {
     fn into_ast(self) -> Join {
-        let constraint = JoinConstraint::On(self.on.into_expr());
         let join_operator = match self.kind {
-            JoinKind::Inner => JoinOperator::Inner(constraint),
-            JoinKind::Left => JoinOperator::Left(constraint),
+            JoinKind::Inner => JoinOperator::Inner(self.constraint),
+            JoinKind::Left => JoinOperator::Left(self.constraint),
         };
 
         Join {
@@ -1296,6 +1295,46 @@ pub trait IntoProjectedTuple {
     fn into_projected_values(self) -> Vec<ProjectedValue>;
 }
 
+#[doc(hidden)]
+pub trait IntoJoinColumns {
+    fn into_join_columns(self) -> Vec<ObjectName>;
+}
+
+impl<M, T> IntoJoinColumns for Field<M, T> {
+    fn into_join_columns(self) -> Vec<ObjectName> {
+        vec![object_name(self.column)]
+    }
+}
+
+macro_rules! impl_into_join_columns {
+    ($(($($name:ident),+)),+ $(,)?) => {
+        $(
+            impl<$($name),+> IntoJoinColumns for ($($name,)+)
+            where
+                $($name: IntoJoinColumns,)+
+            {
+                #[allow(non_snake_case)]
+                fn into_join_columns(self) -> Vec<ObjectName> {
+                    let ($($name,)+) = self;
+                    let mut columns = Vec::new();
+                    $(columns.extend($name.into_join_columns());)+
+                    columns
+                }
+            }
+        )+
+    };
+}
+
+impl_into_join_columns!(
+    (A, B),
+    (A, B, C),
+    (A, B, C, D),
+    (A, B, C, D, E),
+    (A, B, C, D, E, F),
+    (A, B, C, D, E, F, G),
+    (A, B, C, D, E, F, G, H),
+);
+
 impl<M: Model> ProjectionSpec<M> for ModelProjection {
     fn into_select_items(self, relation: &str) -> Vec<SelectItem> {
         select_projection(M::fields(), relation)
@@ -1390,7 +1429,30 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> JoinOnBuilder<Q, M, P> 
     /// # Ok::<(), kite_sql::errors::DatabaseError>(())
     /// ```
     pub fn on(self, expr: QueryExpr) -> FromBuilder<Q, M, P> {
-        FromBuilder::from_inner(self.inner.join(self.join_source, self.join_kind, expr))
+        FromBuilder::from_inner(self.inner.join(
+            self.join_source,
+            self.join_kind,
+            JoinConstraint::On(expr.into_expr()),
+        ))
+    }
+
+    /// Completes a pending join with a `USING (...)` column list.
+    ///
+    /// ```rust,ignore
+    /// let rows = database
+    ///     .from::<User>()
+    ///     .inner_join::<Wallet>()
+    ///     .using(User::id())
+    ///     .project_tuple((User::name(), Wallet::balance()))
+    ///     .fetch::<(String, rust_decimal::Decimal)>()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
+    pub fn using<C: IntoJoinColumns>(self, columns: C) -> FromBuilder<Q, M, P> {
+        FromBuilder::from_inner(self.inner.join(
+            self.join_source,
+            self.join_kind,
+            JoinConstraint::Using(columns.into_join_columns()),
+        ))
     }
 }
 
@@ -1464,7 +1526,7 @@ impl<Q: StatementSource, M: Model> FromBuilder<Q, M, ModelProjection> {
 impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
     /// Starts an `INNER JOIN` against another model source.
     ///
-    /// Call `.on(...)` to supply the join condition. Use `.alias(...)` only
+    /// Call `.on(...)` or `.using(...)` to supply the join condition. Use `.alias(...)` only
     /// when explicit qualification is needed, such as self-joins.
     pub fn inner_join<J: Model>(self) -> JoinOnBuilder<Q, M, P> {
         JoinOnBuilder {
@@ -1476,7 +1538,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
 
     /// Starts a `LEFT JOIN` against another model source.
     ///
-    /// Call `.on(...)` to supply the join condition. Use `.alias(...)` only
+    /// Call `.on(...)` or `.using(...)` to supply the join condition. Use `.alias(...)` only
     /// when explicit qualification is needed, such as self-joins.
     pub fn left_join<J: Model>(self) -> JoinOnBuilder<Q, M, P> {
         JoinOnBuilder {
@@ -1724,12 +1786,17 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         }
     }
 
-    fn join(self, join_source: QuerySource, join_kind: JoinKind, on: QueryExpr) -> Self {
+    fn join(
+        self,
+        join_source: QuerySource,
+        join_kind: JoinKind,
+        constraint: JoinConstraint,
+    ) -> Self {
         Self {
             state: self.state.push_join(JoinSpec {
                 source: join_source,
                 kind: join_kind,
-                on,
+                constraint,
             }),
             projection: self.projection,
         }

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -133,6 +133,9 @@ struct JoinSpec {
 enum JoinKind {
     Inner,
     Left,
+    Right,
+    Full,
+    Cross,
 }
 
 impl QuerySource {
@@ -158,6 +161,9 @@ impl JoinSpec {
         let join_operator = match self.kind {
             JoinKind::Inner => JoinOperator::Inner(self.constraint),
             JoinKind::Left => JoinOperator::Left(self.constraint),
+            JoinKind::Right => JoinOperator::Right(self.constraint),
+            JoinKind::Full => JoinOperator::FullOuter(self.constraint),
+            JoinKind::Cross => JoinOperator::CrossJoin(self.constraint),
         };
 
         Join {
@@ -1634,6 +1640,41 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> FromBuilder<Q, M, P> {
             join_source: QuerySource::model::<J>(),
             join_kind: JoinKind::Left,
         }
+    }
+
+    /// Starts a `RIGHT JOIN` against another model source.
+    ///
+    /// Call `.on(...)` or `.using(...)` to supply the join condition. Use `.alias(...)` only
+    /// when explicit qualification is needed, such as self-joins.
+    pub fn right_join<J: Model>(self) -> JoinOnBuilder<Q, M, P> {
+        JoinOnBuilder {
+            inner: self.inner,
+            join_source: QuerySource::model::<J>(),
+            join_kind: JoinKind::Right,
+        }
+    }
+
+    /// Starts a `FULL OUTER JOIN` against another model source.
+    ///
+    /// Call `.on(...)` or `.using(...)` to supply the join condition. Use `.alias(...)` only
+    /// when explicit qualification is needed, such as self-joins.
+    pub fn full_join<J: Model>(self) -> JoinOnBuilder<Q, M, P> {
+        JoinOnBuilder {
+            inner: self.inner,
+            join_source: QuerySource::model::<J>(),
+            join_kind: JoinKind::Full,
+        }
+    }
+
+    /// Starts a `CROSS JOIN` against another model source.
+    ///
+    /// `CROSS JOIN` does not take an `ON` or `USING` clause.
+    pub fn cross_join<J: Model>(self) -> Self {
+        Self::from_inner(self.inner.join(
+            QuerySource::model::<J>(),
+            JoinKind::Cross,
+            JoinConstraint::None,
+        ))
     }
 
     /// Replaces the current `WHERE` predicate.

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -20,8 +20,8 @@ use sqlparser::ast::{
     GroupByExpr, HiveDistributionStyle, Ident, IndexColumn, Insert, KeyOrIndexDisplay, LimitClause,
     NullsDistinctOption, ObjectName, ObjectType, Offset, OffsetRows, OrderBy, OrderByExpr,
     OrderByKind, OrderByOptions, PrimaryKeyConstraint, Query, Select, SelectFlavor, SelectItem,
-    SetExpr, TableFactor, TableObject, TableWithJoins, TimezoneInfo, UniqueConstraint, Update,
-    Value, Values,
+    SetExpr, TableAlias, TableFactor, TableObject, TableWithJoins, TimezoneInfo, UniqueConstraint,
+    Update, Value, Values,
 };
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
@@ -114,6 +114,32 @@ pub struct Field<M, T> {
     table: &'static str,
     column: &'static str,
     _marker: PhantomData<(M, T)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct QuerySource {
+    table_name: String,
+    alias: Option<String>,
+}
+
+impl QuerySource {
+    fn model<M: Model>() -> Self {
+        Self {
+            table_name: M::table_name().to_string(),
+            alias: None,
+        }
+    }
+
+    fn aliased<M: Model>(alias: impl Into<String>) -> Self {
+        Self {
+            table_name: M::table_name().to_string(),
+            alias: Some(alias.into()),
+        }
+    }
+
+    fn relation_name(&self) -> &str {
+        self.alias.as_deref().unwrap_or(&self.table_name)
+    }
 }
 
 trait ValueExpressionOps: Sized {
@@ -341,10 +367,20 @@ impl<M, T> Field<M, T> {
     }
 
     fn value(self) -> QueryValue {
-        QueryValue::from_expr(Expr::CompoundIdentifier(vec![
-            ident(self.table),
-            ident(self.column),
-        ]))
+        qualified_column_value(self.table, self.column)
+    }
+
+    /// Re-qualifies this field with a different source name such as a table alias.
+    ///
+    /// ```rust,ignore
+    /// let user = database
+    ///     .from_alias::<User>("u")
+    ///     .eq(User::id().qualify("u"), 1)
+    ///     .get()?;
+    /// # Ok::<(), kite_sql::errors::DatabaseError>(())
+    /// ```
+    pub fn qualify(self, relation: &str) -> QueryValue {
+        qualified_column_value(relation, self.column)
     }
 
     /// Builds `field + value`.
@@ -1002,13 +1038,17 @@ impl ProjectedValue {
 }
 
 #[doc(hidden)]
-pub fn projection_value<M: Model>(column: &'static str, alias: &'static str) -> ProjectedValue {
-    Field::<M, ()>::new(M::table_name(), column).alias(alias)
+pub fn projection_value(
+    column: &'static str,
+    relation: &str,
+    alias: &'static str,
+) -> ProjectedValue {
+    qualified_column_value(relation, column).alias(alias)
 }
 
 #[doc(hidden)]
-pub fn projection_column<M: Model>(column: &'static str) -> ProjectedValue {
-    ProjectedValue::from(Field::<M, ()>::new(M::table_name(), column))
+pub fn projection_column(column: &'static str, relation: &str) -> ProjectedValue {
+    ProjectedValue::from(qualified_column_value(relation, column))
 }
 
 impl<V: Into<QueryValue>> From<V> for ProjectedValue {
@@ -1143,6 +1183,7 @@ pub struct StructProjection<T> {
 
 struct BuilderState<Q: StatementSource, M: Model> {
     source: Q,
+    query_source: QuerySource,
     distinct: bool,
     filter: Option<QueryExpr>,
     group_bys: Vec<QueryValue>,
@@ -1154,9 +1195,10 @@ struct BuilderState<Q: StatementSource, M: Model> {
 }
 
 impl<Q: StatementSource, M: Model> BuilderState<Q, M> {
-    fn new(source: Q) -> Self {
+    fn new(source: Q, query_source: QuerySource) -> Self {
         Self {
             source,
+            query_source,
             distinct: false,
             filter: None,
             group_bys: Vec::new(),
@@ -1196,7 +1238,7 @@ impl<Q: StatementSource, M: Model> BuilderState<Q, M> {
 
 #[doc(hidden)]
 pub trait ProjectionSpec<M: Model> {
-    fn into_select_items(self) -> Vec<SelectItem>;
+    fn into_select_items(self, relation: &str) -> Vec<SelectItem>;
 }
 
 /// Declares a struct-backed ORM projection used by [`FromBuilder::project`].
@@ -1204,7 +1246,7 @@ pub trait ProjectionSpec<M: Model> {
 /// This trait is typically derived with `#[derive(Projection)]`.
 pub trait Projection: for<'a> From<(&'a SchemaRef, Tuple)> {
     /// Returns the projected select-list items for model `M`.
-    fn projected_values<M: Model>() -> Vec<ProjectedValue>;
+    fn projected_values<M: Model>(relation: &str) -> Vec<ProjectedValue>;
 }
 
 #[doc(hidden)]
@@ -1213,19 +1255,19 @@ pub trait IntoProjectedTuple {
 }
 
 impl<M: Model> ProjectionSpec<M> for ModelProjection {
-    fn into_select_items(self) -> Vec<SelectItem> {
+    fn into_select_items(self, _relation: &str) -> Vec<SelectItem> {
         select_projection(M::fields())
     }
 }
 
 impl<M: Model> ProjectionSpec<M> for ValueProjection {
-    fn into_select_items(self) -> Vec<SelectItem> {
+    fn into_select_items(self, _relation: &str) -> Vec<SelectItem> {
         vec![self.value.into_select_item()]
     }
 }
 
 impl<M: Model> ProjectionSpec<M> for TupleProjection {
-    fn into_select_items(self) -> Vec<SelectItem> {
+    fn into_select_items(self, _relation: &str) -> Vec<SelectItem> {
         self.values
             .into_iter()
             .map(ProjectedValue::into_select_item)
@@ -1234,8 +1276,8 @@ impl<M: Model> ProjectionSpec<M> for TupleProjection {
 }
 
 impl<M: Model, T: Projection> ProjectionSpec<M> for StructProjection<T> {
-    fn into_select_items(self) -> Vec<SelectItem> {
-        T::projected_values::<M>()
+    fn into_select_items(self, relation: &str) -> Vec<SelectItem> {
+        T::projected_values::<M>(relation)
             .into_iter()
             .map(ProjectedValue::into_select_item)
             .collect()
@@ -1252,7 +1294,14 @@ enum FilterMode {
 impl<Q: StatementSource, M: Model> QueryBuilder<Q, M, ModelProjection> {
     fn new(source: Q) -> Self {
         Self {
-            state: BuilderState::new(source),
+            state: BuilderState::new(source, QuerySource::model::<M>()),
+            projection: ModelProjection,
+        }
+    }
+
+    fn aliased(source: Q, alias: impl Into<String>) -> Self {
+        Self {
+            state: BuilderState::new(source, QuerySource::aliased::<M>(alias)),
             projection: ModelProjection,
         }
     }
@@ -1675,6 +1724,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
             state:
                 BuilderState {
                     source: _,
+                    query_source,
                     distinct,
                     filter,
                     group_bys,
@@ -1688,8 +1738,8 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         } = self;
 
         select_query(
-            M::table_name(),
-            projection.into_select_items(),
+            &query_source,
+            projection.into_select_items(query_source.relation_name()),
             distinct,
             filter,
             group_bys,
@@ -1705,6 +1755,7 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
             state:
                 BuilderState {
                     source,
+                    query_source,
                     distinct,
                     filter,
                     group_bys,
@@ -1718,8 +1769,8 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
         } = self;
 
         let statement = Statement::Query(Box::new(select_query(
-            M::table_name(),
-            projection.into_select_items(),
+            &query_source,
+            projection.into_select_items(query_source.relation_name()),
             distinct,
             filter,
             group_bys,
@@ -1872,8 +1923,13 @@ impl<Q: StatementSource, M: Model, P: ProjectionSpec<M>> QueryBuilder<Q, M, P> {
             return Ok(count);
         }
 
-        let BuilderState { source, filter, .. } = self.state;
-        let statement = orm_count_statement(M::table_name(), filter);
+        let BuilderState {
+            source,
+            query_source,
+            filter,
+            ..
+        } = self.state;
+        let statement = orm_count_statement(&query_source, filter);
         let mut iter = source.execute_statement(&statement, &[])?;
         let count = match iter.next().transpose()? {
             Some(tuple) => match tuple.values.first() {
@@ -1909,6 +1965,13 @@ fn ident(value: impl Into<String>) -> Ident {
 
 fn object_name(value: &str) -> ObjectName {
     value.split('.').map(ident).collect::<Vec<_>>().into()
+}
+
+fn qualified_column_value(relation: &str, column: &str) -> QueryValue {
+    QueryValue::from_expr(Expr::CompoundIdentifier(vec![
+        ident(relation),
+        ident(column),
+    ]))
 }
 
 fn nested_expr(expr: Expr) -> Expr {
@@ -1954,9 +2017,35 @@ fn table_factor(table_name: &str) -> TableFactor {
     }
 }
 
+fn source_table_factor(source: &QuerySource) -> TableFactor {
+    TableFactor::Table {
+        name: object_name(&source.table_name),
+        alias: source.alias.as_ref().map(|alias| TableAlias {
+            explicit: true,
+            name: ident(alias),
+            columns: vec![],
+        }),
+        args: None,
+        with_hints: vec![],
+        version: None,
+        with_ordinality: false,
+        partitions: vec![],
+        json_path: None,
+        sample: None,
+        index_hints: vec![],
+    }
+}
+
 fn table_with_joins(table_name: &str) -> TableWithJoins {
     TableWithJoins {
         relation: table_factor(table_name),
+        joins: vec![],
+    }
+}
+
+fn source_table_with_joins(source: &QuerySource) -> TableWithJoins {
+    TableWithJoins {
+        relation: source_table_factor(source),
         joins: vec![],
     }
 }
@@ -1969,7 +2058,7 @@ fn select_projection(fields: &[OrmField]) -> Vec<SelectItem> {
 }
 
 fn select_query(
-    table_name: &str,
+    source: &QuerySource,
     projection: Vec<SelectItem>,
     distinct: bool,
     filter: Option<QueryExpr>,
@@ -1991,7 +2080,7 @@ fn select_query(
             projection,
             exclude: None,
             into: None,
-            from: vec![table_with_joins(table_name)],
+            from: vec![source_table_with_joins(source)],
             lateral_views: vec![],
             prewhere: None,
             selection: filter.map(QueryExpr::into_expr),
@@ -2107,7 +2196,10 @@ fn data_value_to_ast_expr(value: &DataValue) -> Expr {
 #[doc(hidden)]
 pub fn orm_select_statement(table_name: &str, fields: &[OrmField]) -> Statement {
     Statement::Query(Box::new(select_query(
-        table_name,
+        &QuerySource {
+            table_name: table_name.to_string(),
+            alias: None,
+        },
         select_projection(fields),
         false,
         None,
@@ -2382,9 +2474,9 @@ pub fn orm_analyze_statement(table_name: &str) -> Statement {
     })
 }
 
-fn orm_count_statement(table_name: &str, filter: Option<QueryExpr>) -> Statement {
+fn orm_count_statement(source: &QuerySource, filter: Option<QueryExpr>) -> Statement {
     Statement::Query(Box::new(select_query(
-        table_name,
+        source,
         vec![SelectItem::UnnamedExpr(Expr::Function(Function {
             name: object_name("count"),
             uses_odbc_syntax: false,

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -704,6 +704,33 @@ impl<V: Into<QueryValue>> From<V> for ProjectedValue {
     }
 }
 
+macro_rules! impl_into_projected_tuple {
+    ($(($($name:ident),+)),+ $(,)?) => {
+        $(
+            impl<$($name),+> IntoProjectedTuple for ($($name,)+)
+            where
+                $($name: Into<ProjectedValue>,)+
+            {
+                #[allow(non_snake_case)]
+                fn into_projected_values(self) -> Vec<ProjectedValue> {
+                    let ($($name,)+) = self;
+                    vec![$($name.into(),)+]
+                }
+            }
+        )+
+    };
+}
+
+impl_into_projected_tuple!(
+    (A, B),
+    (A, B, C),
+    (A, B, C, D),
+    (A, B, C, D, E),
+    (A, B, C, D, E, F),
+    (A, B, C, D, E, F, G),
+    (A, B, C, D, E, F, G, H),
+);
+
 impl From<Expr> for QueryValue {
     fn from(value: Expr) -> Self {
         QueryValue::from_ast(value)
@@ -786,11 +813,17 @@ pub struct SelectBuilder<Q: StatementSource, M: Model, P = ModelProjection> {
 
 /// Lightweight single-table query builder for scalar value projections.
 pub type ProjectValueBuilder<Q, M> = SelectBuilder<Q, M, ValueProjection>;
+/// Lightweight single-table query builder for tuple projections.
+pub type ProjectTupleBuilder<Q, M> = SelectBuilder<Q, M, TupleProjection>;
 
 pub struct ModelProjection;
 
 pub struct ValueProjection {
     value: ProjectedValue,
+}
+
+pub struct TupleProjection {
+    values: Vec<ProjectedValue>,
 }
 
 struct BuilderState<Q: StatementSource, M: Model> {
@@ -844,6 +877,11 @@ pub trait ProjectionSpec<M: Model> {
     fn into_select_items(self) -> Vec<SelectItem>;
 }
 
+#[doc(hidden)]
+pub trait IntoProjectedTuple {
+    fn into_projected_values(self) -> Vec<ProjectedValue>;
+}
+
 impl<M: Model> ProjectionSpec<M> for ModelProjection {
     fn into_select_items(self) -> Vec<SelectItem> {
         select_projection(M::fields())
@@ -853,6 +891,15 @@ impl<M: Model> ProjectionSpec<M> for ModelProjection {
 impl<M: Model> ProjectionSpec<M> for ValueProjection {
     fn into_select_items(self) -> Vec<SelectItem> {
         vec![self.value.into_select_item()]
+    }
+}
+
+impl<M: Model> ProjectionSpec<M> for TupleProjection {
+    fn into_select_items(self) -> Vec<SelectItem> {
+        self.values
+            .into_iter()
+            .map(ProjectedValue::into_select_item)
+            .collect()
     }
 }
 
@@ -926,6 +973,25 @@ impl<Q: StatementSource, M: Model> SelectBuilder<Q, M, ValueProjection> {
 
     pub fn get<T: FromDataValue>(self) -> Result<Option<T>, DatabaseError> {
         extract_optional_value(self.limit(1).raw()?)
+    }
+}
+
+impl<Q: StatementSource, M: Model> SelectBuilder<Q, M, TupleProjection> {
+    fn new_tuple<V: IntoProjectedTuple>(source: Q, values: V) -> Self {
+        Self {
+            state: BuilderState::new(source),
+            projection: TupleProjection {
+                values: values.into_projected_values(),
+            },
+        }
+    }
+
+    pub fn fetch<T: FromQueryTuple>(self) -> Result<ProjectTupleIter<Q::Iter, T>, DatabaseError> {
+        Ok(ProjectTupleIter::new(self.raw()?))
+    }
+
+    pub fn get<T: FromQueryTuple>(self) -> Result<Option<T>, DatabaseError> {
+        extract_optional_tuple(self.limit(1).raw()?)
     }
 }
 
@@ -1920,6 +1986,11 @@ pub trait FromDataValue: Sized {
     fn from_data_value(value: DataValue) -> Option<Self>;
 }
 
+/// Conversion trait from a projected result tuple into a Rust value.
+pub trait FromQueryTuple: Sized {
+    fn from_query_tuple(tuple: Tuple) -> Result<Self, DatabaseError>;
+}
+
 /// Typed adapter over a [`ResultIter`] that yields projected values instead of raw tuples.
 pub struct ProjectValueIter<I, T> {
     inner: I,
@@ -1930,6 +2001,30 @@ impl<I, T> ProjectValueIter<I, T>
 where
     I: ResultIter,
     T: FromDataValue,
+{
+    fn new(inner: I) -> Self {
+        Self {
+            inner,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Finishes the underlying raw iterator.
+    pub fn done(self) -> Result<(), DatabaseError> {
+        self.inner.done()
+    }
+}
+
+/// Typed adapter over a [`ResultIter`] that yields projected tuples.
+pub struct ProjectTupleIter<I, T> {
+    inner: I,
+    _marker: PhantomData<T>,
+}
+
+impl<I, T> ProjectTupleIter<I, T>
+where
+    I: ResultIter,
+    T: FromQueryTuple,
 {
     fn new(inner: I) -> Self {
         Self {
@@ -1955,6 +2050,20 @@ where
         self.inner
             .next()
             .map(|result| result.and_then(extract_value_from_tuple::<T>))
+    }
+}
+
+impl<I, T> Iterator for ProjectTupleIter<I, T>
+where
+    I: ResultIter,
+    T: FromQueryTuple,
+{
+    type Item = Result<T, DatabaseError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next()
+            .map(|result| result.and_then(extract_projected_tuple::<T>))
     }
 }
 
@@ -2185,6 +2294,49 @@ impl<T: ModelColumnType> ModelColumnType for Option<T> {
 impl<T: StringType> StringType for Option<T> {}
 impl<T: DecimalType> DecimalType for Option<T> {}
 
+macro_rules! impl_from_query_tuple {
+    ($(($($name:ident),+)),+ $(,)?) => {
+        $(
+            impl<$($name),+> FromQueryTuple for ($($name,)+)
+            where
+                $($name: FromDataValue,)+
+            {
+                #[allow(non_snake_case)]
+                fn from_query_tuple(tuple: Tuple) -> Result<Self, DatabaseError> {
+                    let expected_len = [$(stringify!($name)),+].len();
+                    let mut values = tuple.values.into_iter();
+
+                    $(
+                        let $name = extract_projected_data_value::<$name>(
+                            values.next(),
+                            expected_len,
+                        )?;
+                    )+
+
+                    if values.next().is_some() {
+                        return Err(DatabaseError::MisMatch(
+                            "the expected tuple projection width",
+                            "the query result",
+                        ));
+                    }
+
+                    Ok(($($name,)+))
+                }
+            }
+        )+
+    };
+}
+
+impl_from_query_tuple!(
+    (A, B),
+    (A, B, C),
+    (A, B, C, D),
+    (A, B, C, D, E),
+    (A, B, C, D, E, F),
+    (A, B, C, D, E, F, G),
+    (A, B, C, D, E, F, G, H),
+);
+
 fn normalize_sql_fragment(value: &str) -> String {
     value
         .split_whitespace()
@@ -2290,16 +2442,7 @@ where
     })
 }
 
-fn extract_value_from_tuple<T: FromDataValue>(mut tuple: Tuple) -> Result<T, DatabaseError> {
-    let value = if tuple.values.len() == 1 {
-        tuple.values.swap_remove(0)
-    } else {
-        return Err(DatabaseError::MisMatch(
-            "one projected expression",
-            "the query result",
-        ));
-    };
-
+fn convert_projected_value<T: FromDataValue>(value: DataValue) -> Result<T, DatabaseError> {
     let value = match T::logical_type() {
         Some(ty) => value.cast(&ty)?,
         None => value,
@@ -2313,6 +2456,34 @@ fn extract_value_from_tuple<T: FromDataValue>(mut tuple: Tuple) -> Result<T, Dat
     })
 }
 
+fn extract_projected_data_value<T: FromDataValue>(
+    value: Option<DataValue>,
+    _expected_len: usize,
+) -> Result<T, DatabaseError> {
+    let value = value.ok_or(DatabaseError::MisMatch(
+        "the expected tuple projection width",
+        "the query result",
+    ))?;
+    convert_projected_value::<T>(value)
+}
+
+fn extract_value_from_tuple<T: FromDataValue>(mut tuple: Tuple) -> Result<T, DatabaseError> {
+    let value = if tuple.values.len() == 1 {
+        tuple.values.swap_remove(0)
+    } else {
+        return Err(DatabaseError::MisMatch(
+            "one projected expression",
+            "the query result",
+        ));
+    };
+
+    convert_projected_value::<T>(value)
+}
+
+fn extract_projected_tuple<T: FromQueryTuple>(tuple: Tuple) -> Result<T, DatabaseError> {
+    T::from_query_tuple(tuple)
+}
+
 fn extract_optional_value<I, T>(mut iter: I) -> Result<Option<T>, DatabaseError>
 where
     I: ResultIter,
@@ -2320,6 +2491,17 @@ where
 {
     Ok(match iter.next() {
         Some(tuple) => Some(extract_value_from_tuple(tuple?)?),
+        None => None,
+    })
+}
+
+fn extract_optional_tuple<I, T>(mut iter: I) -> Result<Option<T>, DatabaseError>
+where
+    I: ResultIter,
+    T: FromQueryTuple,
+{
+    Ok(match iter.next() {
+        Some(tuple) => Some(extract_projected_tuple(tuple?)?),
         None => None,
     })
 }

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -14,13 +14,14 @@ use rust_decimal::Decimal;
 use sqlparser::ast::helpers::attached_token::AttachedToken;
 use sqlparser::ast::{
     AlterColumnOperation, AlterTable, AlterTableOperation, Analyze, Assignment, AssignmentTarget,
-    BinaryOperator as SqlBinaryOperator, CharLengthUnits, ColumnDef, ColumnOption, ColumnOptionDef,
-    CreateIndex, CreateTable, DataType, Delete, Expr, FromTable, Function, FunctionArg,
-    FunctionArgExpr, FunctionArgumentList, FunctionArguments, GroupByExpr, HiveDistributionStyle,
-    Ident, IndexColumn, Insert, KeyOrIndexDisplay, LimitClause, NullsDistinctOption, ObjectName,
-    ObjectType, Offset, OffsetRows, OrderBy, OrderByExpr, OrderByKind, OrderByOptions,
-    PrimaryKeyConstraint, Query, Select, SelectFlavor, SelectItem, SetExpr, TableFactor,
-    TableObject, TableWithJoins, TimezoneInfo, UniqueConstraint, Update, Value, Values,
+    BinaryOperator as SqlBinaryOperator, CastKind, CharLengthUnits, ColumnDef, ColumnOption,
+    ColumnOptionDef, CreateIndex, CreateTable, DataType, Delete, Expr, FromTable, Function,
+    FunctionArg, FunctionArgExpr, FunctionArgumentList, FunctionArguments, GroupByExpr,
+    HiveDistributionStyle, Ident, IndexColumn, Insert, KeyOrIndexDisplay, LimitClause,
+    NullsDistinctOption, ObjectName, ObjectType, Offset, OffsetRows, OrderBy, OrderByExpr,
+    OrderByKind, OrderByOptions, PrimaryKeyConstraint, Query, Select, SelectFlavor, SelectItem,
+    SetExpr, TableFactor, TableObject, TableWithJoins, TimezoneInfo, UniqueConstraint, Update,
+    Value, Values,
 };
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
@@ -142,10 +143,10 @@ impl<M, T> Field<M, T> {
     }
 
     fn value(self) -> QueryValue {
-        QueryValue::Column {
-            table: self.table,
-            column: self.column,
-        }
+        QueryValue::from_ast(Expr::CompoundIdentifier(vec![
+            ident(self.table),
+            ident(self.column),
+        ]))
     }
 
     pub fn eq<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
@@ -187,19 +188,56 @@ impl<M, T> Field<M, T> {
     pub fn not_like<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
         self.value().not_like(pattern)
     }
+
+    pub fn in_list<I, V>(self, values: I) -> QueryExpr
+    where
+        I: IntoIterator<Item = V>,
+        V: Into<QueryValue>,
+    {
+        self.value().in_list(values)
+    }
+
+    pub fn not_in_list<I, V>(self, values: I) -> QueryExpr
+    where
+        I: IntoIterator<Item = V>,
+        V: Into<QueryValue>,
+    {
+        self.value().not_in_list(values)
+    }
+
+    pub fn between<L: Into<QueryValue>, H: Into<QueryValue>>(self, low: L, high: H) -> QueryExpr {
+        self.value().between(low, high)
+    }
+
+    pub fn not_between<L: Into<QueryValue>, H: Into<QueryValue>>(
+        self,
+        low: L,
+        high: H,
+    ) -> QueryExpr {
+        self.value().not_between(low, high)
+    }
+
+    pub fn cast(self, data_type: &str) -> Result<QueryValue, DatabaseError> {
+        self.value().cast(data_type)
+    }
+
+    pub fn cast_to(self, data_type: DataType) -> QueryValue {
+        self.value().cast_to(data_type)
+    }
+
+    pub fn in_subquery(self, subquery: Query) -> QueryExpr {
+        self.value().in_subquery(subquery)
+    }
+
+    pub fn not_in_subquery(self, subquery: Query) -> QueryExpr {
+        self.value().not_in_subquery(subquery)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum QueryValue {
-    Column {
-        table: &'static str,
-        column: &'static str,
-    },
-    Param(DataValue),
-    Function {
-        name: String,
-        args: Vec<QueryValue>,
-    },
+/// A lightweight ORM expression wrapper for value-producing SQL AST nodes.
+pub struct QueryValue {
+    expr: Expr,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -213,24 +251,9 @@ pub enum CompareOp {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum QueryExpr {
-    Compare {
-        left: QueryValue,
-        op: CompareOp,
-        right: QueryValue,
-    },
-    IsNull {
-        value: QueryValue,
-        negated: bool,
-    },
-    Like {
-        value: QueryValue,
-        pattern: QueryValue,
-        negated: bool,
-    },
-    And(Box<QueryExpr>, Box<QueryExpr>),
-    Or(Box<QueryExpr>, Box<QueryExpr>),
-    Not(Box<QueryExpr>),
+/// A lightweight ORM expression wrapper for predicate-oriented SQL AST nodes.
+pub struct QueryExpr {
+    expr: Expr,
 }
 
 pub fn func<N, I, V>(name: N, args: I) -> QueryValue
@@ -243,58 +266,53 @@ where
 }
 
 impl QueryExpr {
+    pub fn from_ast(expr: Expr) -> QueryExpr {
+        Self { expr }
+    }
+
+    pub fn as_ast(&self) -> &Expr {
+        &self.expr
+    }
+
+    pub fn into_ast(self) -> Expr {
+        self.expr
+    }
+
     pub fn and(self, rhs: QueryExpr) -> QueryExpr {
-        QueryExpr::And(Box::new(self), Box::new(rhs))
+        QueryExpr::from_ast(Expr::BinaryOp {
+            left: Box::new(nested_expr(self.into_ast())),
+            op: SqlBinaryOperator::And,
+            right: Box::new(nested_expr(rhs.into_ast())),
+        })
     }
 
     pub fn or(self, rhs: QueryExpr) -> QueryExpr {
-        QueryExpr::Or(Box::new(self), Box::new(rhs))
+        QueryExpr::from_ast(Expr::BinaryOp {
+            left: Box::new(nested_expr(self.into_ast())),
+            op: SqlBinaryOperator::Or,
+            right: Box::new(nested_expr(rhs.into_ast())),
+        })
     }
 
     pub fn not(self) -> QueryExpr {
-        QueryExpr::Not(Box::new(self))
+        QueryExpr::from_ast(Expr::UnaryOp {
+            op: sqlparser::ast::UnaryOperator::Not,
+            expr: Box::new(nested_expr(self.into_ast())),
+        })
     }
 
-    fn to_ast(&self) -> Expr {
-        match self {
-            QueryExpr::Compare { left, op, right } => Expr::BinaryOp {
-                left: Box::new(left.to_ast()),
-                op: op.as_ast(),
-                right: Box::new(right.to_ast()),
-            },
-            QueryExpr::IsNull { value, negated } => {
-                if *negated {
-                    Expr::IsNotNull(Box::new(value.to_ast()))
-                } else {
-                    Expr::IsNull(Box::new(value.to_ast()))
-                }
-            }
-            QueryExpr::Like {
-                value,
-                pattern,
-                negated,
-            } => Expr::Like {
-                negated: *negated,
-                expr: Box::new(value.to_ast()),
-                pattern: Box::new(pattern.to_ast()),
-                escape_char: None,
-                any: false,
-            },
-            QueryExpr::And(left, right) => Expr::BinaryOp {
-                left: Box::new(nested_expr(left.to_ast())),
-                op: SqlBinaryOperator::And,
-                right: Box::new(nested_expr(right.to_ast())),
-            },
-            QueryExpr::Or(left, right) => Expr::BinaryOp {
-                left: Box::new(nested_expr(left.to_ast())),
-                op: SqlBinaryOperator::Or,
-                right: Box::new(nested_expr(right.to_ast())),
-            },
-            QueryExpr::Not(inner) => Expr::UnaryOp {
-                op: sqlparser::ast::UnaryOperator::Not,
-                expr: Box::new(nested_expr(inner.to_ast())),
-            },
-        }
+    pub fn exists(subquery: Query) -> QueryExpr {
+        QueryExpr::from_ast(Expr::Exists {
+            subquery: Box::new(subquery),
+            negated: false,
+        })
+    }
+
+    pub fn not_exists(subquery: Query) -> QueryExpr {
+        QueryExpr::from_ast(Expr::Exists {
+            subquery: Box::new(subquery),
+            negated: true,
+        })
     }
 }
 
@@ -309,9 +327,9 @@ impl SortExpr {
         Self { value, desc }
     }
 
-    fn to_ast(&self) -> OrderByExpr {
+    fn into_ast(self) -> OrderByExpr {
         OrderByExpr {
-            expr: self.value.to_ast(),
+            expr: self.value.into_ast(),
             options: OrderByOptions {
                 asc: Some(!self.desc),
                 nulls_first: None,
@@ -322,94 +340,209 @@ impl SortExpr {
 }
 
 impl QueryValue {
+    pub fn from_ast(expr: Expr) -> Self {
+        Self { expr }
+    }
+
+    pub fn as_ast(&self) -> &Expr {
+        &self.expr
+    }
+
+    pub fn into_ast(self) -> Expr {
+        self.expr
+    }
+
     pub fn function<N, I, V>(name: N, args: I) -> Self
     where
         N: Into<String>,
         I: IntoIterator<Item = V>,
         V: Into<QueryValue>,
     {
-        Self::Function {
-            name: name.into(),
-            args: args.into_iter().map(Into::into).collect(),
-        }
+        let name = name.into();
+        Self::from_ast(Expr::Function(Function {
+            name: object_name(&name),
+            uses_odbc_syntax: false,
+            parameters: FunctionArguments::None,
+            args: FunctionArguments::List(FunctionArgumentList {
+                duplicate_treatment: None,
+                args: args
+                    .into_iter()
+                    .map(Into::into)
+                    .map(QueryValue::into_ast)
+                    .map(FunctionArgExpr::Expr)
+                    .map(FunctionArg::Unnamed)
+                    .collect(),
+                clauses: vec![],
+            }),
+            filter: None,
+            null_treatment: None,
+            over: None,
+            within_group: vec![],
+        }))
     }
 
     pub fn eq<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::Compare {
-            left: self,
-            op: CompareOp::Eq,
-            right: value.into(),
-        }
+        QueryExpr::from_ast(Expr::BinaryOp {
+            left: Box::new(self.into_ast()),
+            op: CompareOp::Eq.as_ast(),
+            right: Box::new(value.into().into_ast()),
+        })
     }
 
     pub fn ne<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::Compare {
-            left: self,
-            op: CompareOp::Ne,
-            right: value.into(),
-        }
+        QueryExpr::from_ast(Expr::BinaryOp {
+            left: Box::new(self.into_ast()),
+            op: CompareOp::Ne.as_ast(),
+            right: Box::new(value.into().into_ast()),
+        })
     }
 
     pub fn gt<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::Compare {
-            left: self,
-            op: CompareOp::Gt,
-            right: value.into(),
-        }
+        QueryExpr::from_ast(Expr::BinaryOp {
+            left: Box::new(self.into_ast()),
+            op: CompareOp::Gt.as_ast(),
+            right: Box::new(value.into().into_ast()),
+        })
     }
 
     pub fn gte<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::Compare {
-            left: self,
-            op: CompareOp::Gte,
-            right: value.into(),
-        }
+        QueryExpr::from_ast(Expr::BinaryOp {
+            left: Box::new(self.into_ast()),
+            op: CompareOp::Gte.as_ast(),
+            right: Box::new(value.into().into_ast()),
+        })
     }
 
     pub fn lt<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::Compare {
-            left: self,
-            op: CompareOp::Lt,
-            right: value.into(),
-        }
+        QueryExpr::from_ast(Expr::BinaryOp {
+            left: Box::new(self.into_ast()),
+            op: CompareOp::Lt.as_ast(),
+            right: Box::new(value.into().into_ast()),
+        })
     }
 
     pub fn lte<V: Into<QueryValue>>(self, value: V) -> QueryExpr {
-        QueryExpr::Compare {
-            left: self,
-            op: CompareOp::Lte,
-            right: value.into(),
-        }
+        QueryExpr::from_ast(Expr::BinaryOp {
+            left: Box::new(self.into_ast()),
+            op: CompareOp::Lte.as_ast(),
+            right: Box::new(value.into().into_ast()),
+        })
     }
 
     pub fn is_null(self) -> QueryExpr {
-        QueryExpr::IsNull {
-            value: self,
-            negated: false,
-        }
+        QueryExpr::from_ast(Expr::IsNull(Box::new(self.into_ast())))
     }
 
     pub fn is_not_null(self) -> QueryExpr {
-        QueryExpr::IsNull {
-            value: self,
-            negated: true,
-        }
+        QueryExpr::from_ast(Expr::IsNotNull(Box::new(self.into_ast())))
     }
 
     pub fn like<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
-        QueryExpr::Like {
-            value: self,
-            pattern: pattern.into(),
+        QueryExpr::from_ast(Expr::Like {
             negated: false,
-        }
+            expr: Box::new(self.into_ast()),
+            pattern: Box::new(pattern.into().into_ast()),
+            escape_char: None,
+            any: false,
+        })
     }
 
     pub fn not_like<V: Into<QueryValue>>(self, pattern: V) -> QueryExpr {
-        QueryExpr::Like {
-            value: self,
-            pattern: pattern.into(),
+        QueryExpr::from_ast(Expr::Like {
             negated: true,
-        }
+            expr: Box::new(self.into_ast()),
+            pattern: Box::new(pattern.into().into_ast()),
+            escape_char: None,
+            any: false,
+        })
+    }
+
+    pub fn in_list<I, V>(self, values: I) -> QueryExpr
+    where
+        I: IntoIterator<Item = V>,
+        V: Into<QueryValue>,
+    {
+        QueryExpr::from_ast(Expr::InList {
+            expr: Box::new(self.into_ast()),
+            list: values
+                .into_iter()
+                .map(Into::into)
+                .map(QueryValue::into_ast)
+                .collect(),
+            negated: false,
+        })
+    }
+
+    pub fn not_in_list<I, V>(self, values: I) -> QueryExpr
+    where
+        I: IntoIterator<Item = V>,
+        V: Into<QueryValue>,
+    {
+        QueryExpr::from_ast(Expr::InList {
+            expr: Box::new(self.into_ast()),
+            list: values
+                .into_iter()
+                .map(Into::into)
+                .map(QueryValue::into_ast)
+                .collect(),
+            negated: true,
+        })
+    }
+
+    pub fn between<L: Into<QueryValue>, H: Into<QueryValue>>(self, low: L, high: H) -> QueryExpr {
+        QueryExpr::from_ast(Expr::Between {
+            expr: Box::new(self.into_ast()),
+            negated: false,
+            low: Box::new(low.into().into_ast()),
+            high: Box::new(high.into().into_ast()),
+        })
+    }
+
+    pub fn not_between<L: Into<QueryValue>, H: Into<QueryValue>>(
+        self,
+        low: L,
+        high: H,
+    ) -> QueryExpr {
+        QueryExpr::from_ast(Expr::Between {
+            expr: Box::new(self.into_ast()),
+            negated: true,
+            low: Box::new(low.into().into_ast()),
+            high: Box::new(high.into().into_ast()),
+        })
+    }
+
+    pub fn cast(self, data_type: &str) -> Result<QueryValue, DatabaseError> {
+        Ok(self.cast_to(parse_data_type_fragment(data_type)?))
+    }
+
+    pub fn cast_to(self, data_type: DataType) -> QueryValue {
+        QueryValue::from_ast(Expr::Cast {
+            kind: CastKind::Cast,
+            expr: Box::new(self.into_ast()),
+            data_type,
+            array: false,
+            format: None,
+        })
+    }
+
+    pub fn subquery(query: Query) -> QueryValue {
+        QueryValue::from_ast(Expr::Subquery(Box::new(query)))
+    }
+
+    pub fn in_subquery(self, subquery: Query) -> QueryExpr {
+        QueryExpr::from_ast(Expr::InSubquery {
+            expr: Box::new(self.into_ast()),
+            subquery: Box::new(subquery),
+            negated: false,
+        })
+    }
+
+    pub fn not_in_subquery(self, subquery: Query) -> QueryExpr {
+        QueryExpr::from_ast(Expr::InSubquery {
+            expr: Box::new(self.into_ast()),
+            subquery: Box::new(subquery),
+            negated: true,
+        })
     }
 
     fn asc(self) -> SortExpr {
@@ -419,34 +552,6 @@ impl QueryValue {
     fn desc(self) -> SortExpr {
         SortExpr::new(self, true)
     }
-
-    fn to_ast(&self) -> Expr {
-        match self {
-            QueryValue::Column { table, column } => {
-                Expr::CompoundIdentifier(vec![ident(*table), ident(*column)])
-            }
-            QueryValue::Param(value) => data_value_to_ast_expr(value),
-            QueryValue::Function { name, args } => Expr::Function(Function {
-                name: object_name(name),
-                uses_odbc_syntax: false,
-                parameters: FunctionArguments::None,
-                args: FunctionArguments::List(FunctionArgumentList {
-                    duplicate_treatment: None,
-                    args: args
-                        .iter()
-                        .map(QueryValue::to_ast)
-                        .map(FunctionArgExpr::Expr)
-                        .map(FunctionArg::Unnamed)
-                        .collect(),
-                    clauses: vec![],
-                }),
-                filter: None,
-                null_treatment: None,
-                over: None,
-                within_group: vec![],
-            }),
-        }
-    }
 }
 
 impl<M, T> From<Field<M, T>> for QueryValue {
@@ -455,9 +560,21 @@ impl<M, T> From<Field<M, T>> for QueryValue {
     }
 }
 
+impl From<Expr> for QueryValue {
+    fn from(value: Expr) -> Self {
+        QueryValue::from_ast(value)
+    }
+}
+
+impl From<Expr> for QueryExpr {
+    fn from(value: Expr) -> Self {
+        QueryExpr::from_ast(value)
+    }
+}
+
 impl<T: ToDataValue> From<T> for QueryValue {
     fn from(value: T) -> Self {
-        QueryValue::Param(value.to_data_value())
+        QueryValue::from_ast(data_value_to_ast_expr(&value.to_data_value()))
     }
 }
 
@@ -594,6 +711,14 @@ impl<Q: StatementSource, M: Model> SelectBuilder<Q, M> {
         self.push_filter(expr.not(), FilterMode::Replace)
     }
 
+    pub fn where_exists(self, subquery: Query) -> Self {
+        self.push_filter(QueryExpr::exists(subquery), FilterMode::Replace)
+    }
+
+    pub fn where_not_exists(self, subquery: Query) -> Self {
+        self.push_filter(QueryExpr::not_exists(subquery), FilterMode::Replace)
+    }
+
     fn push_order(mut self, order: SortExpr) -> Self {
         self.order_bys.push(order);
         self
@@ -617,15 +742,46 @@ impl<Q: StatementSource, M: Model> SelectBuilder<Q, M> {
         self
     }
 
-    fn statement(&self) -> Statement {
-        orm_select_query_statement(
+    pub fn into_query(self) -> Query {
+        let SelectBuilder {
+            source: _,
+            filter,
+            order_bys,
+            limit,
+            offset,
+            ..
+        } = self;
+
+        select_query(
+            M::table_name(),
+            select_projection(M::fields()),
+            filter,
+            order_bys,
+            limit,
+            offset,
+        )
+    }
+
+    fn into_statement(self) -> (Q, Statement) {
+        let SelectBuilder {
+            source,
+            filter,
+            order_bys,
+            limit,
+            offset,
+            ..
+        } = self;
+
+        let statement = orm_select_query_statement(
             M::table_name(),
             M::fields(),
-            self.filter.as_ref(),
-            &self.order_bys,
-            self.limit,
-            self.offset,
-        )
+            filter,
+            order_bys,
+            limit,
+            offset,
+        );
+
+        (source, statement)
     }
 
     impl_select_builder_compare_methods!(eq, ne, gt, gte, lt, lte);
@@ -634,9 +790,53 @@ impl<Q: StatementSource, M: Model> SelectBuilder<Q, M> {
 
     impl_select_builder_like_methods!(like, not_like);
 
+    pub fn in_list<L, I, V>(self, left: L, values: I) -> Self
+    where
+        L: Into<QueryValue>,
+        I: IntoIterator<Item = V>,
+        V: Into<QueryValue>,
+    {
+        self.push_filter(left.into().in_list(values), FilterMode::Replace)
+    }
+
+    pub fn not_in_list<L, I, V>(self, left: L, values: I) -> Self
+    where
+        L: Into<QueryValue>,
+        I: IntoIterator<Item = V>,
+        V: Into<QueryValue>,
+    {
+        self.push_filter(left.into().not_in_list(values), FilterMode::Replace)
+    }
+
+    pub fn between<L, Low, High>(self, expr: L, low: Low, high: High) -> Self
+    where
+        L: Into<QueryValue>,
+        Low: Into<QueryValue>,
+        High: Into<QueryValue>,
+    {
+        self.push_filter(expr.into().between(low, high), FilterMode::Replace)
+    }
+
+    pub fn not_between<L, Low, High>(self, expr: L, low: Low, high: High) -> Self
+    where
+        L: Into<QueryValue>,
+        Low: Into<QueryValue>,
+        High: Into<QueryValue>,
+    {
+        self.push_filter(expr.into().not_between(low, high), FilterMode::Replace)
+    }
+
+    pub fn in_subquery<L: Into<QueryValue>>(self, left: L, subquery: Query) -> Self {
+        self.push_filter(left.into().in_subquery(subquery), FilterMode::Replace)
+    }
+
+    pub fn not_in_subquery<L: Into<QueryValue>>(self, left: L, subquery: Query) -> Self {
+        self.push_filter(left.into().not_in_subquery(subquery), FilterMode::Replace)
+    }
+
     pub fn raw(self) -> Result<Q::Iter, DatabaseError> {
-        let statement = self.statement();
-        self.source.execute_statement(&statement, &[])
+        let (source, statement) = self.into_statement();
+        source.execute_statement(&statement, &[])
     }
 
     pub fn fetch(self) -> Result<OrmIter<Q::Iter, M>, DatabaseError> {
@@ -653,8 +853,9 @@ impl<Q: StatementSource, M: Model> SelectBuilder<Q, M> {
     }
 
     pub fn count(self) -> Result<usize, DatabaseError> {
-        let statement = orm_count_statement(M::table_name(), self.filter.as_ref());
-        let mut iter = self.source.execute_statement(&statement, &[])?;
+        let SelectBuilder { source, filter, .. } = self;
+        let statement = orm_count_statement(M::table_name(), filter);
+        let mut iter = source.execute_statement(&statement, &[])?;
         let count = match iter.next().transpose()? {
             Some(tuple) => match tuple.values.first() {
                 Some(DataValue::Int32(value)) => *value as usize,
@@ -743,8 +944,8 @@ fn select_projection(fields: &[OrmField]) -> Vec<SelectItem> {
 fn select_query(
     table_name: &str,
     projection: Vec<SelectItem>,
-    filter: Option<&QueryExpr>,
-    order_bys: &[SortExpr],
+    filter: Option<QueryExpr>,
+    order_bys: Vec<SortExpr>,
     limit: Option<usize>,
     offset: Option<usize>,
 ) -> Query {
@@ -763,7 +964,7 @@ fn select_query(
             from: vec![table_with_joins(table_name)],
             lateral_views: vec![],
             prewhere: None,
-            selection: filter.map(QueryExpr::to_ast),
+            selection: filter.map(QueryExpr::into_ast),
             connect_by: vec![],
             group_by: GroupByExpr::Expressions(vec![], vec![]),
             cluster_by: vec![],
@@ -777,7 +978,7 @@ fn select_query(
             flavor: SelectFlavor::Standard,
         }))),
         order_by: (!order_bys.is_empty()).then(|| OrderBy {
-            kind: OrderByKind::Expressions(order_bys.iter().map(SortExpr::to_ast).collect()),
+            kind: OrderByKind::Expressions(order_bys.into_iter().map(SortExpr::into_ast).collect()),
             interpolate: None,
         }),
         limit_clause: if limit.is_some() || offset.is_some() {
@@ -876,7 +1077,7 @@ pub fn orm_select_statement(table_name: &str, fields: &[OrmField]) -> Statement 
         table_name,
         select_projection(fields),
         None,
-        &[],
+        vec![],
         None,
         None,
     )))
@@ -1148,8 +1349,8 @@ pub fn orm_analyze_statement(table_name: &str) -> Statement {
 fn orm_select_query_statement(
     table_name: &str,
     fields: &[OrmField],
-    filter: Option<&QueryExpr>,
-    order_bys: &[SortExpr],
+    filter: Option<QueryExpr>,
+    order_bys: Vec<SortExpr>,
     limit: Option<usize>,
     offset: Option<usize>,
 ) -> Statement {
@@ -1163,7 +1364,7 @@ fn orm_select_query_statement(
     )))
 }
 
-fn orm_count_statement(table_name: &str, filter: Option<&QueryExpr>) -> Statement {
+fn orm_count_statement(table_name: &str, filter: Option<QueryExpr>) -> Statement {
     Statement::Query(Box::new(select_query(
         table_name,
         vec![SelectItem::UnnamedExpr(Expr::Function(Function {
@@ -1181,7 +1382,7 @@ fn orm_count_statement(table_name: &str, filter: Option<&QueryExpr>) -> Statemen
             within_group: vec![],
         }))],
         filter,
-        &[],
+        vec![],
         None,
         None,
     )))

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -437,18 +437,18 @@ mod test {
         })?;
 
         let adults = database
-            .select::<User>()
+            .from::<User>()
             .and(User::age().gte(18), User::name().like("A%"))
             .fetch()?
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(adults.len(), 1);
         assert_eq!(adults[0].name, "Alice");
 
-        let quoted = database.select::<User>().eq(User::name(), "A'lex").get()?;
+        let quoted = database.from::<User>().eq(User::name(), "A'lex").get()?;
         assert_eq!(quoted.unwrap().id, 3);
 
         let ordered = database
-            .select::<User>()
+            .from::<User>()
             .not(User::age().is_null())
             .desc(User::age())
             .limit(1)
@@ -456,16 +456,16 @@ mod test {
             .unwrap();
         assert_eq!(ordered.id, 2);
 
-        let count = database.select::<User>().is_not_null(User::age()).count()?;
+        let count = database.from::<User>().is_not_null(User::age()).count()?;
         assert_eq!(count, 2);
 
-        let exists = database.select::<User>().eq(User::id(), 2).exists()?;
+        let exists = database.from::<User>().eq(User::id(), 2).exists()?;
         assert!(exists);
-        let missing = database.select::<User>().eq(User::id(), 99).exists()?;
+        let missing = database.from::<User>().eq(User::id(), 99).exists()?;
         assert!(!missing);
 
         let two_users = database
-            .select::<User>()
+            .from::<User>()
             .or(User::id().eq(1), User::id().eq(2))
             .asc(User::id())
             .fetch()?
@@ -476,13 +476,13 @@ mod test {
         );
 
         let alice_only = database
-            .select::<User>()
+            .from::<User>()
             .and(User::age().is_not_null(), User::name().not_like("B%"))
             .count()?;
         assert_eq!(alice_only, 1);
 
         let in_list = database
-            .select::<User>()
+            .from::<User>()
             .in_list(User::id(), [1, 3])
             .asc(User::id())
             .fetch()?
@@ -493,7 +493,7 @@ mod test {
         );
 
         let not_between = database
-            .select::<User>()
+            .from::<User>()
             .not_between(User::id(), 2, 2)
             .asc(User::id())
             .fetch()?
@@ -504,7 +504,7 @@ mod test {
         );
 
         let either_named_a_or_missing_age = database
-            .select::<User>()
+            .from::<User>()
             .or(User::name().like("A%"), User::age().is_null())
             .asc(User::id())
             .fetch()?
@@ -518,34 +518,37 @@ mod test {
         );
 
         let udf_matched = database
-            .select::<User>()
+            .from::<User>()
             .eq(func("add_one", [QueryValue::from(User::id())]), 2)
             .get()?
             .unwrap();
         assert_eq!(udf_matched.id, 1);
 
         let cast_matched = database
-            .select::<User>()
+            .from::<User>()
             .eq(User::id().cast("BIGINT")?, 2_i64)
             .get()?
             .unwrap();
         assert_eq!(cast_matched.id, 2);
 
         let projected_ids = database
-            .project_value::<User, _>(User::id())
+            .from::<User>()
+            .project_value(User::id())
             .asc(User::id())
             .fetch::<i32>()?
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(projected_ids, vec![1, 2, 3]);
 
         let projected_name = database
-            .project_value::<User, _>(User::name())
+            .from::<User>()
+            .project_value(User::name())
             .eq(User::id(), 1)
             .get::<String>()?;
         assert_eq!(projected_name.as_deref(), Some("Alice"));
 
         let age_buckets = database
-            .project_value::<User, _>(case_when(
+            .from::<User>()
+            .project_value(case_when(
                 [
                     (User::age().is_null(), "unknown"),
                     (User::age().lt(20), "minor"),
@@ -558,24 +561,28 @@ mod test {
         assert_eq!(age_buckets, vec!["minor", "adult", "unknown"]);
 
         let id_labels = database
-            .project_value::<User, _>(case_value(User::id(), [(1, "one"), (2, "two")], "other"))
+            .from::<User>()
+            .project_value(case_value(User::id(), [(1, "one"), (2, "two")], "other"))
             .asc(User::id())
             .fetch::<String>()?
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(id_labels, vec!["one", "two", "other"]);
 
         let id_sum = database
-            .project_value::<User, _>(sum(User::id()))
+            .from::<User>()
+            .project_value(sum(User::id()))
             .get::<i32>()?;
         assert_eq!(id_sum, Some(6));
 
         let total_users = database
-            .project_value::<User, _>(count_all().alias("total_users"))
+            .from::<User>()
+            .project_value(count_all().alias("total_users"))
             .get::<i32>()?;
         assert_eq!(total_users, Some(3));
 
         let projected_user_rows = database
-            .project_tuple::<User, _>((User::id(), User::name()))
+            .from::<User>()
+            .project_tuple((User::id(), User::name()))
             .asc(User::id())
             .fetch::<(i32, String)>()?
             .collect::<Result<Vec<_>, _>>()?;
@@ -589,13 +596,14 @@ mod test {
         );
 
         let aliased_total_users = database
-            .project_value::<User, _>(count_all().alias("total_users"))
+            .from::<User>()
+            .project_value(count_all().alias("total_users"))
             .raw()?;
         assert_eq!(aliased_total_users.schema()[0].name(), "total_users");
         aliased_total_users.done()?;
 
         let raw_ast_matched = database
-            .select::<User>()
+            .from::<User>()
             .filter(QueryExpr::from_ast(SqlExpr::BinaryOp {
                 left: Box::new(QueryValue::from(User::id()).into_ast()),
                 op: SqlBinaryOperator::Eq,
@@ -606,21 +614,23 @@ mod test {
         assert_eq!(raw_ast_matched.id, 3);
 
         let exists_count = database
-            .select::<User>()
+            .from::<User>()
             .where_exists(
                 database
-                    .project_value::<User, _>(User::id())
+                    .from::<User>()
+                    .project_value(User::id())
                     .eq(User::id(), 2),
             )
             .count()?;
         assert_eq!(exists_count, 3);
 
         let in_subquery = database
-            .select::<User>()
+            .from::<User>()
             .in_subquery(
                 User::id(),
                 database
-                    .project_value::<User, _>(User::id())
+                    .from::<User>()
+                    .project_value(User::id())
                     .in_list(User::id(), [1, 3]),
             )
             .asc(User::id())
@@ -632,7 +642,7 @@ mod test {
         );
 
         let mut tx = database.new_transaction()?;
-        let in_tx = tx.select::<User>().eq(User::id(), 2).get()?.unwrap();
+        let in_tx = tx.from::<User>().eq(User::id(), 2).get()?.unwrap();
         assert_eq!(in_tx.name, "Bob");
         tx.commit()?;
 
@@ -663,7 +673,8 @@ mod test {
         })?;
 
         let repeated_categories = database
-            .project_value::<EventLog, _>(EventLog::category())
+            .from::<EventLog>()
+            .project_value(EventLog::category())
             .group_by(EventLog::category())
             .having(count_all().gt(1))
             .fetch::<String>()?
@@ -671,14 +682,16 @@ mod test {
         assert_eq!(repeated_categories, vec!["alpha"]);
 
         let grouped_count = database
-            .project_value::<EventLog, _>(EventLog::category())
+            .from::<EventLog>()
+            .project_value(EventLog::category())
             .group_by(EventLog::category())
             .having(count_all().gt(1))
             .count()?;
         assert_eq!(grouped_count, 1);
 
         let grouped_scores = database
-            .project_tuple::<EventLog, _>((
+            .from::<EventLog>()
+            .project_tuple((
                 EventLog::category(),
                 sum(EventLog::score()).alias("total_score"),
             ))

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -24,6 +24,7 @@ mod test {
     use kite_sql::expression::function::FunctionSummary;
     use kite_sql::expression::BinaryOperator;
     use kite_sql::expression::ScalarExpression;
+    use kite_sql::orm::{func, QueryValue};
     use kite_sql::types::evaluator::EvaluatorFactory;
     use kite_sql::types::tuple::{SchemaRef, Tuple};
     use kite_sql::types::value::{DataValue, Utf8Type};
@@ -401,7 +402,9 @@ mod test {
 
     #[test]
     fn test_orm_query_builder() -> Result<(), DatabaseError> {
-        let database = DataBaseBuilder::path(".").build_in_memory()?;
+        let database = DataBaseBuilder::path(".")
+            .register_scala_function(MyOrmFunction::new())
+            .build_in_memory()?;
 
         database.create_table::<User>()?;
         database.run("drop index users.users_age_index")?.done()?;
@@ -426,46 +429,72 @@ mod test {
 
         let adults = database
             .select::<User>()
-            .filter(User::age().gte(18).and(User::name().like("A%")))
+            .and(User::age().gte(18), User::name().like("A%"))
             .fetch()?
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(adults.len(), 1);
         assert_eq!(adults[0].name, "Alice");
 
-        let quoted = database
-            .select::<User>()
-            .filter(User::name().eq("A'lex"))
-            .get()?;
+        let quoted = database.select::<User>().eq(User::name(), "A'lex").get()?;
         assert_eq!(quoted.unwrap().id, 3);
 
         let ordered = database
             .select::<User>()
-            .filter(User::age().is_null().not())
-            .order_by(User::age().desc())
+            .not(User::age().is_null())
+            .desc(User::age())
             .limit(1)
             .get()?
             .unwrap();
         assert_eq!(ordered.id, 2);
 
-        let count = database
-            .select::<User>()
-            .filter(User::age().is_not_null())
-            .count()?;
+        let count = database.select::<User>().is_not_null(User::age()).count()?;
         assert_eq!(count, 2);
 
-        let exists = database
-            .select::<User>()
-            .filter(User::id().eq(2))
-            .exists()?;
+        let exists = database.select::<User>().eq(User::id(), 2).exists()?;
         assert!(exists);
-        let missing = database
-            .select::<User>()
-            .filter(User::id().eq(99))
-            .exists()?;
+        let missing = database.select::<User>().eq(User::id(), 99).exists()?;
         assert!(!missing);
 
+        let two_users = database
+            .select::<User>()
+            .or(User::id().eq(1), User::id().eq(2))
+            .asc(User::id())
+            .fetch()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            two_users.iter().map(|user| user.id).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+
+        let alice_only = database
+            .select::<User>()
+            .and(User::age().is_not_null(), User::name().not_like("B%"))
+            .count()?;
+        assert_eq!(alice_only, 1);
+
+        let either_named_a_or_missing_age = database
+            .select::<User>()
+            .or(User::name().like("A%"), User::age().is_null())
+            .asc(User::id())
+            .fetch()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            either_named_a_or_missing_age
+                .iter()
+                .map(|user| user.id)
+                .collect::<Vec<_>>(),
+            vec![1, 3]
+        );
+
+        let udf_matched = database
+            .select::<User>()
+            .eq(func("add_one", [QueryValue::from(User::id())]), 2)
+            .get()?
+            .unwrap();
+        assert_eq!(udf_matched.id, 1);
+
         let mut tx = database.new_transaction()?;
-        let in_tx = tx.select::<User>().filter(User::id().eq(2)).get()?.unwrap();
+        let in_tx = tx.select::<User>().eq(User::id(), 2).get()?.unwrap();
         assert_eq!(in_tx.name, "Bob");
         tx.commit()?;
 
@@ -632,6 +661,10 @@ mod test {
 
     scala_function!(MyScalaFunction::SUM(LogicalType::Integer, LogicalType::Integer) -> LogicalType::Integer => (|v1: DataValue, v2: DataValue| {
         EvaluatorFactory::binary_create(LogicalType::Integer, BinaryOperator::Plus)?.binary_eval(&v1, &v2)
+    }));
+
+    scala_function!(MyOrmFunction::ADD_ONE(LogicalType::Integer) -> LogicalType::Integer => (|v1: DataValue| {
+        Ok(DataValue::Int32(v1.i32().unwrap() + 1))
     }));
 
     table_function!(MyTableFunction::TEST_NUMBERS(LogicalType::Integer) -> [c1: LogicalType::Integer, c2: LogicalType::Integer] => (|v1: DataValue| {

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -478,6 +478,16 @@ mod test {
             amount: 300,
         })?;
 
+        database.create_table::<Wallet>()?;
+        database.insert(&Wallet {
+            id: 1,
+            balance: Decimal::new(5000, 2),
+        })?;
+        database.insert(&Wallet {
+            id: 3,
+            balance: Decimal::new(1250, 2),
+        })?;
+
         let adults = database
             .from::<User>()
             .and(User::age().gte(18), User::name().like("A%"))
@@ -976,6 +986,22 @@ mod test {
             ]
         );
 
+        let using_joined_rows = database
+            .from::<User>()
+            .inner_join::<Wallet>()
+            .using(User::id())
+            .project_tuple((User::name(), Wallet::balance()))
+            .asc(User::id())
+            .fetch::<(String, Decimal)>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            using_joined_rows,
+            vec![
+                ("Alice".to_string(), Decimal::new(5000, 2)),
+                ("A'lex".to_string(), Decimal::new(1250, 2)),
+            ]
+        );
+
         let left_joined_rows = database
             .from::<User>()
             .alias("u")
@@ -1000,6 +1026,7 @@ mod test {
         assert_eq!(in_tx.name, "Bob");
         tx.commit()?;
 
+        database.drop_table::<Wallet>()?;
         database.drop_table::<Order>()?;
         database.drop_table::<User>()?;
 

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -116,6 +116,15 @@ mod test {
     }
 
     #[derive(Default, Debug, PartialEq, Model)]
+    #[model(table = "event_logs")]
+    struct EventLog {
+        #[model(primary_key)]
+        id: i32,
+        category: String,
+        score: i32,
+    }
+
+    #[derive(Default, Debug, PartialEq, Model)]
     #[model(table = "migrating_users")]
     struct MigratingUserV1 {
         #[model(primary_key)]
@@ -614,6 +623,47 @@ mod test {
         tx.commit()?;
 
         database.drop_table::<User>()?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_orm_group_by_builder() -> Result<(), DatabaseError> {
+        let database = DataBaseBuilder::path(".").build_in_memory()?;
+
+        database.create_table::<EventLog>()?;
+        database.insert(&EventLog {
+            id: 1,
+            category: "alpha".to_string(),
+            score: 10,
+        })?;
+        database.insert(&EventLog {
+            id: 2,
+            category: "alpha".to_string(),
+            score: 20,
+        })?;
+        database.insert(&EventLog {
+            id: 3,
+            category: "beta".to_string(),
+            score: 5,
+        })?;
+
+        let repeated_categories = database
+            .project_value::<EventLog, _>(EventLog::category())
+            .group_by(EventLog::category())
+            .having(count_all().gt(1))
+            .fetch::<String>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(repeated_categories, vec!["alpha"]);
+
+        let grouped_count = database
+            .project_value::<EventLog, _>(EventLog::category())
+            .group_by(EventLog::category())
+            .having(count_all().gt(1))
+            .count()?;
+        assert_eq!(grouped_count, 1);
+
+        database.drop_table::<EventLog>()?;
 
         Ok(())
     }

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -24,7 +24,7 @@ mod test {
     use kite_sql::expression::function::FunctionSummary;
     use kite_sql::expression::BinaryOperator;
     use kite_sql::expression::ScalarExpression;
-    use kite_sql::orm::{case_value, case_when, count_all, func, max, min, sum, QueryValue};
+    use kite_sql::orm::{case_when, count_all, func, max, min, sum, QueryValue};
     use kite_sql::types::evaluator::EvaluatorFactory;
     use kite_sql::types::tuple::{SchemaRef, Tuple};
     use kite_sql::types::value::{DataValue, Utf8Type};
@@ -531,11 +531,13 @@ mod test {
             vec![1, 2]
         );
 
-        let alice_only = database
-            .from::<User>()
-            .and(User::age().is_not_null(), User::name().not_like("B%"))
-            .count()?;
-        assert_eq!(alice_only, 1);
+        assert_eq!(
+            database
+                .from::<User>()
+                .and(User::age().is_not_null(), User::name().not_like("B%"))
+                .count()?,
+            1
+        );
 
         let in_list = database
             .from::<User>()
@@ -545,17 +547,6 @@ mod test {
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(
             in_list.iter().map(|user| user.id).collect::<Vec<_>>(),
-            vec![1, 3]
-        );
-
-        let not_between = database
-            .from::<User>()
-            .not_between(User::id(), 2, 2)
-            .asc(User::id())
-            .fetch()?
-            .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(
-            not_between.iter().map(|user| user.id).collect::<Vec<_>>(),
             vec![1, 3]
         );
 
@@ -573,26 +564,12 @@ mod test {
             vec![1, 3]
         );
 
-        let udf_matched = database
-            .from::<User>()
-            .eq(func("add_one", [QueryValue::from(User::id())]), 2)
-            .get()?
-            .unwrap();
-        assert_eq!(udf_matched.id, 1);
-
         let query_value_function_matched = database
             .from::<User>()
             .eq(QueryValue::function("add_one", [User::id()]), 3)
             .get()?
             .unwrap();
         assert_eq!(query_value_function_matched.id, 2);
-
-        let cast_matched = database
-            .from::<User>()
-            .eq(User::id().cast("BIGINT")?, 2_i64)
-            .get()?
-            .unwrap();
-        assert_eq!(cast_matched.id, 2);
 
         let cast_to_matched = database
             .from::<User>()
@@ -607,28 +584,6 @@ mod test {
             .get()?
             .unwrap();
         assert_eq!(add_matched.id, 2);
-
-        let sub_matched = database
-            .from::<User>()
-            .eq(User::id().sub(1), 2)
-            .get()?
-            .unwrap();
-        assert_eq!(sub_matched.id, 3);
-
-        let neg_matched = database
-            .from::<User>()
-            .eq(User::id().neg(), -1)
-            .get()?
-            .unwrap();
-        assert_eq!(neg_matched.id, 1);
-
-        let projected_ids = database
-            .from::<User>()
-            .project_value(User::id())
-            .asc(User::id())
-            .fetch::<i32>()?
-            .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(projected_ids, vec![1, 2, 3]);
 
         let arithmetic_projection = database
             .from::<User>()
@@ -666,31 +621,6 @@ mod test {
             .fetch::<String>()?
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(age_buckets, vec!["minor", "adult", "unknown"]);
-
-        let searched_case_buckets = database
-            .from::<User>()
-            .project_value(
-                QueryValue::searched_case(
-                    [
-                        (User::age().is_null(), "unknown"),
-                        (User::age().lt(20), "minor"),
-                    ],
-                    "adult",
-                )
-                .alias("age_bucket"),
-            )
-            .asc(User::id())
-            .fetch::<String>()?
-            .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(searched_case_buckets, vec!["minor", "adult", "unknown"]);
-
-        let id_labels = database
-            .from::<User>()
-            .project_value(case_value(User::id(), [(1, "one"), (2, "two")], "other"))
-            .asc(User::id())
-            .fetch::<String>()?
-            .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(id_labels, vec!["one", "two", "other"]);
 
         let simple_case_labels = database
             .from::<User>()
@@ -841,38 +771,31 @@ mod test {
         );
         projected_schema.done()?;
 
-        let exists_count = database
-            .from::<User>()
-            .where_exists(
-                database
-                    .from::<User>()
-                    .project_value(User::id())
-                    .eq(User::id(), 2),
-            )
-            .count()?;
-        assert_eq!(exists_count, 3);
+        assert_eq!(
+            database
+                .from::<User>()
+                .where_exists(
+                    database
+                        .from::<User>()
+                        .project_value(User::id())
+                        .eq(User::id(), 2),
+                )
+                .count()?,
+            3
+        );
 
-        let not_exists_count = database
-            .from::<User>()
-            .where_not_exists(
-                database
-                    .from::<User>()
-                    .project_value(User::id())
-                    .eq(User::id(), 99),
-            )
-            .count()?;
-        assert_eq!(not_exists_count, 3);
-
-        let blocked_by_not_exists = database
-            .from::<User>()
-            .where_not_exists(
-                database
-                    .from::<User>()
-                    .project_value(User::id())
-                    .eq(User::id(), 2),
-            )
-            .count()?;
-        assert_eq!(blocked_by_not_exists, 0);
+        assert_eq!(
+            database
+                .from::<User>()
+                .where_not_exists(
+                    database
+                        .from::<User>()
+                        .project_value(User::id())
+                        .eq(User::id(), 2),
+                )
+                .count()?,
+            0
+        );
 
         let in_subquery = database
             .from::<User>()
@@ -889,25 +812,6 @@ mod test {
         assert_eq!(
             in_subquery.iter().map(|user| user.id).collect::<Vec<_>>(),
             vec![1, 3]
-        );
-
-        let not_in_subquery = database
-            .from::<User>()
-            .not_in_subquery(
-                User::id(),
-                database
-                    .from::<User>()
-                    .project_value(User::id())
-                    .in_list(User::id(), [1, 3]),
-            )
-            .fetch()?
-            .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(
-            not_in_subquery
-                .iter()
-                .map(|user| user.id)
-                .collect::<Vec<_>>(),
-            vec![2]
         );
 
         let aliased_user = database
@@ -932,37 +836,6 @@ mod test {
                 age: Some(30),
             })
         );
-
-        let joined_rows = database
-            .from::<User>()
-            .alias("u")
-            .inner_join::<Order>()
-            .alias("o")
-            .on(User::id().qualify("u").eq(Order::user_id().qualify("o")))
-            .project_tuple((
-                User::name().qualify("u").alias("user_name"),
-                Order::amount().qualify("o").alias("order_amount"),
-            ))
-            .asc(Order::id().qualify("o"))
-            .fetch::<(String, i32)>()?
-            .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(
-            joined_rows,
-            vec![
-                ("Alice".to_string(), 100),
-                ("Alice".to_string(), 200),
-                ("Bob".to_string(), 300),
-            ]
-        );
-
-        let joined_count = database
-            .from::<User>()
-            .alias("u")
-            .inner_join::<Order>()
-            .alias("o")
-            .on(User::id().qualify("u").eq(Order::user_id().qualify("o")))
-            .count()?;
-        assert_eq!(joined_count, 3);
 
         let joined_projection = database
             .from::<User>()
@@ -1006,109 +879,28 @@ mod test {
             ]
         );
 
-        let mut right_joined_rows = database
-            .from::<User>()
-            .right_join::<Wallet>()
-            .on(User::id().eq(Wallet::id()))
-            .project_tuple((User::name(), Wallet::id()))
-            .fetch::<(Option<String>, i32)>()?
-            .collect::<Result<Vec<_>, _>>()?;
-        right_joined_rows.sort_by_key(|(_, wallet_id)| *wallet_id);
-        assert_eq!(
-            right_joined_rows,
-            vec![
-                (Some("Alice".to_string()), 1),
-                (Some("A'lex".to_string()), 3),
-                (None, 4),
-            ]
-        );
-
-        let mut full_joined_rows = database
+        let full_joined_rows = database
             .from::<User>()
             .full_join::<Wallet>()
             .using(User::id())
             .project_tuple((User::id(), Wallet::id()))
             .fetch::<(Option<i32>, Option<i32>)>()?
             .collect::<Result<Vec<_>, _>>()?;
-        full_joined_rows.sort_by_key(|(user_id, wallet_id)| {
-            (user_id.unwrap_or(i32::MAX), wallet_id.unwrap_or(i32::MAX))
-        });
-        assert_eq!(
-            full_joined_rows,
-            vec![
-                (Some(1), Some(1)),
-                (Some(2), None),
-                (Some(3), Some(3)),
-                (None, Some(4))
-            ]
-        );
+        assert_eq!(full_joined_rows.len(), 4);
 
-        let cross_joined_count = database.from::<User>().cross_join::<Wallet>().count()?;
-        assert_eq!(cross_joined_count, 9);
-
-        let cross_joined_rows = database
+        let union_tuple = database
             .from::<User>()
-            .cross_join::<Wallet>()
-            .project_tuple((User::id(), Wallet::id()))
-            .asc(User::id())
-            .asc(Wallet::id())
-            .fetch::<(i32, i32)>()?
-            .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(
-            cross_joined_rows,
-            vec![
-                (1, 1),
-                (1, 3),
-                (1, 4),
-                (2, 1),
-                (2, 3),
-                (2, 4),
-                (3, 1),
-                (3, 3),
-                (3, 4),
-            ]
-        );
-
-        let mut union_ids = database
-            .from::<User>()
-            .project_value(User::id())
-            .union(database.from::<Order>().project_value(Order::user_id()))
-            .fetch::<i32>()?
-            .collect::<Result<Vec<_>, _>>()?;
-        union_ids.sort();
-        assert_eq!(union_ids, vec![1, 2, 3]);
-
-        let union_count = database
-            .from::<User>()
-            .project_value(User::id())
-            .union(database.from::<Order>().project_value(Order::user_id()))
-            .count()?;
-        assert_eq!(union_count, 3);
-
-        let union_exists = database
-            .from::<User>()
-            .project_value(User::id())
-            .union(database.from::<Order>().project_value(Order::user_id()))
-            .exists()?;
-        assert!(union_exists);
-
-        let mut union_all_ids = database
-            .from::<User>()
-            .project_value(User::id())
-            .union(database.from::<Order>().project_value(Order::user_id()))
+            .eq(User::id(), 2)
+            .project_tuple((User::id(), User::name()))
+            .union(
+                database
+                    .from::<User>()
+                    .eq(User::id(), 2)
+                    .project_tuple((User::id(), User::name())),
+            )
             .all()
-            .fetch::<i32>()?
-            .collect::<Result<Vec<_>, _>>()?;
-        union_all_ids.sort();
-        assert_eq!(union_all_ids, vec![1, 1, 1, 2, 2, 3]);
-
-        let union_all_count = database
-            .from::<User>()
-            .project_value(User::id())
-            .union(database.from::<Order>().project_value(Order::user_id()))
-            .all()
-            .count()?;
-        assert_eq!(union_all_count, 6);
+            .get::<(i32, String)>()?;
+        assert_eq!(union_tuple, Some((2, "Bob".to_string())));
 
         let ordered_union_ids = database
             .from::<User>()
@@ -1121,41 +913,6 @@ mod test {
             .fetch::<i32>()?
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(ordered_union_ids, vec![1, 1, 2]);
-
-        let ordered_union_count = database
-            .from::<User>()
-            .project_value(User::id())
-            .union(database.from::<Order>().project_value(Order::user_id()))
-            .all()
-            .asc(User::id())
-            .limit(2)
-            .count()?;
-        assert_eq!(ordered_union_count, 2);
-
-        let except_ids = database
-            .from::<Order>()
-            .project_value(Order::user_id())
-            .except(database.from::<User>().project_value(User::id()))
-            .fetch::<i32>()?
-            .collect::<Result<Vec<_>, _>>()?;
-        assert!(except_ids.is_empty());
-
-        let except_exists = database
-            .from::<Order>()
-            .project_value(Order::user_id())
-            .except(database.from::<User>().project_value(User::id()))
-            .exists()?;
-        assert!(!except_exists);
-
-        let except_all_ids = database
-            .from::<Order>()
-            .project_value(Order::user_id())
-            .except(database.from::<User>().project_value(User::id()))
-            .all()
-            .asc(Order::user_id())
-            .fetch::<i32>()?
-            .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(except_all_ids, vec![1]);
 
         let users_without_orders = database
             .from::<User>()
@@ -1317,6 +1074,72 @@ mod test {
                 .collect::<Vec<_>>(),
             vec![3]
         );
+
+        database
+            .from::<User>()
+            .filter(
+                User::id().in_subquery(
+                    database
+                        .from::<Order>()
+                        .project_value(Order::user_id())
+                        .eq(Order::user_id(), User::id()),
+                ),
+            )
+            .asc(User::id())
+            .raw()?
+            .done()?;
+
+        database
+            .from::<User>()
+            .filter(
+                User::id().not_in_subquery(
+                    database
+                        .from::<Order>()
+                        .project_value(Order::user_id())
+                        .eq(Order::user_id(), User::id()),
+                ),
+            )
+            .asc(User::id())
+            .raw()?
+            .done()?;
+
+        database
+            .from::<User>()
+            .filter(
+                User::id().in_subquery(
+                    database
+                        .from::<Order>()
+                        .project_value(Order::user_id())
+                        .eq(Order::amount(), 100)
+                        .union(
+                            database
+                                .from::<Order>()
+                                .project_value(Order::user_id())
+                                .eq(Order::amount(), 300),
+                        )
+                        .all(),
+                ),
+            )
+            .asc(User::id())
+            .raw()?
+            .done()?;
+
+        let correlated_exists_with_union = database
+            .from::<User>()
+            .filter(kite_sql::orm::QueryExpr::exists(
+                database
+                    .from::<Order>()
+                    .project_value(Order::id())
+                    .eq(Order::user_id(), User::id())
+                    .union(
+                        database
+                            .from::<Order>()
+                            .project_value(Order::id())
+                            .eq(Order::amount(), 300),
+                    ),
+            ))
+            .count();
+        assert!(correlated_exists_with_union.is_err());
 
         let max_id_user = database
             .from::<User>()

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -31,12 +31,7 @@ mod test {
     use kite_sql::types::LogicalType;
     use kite_sql::{from_tuple, scala_function, table_function, Model};
     use rust_decimal::Decimal;
-    use sqlparser::ast::{
-        BinaryOperator as SqlBinaryOperator, CharLengthUnits, Expr as SqlExpr, Query as SqlQuery,
-        Statement as SqlStatement,
-    };
-    use sqlparser::dialect::PostgreSqlDialect;
-    use sqlparser::parser::Parser;
+    use sqlparser::ast::{BinaryOperator as SqlBinaryOperator, CharLengthUnits, Expr as SqlExpr};
     use std::sync::Arc;
 
     fn build_tuple() -> (Tuple, SchemaRef) {
@@ -68,15 +63,6 @@ mod test {
         ];
 
         (Tuple::new(None, values), schema_ref)
-    }
-
-    fn parse_query(sql: &str) -> SqlQuery {
-        let dialect = PostgreSqlDialect {};
-        let mut parser = Parser::new(&dialect).try_with_sql(sql).unwrap();
-        match parser.parse_statement().unwrap() {
-            SqlStatement::Query(query) => *query,
-            statement => panic!("expected query statement, got {statement:?}"),
-        }
     }
 
     #[derive(Default, Debug, PartialEq)]
@@ -536,6 +522,19 @@ mod test {
             .unwrap();
         assert_eq!(cast_matched.id, 2);
 
+        let projected_ids = database
+            .project_value::<User, _>(User::id())
+            .asc(User::id())
+            .fetch::<i32>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(projected_ids, vec![1, 2, 3]);
+
+        let projected_name = database
+            .project_value::<User, _>(User::name())
+            .eq(User::id(), 1)
+            .get::<String>()?;
+        assert_eq!(projected_name.as_deref(), Some("Alice"));
+
         let raw_ast_matched = database
             .select::<User>()
             .filter(QueryExpr::from_ast(SqlExpr::BinaryOp {
@@ -549,7 +548,11 @@ mod test {
 
         let exists_count = database
             .select::<User>()
-            .where_exists(parse_query("select id from users where id = 2"))
+            .where_exists(
+                database
+                    .project_value::<User, _>(User::id())
+                    .eq(User::id(), 2),
+            )
             .count()?;
         assert_eq!(exists_count, 3);
 
@@ -557,7 +560,9 @@ mod test {
             .select::<User>()
             .in_subquery(
                 User::id(),
-                parse_query("select id from users where id in (1, 3)"),
+                database
+                    .project_value::<User, _>(User::id())
+                    .in_list(User::id(), [1, 3]),
             )
             .asc(User::id())
             .fetch()?

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -1673,6 +1673,124 @@ mod test {
     }
 
     #[test]
+    fn test_orm_extended_write_and_ddl_helpers() -> Result<(), DatabaseError> {
+        let database = DataBaseBuilder::path(".").build_in_memory()?;
+        database.create_table::<User>()?;
+
+        database.insert_many([
+            User {
+                id: 1,
+                name: "Alice".to_string(),
+                age: Some(18),
+                cache: String::new(),
+            },
+            User {
+                id: 2,
+                name: "Bob".to_string(),
+                age: None,
+                cache: String::new(),
+            },
+            User {
+                id: 3,
+                name: "Carol".to_string(),
+                age: Some(30),
+                cache: String::new(),
+            },
+        ])?;
+
+        let ages_nulls_first = database
+            .from::<User>()
+            .project_value(User::age())
+            .asc(User::age())
+            .nulls_first()
+            .fetch::<Option<i32>>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(ages_nulls_first, vec![None, Some(18), Some(30)]);
+
+        let ages_nulls_last = database
+            .from::<User>()
+            .project_value(User::age())
+            .asc(User::age())
+            .nulls_last()
+            .fetch::<Option<i32>>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(ages_nulls_last, vec![Some(18), Some(30), None]);
+
+        let set_query_ages = database
+            .from::<User>()
+            .project_value(User::age())
+            .eq(User::id(), 1)
+            .union(database.from::<User>().project_value(User::age()))
+            .all()
+            .desc(User::age())
+            .nulls_first()
+            .fetch::<Option<i32>>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(set_query_ages, vec![None, Some(30), Some(18), Some(18)]);
+
+        let mut tx = database.new_transaction()?;
+        tx.insert_many([User {
+            id: 4,
+            name: "Dora".to_string(),
+            age: None,
+            cache: String::new(),
+        }])?;
+        tx.commit()?;
+
+        let updated_users = database
+            .from::<User>()
+            .asc(User::id())
+            .fetch()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            updated_users
+                .iter()
+                .map(|user| (user.id, user.name.as_str()))
+                .collect::<Vec<_>>(),
+            vec![(1, "Alice"), (2, "Bob"), (3, "Carol"), (4, "Dora")]
+        );
+
+        database.create_view(
+            "user_names",
+            database
+                .from::<User>()
+                .project_tuple((User::id(), User::name())),
+        )?;
+
+        let mut view_rows = database
+            .run("select * from user_names")?
+            .orm::<UserNameSnapshot>()
+            .collect::<Result<Vec<_>, _>>()?;
+        view_rows.sort_by_key(|row| row.id);
+        assert_eq!(view_rows.len(), 4);
+        assert_eq!(view_rows[0].name, "Alice");
+
+        database.create_or_replace_view(
+            "user_names",
+            database
+                .from::<User>()
+                .eq(User::id(), 2)
+                .project_tuple((User::id(), User::name())),
+        )?;
+
+        let replaced_view_rows = database
+            .run("select * from user_names")?
+            .orm::<UserNameSnapshot>()
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(replaced_view_rows.len(), 1);
+        assert_eq!(replaced_view_rows[0].id, 2);
+        assert_eq!(replaced_view_rows[0].name, "Bob");
+
+        database.drop_view("user_names")?;
+        database.drop_view_if_exists("user_names")?;
+
+        database.truncate::<User>()?;
+        assert_eq!(database.from::<User>().count()?, 0);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_orm_drop_index() -> Result<(), DatabaseError> {
         let database = DataBaseBuilder::path(".").build_in_memory()?;
 

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -553,6 +553,27 @@ mod test {
             .unwrap();
         assert_eq!(cast_to_matched.id, 3);
 
+        let add_matched = database
+            .from::<User>()
+            .eq(User::id().add(1), 3)
+            .get()?
+            .unwrap();
+        assert_eq!(add_matched.id, 2);
+
+        let sub_matched = database
+            .from::<User>()
+            .eq(User::id().sub(1), 2)
+            .get()?
+            .unwrap();
+        assert_eq!(sub_matched.id, 3);
+
+        let neg_matched = database
+            .from::<User>()
+            .eq(User::id().neg(), -1)
+            .get()?
+            .unwrap();
+        assert_eq!(neg_matched.id, 1);
+
         let projected_ids = database
             .from::<User>()
             .project_value(User::id())
@@ -560,6 +581,22 @@ mod test {
             .fetch::<i32>()?
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(projected_ids, vec![1, 2, 3]);
+
+        let arithmetic_projection = database
+            .from::<User>()
+            .project_tuple((
+                User::id(),
+                User::id().mul(10).alias("times_ten"),
+                User::id().div(2).alias("half_id"),
+                User::id().modulo(2).alias("id_mod_2"),
+            ))
+            .asc(User::id())
+            .fetch::<(i32, i32, i32, i32)>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            arithmetic_projection,
+            vec![(1, 10, 0, 1), (2, 20, 1, 0), (3, 30, 1, 1)]
+        );
 
         let projected_name = database
             .from::<User>()
@@ -617,6 +654,17 @@ mod test {
             .fetch::<String>()?
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(simple_case_labels, vec!["one", "two", "other"]);
+
+        let arithmetic_query_value = database
+            .from::<User>()
+            .project_value(
+                QueryValue::function("add_one", [User::id()])
+                    .add(10)
+                    .alias("boosted_id"),
+            )
+            .eq(User::id(), 1)
+            .get::<i32>()?;
+        assert_eq!(arithmetic_query_value, Some(12));
 
         let id_sum = database
             .from::<User>()

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -862,6 +862,27 @@ mod test {
             vec![2]
         );
 
+        let aliased_user = database
+            .from_alias::<User>("u")
+            .eq(User::id().qualify("u"), 2)
+            .get()?
+            .unwrap();
+        assert_eq!(aliased_user.name, "Bob");
+
+        let aliased_projection = database
+            .from_alias::<User>("u")
+            .project::<UserSummary>()
+            .eq(User::id().qualify("u"), 2)
+            .get()?;
+        assert_eq!(
+            aliased_projection,
+            Some(UserSummary {
+                id: 2,
+                display_name: "Bob".to_string(),
+                age: Some(30),
+            })
+        );
+
         let mut tx = database.new_transaction()?;
         let in_tx = tx.from::<User>().eq(User::id(), 2).get()?.unwrap();
         assert_eq!(in_tx.name, "Bob");

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -1208,6 +1208,154 @@ mod test {
     }
 
     #[test]
+    fn test_orm_expression_and_set_query_helpers() -> Result<(), DatabaseError> {
+        let database = DataBaseBuilder::path(".").build_in_memory()?;
+
+        database.create_table::<User>()?;
+        database.insert(&User {
+            id: 1,
+            name: "Alice".to_string(),
+            age: Some(18),
+            cache: "".to_string(),
+        })?;
+        database.insert(&User {
+            id: 2,
+            name: "Bob".to_string(),
+            age: Some(30),
+            cache: "".to_string(),
+        })?;
+        database.insert(&User {
+            id: 3,
+            name: "Carol".to_string(),
+            age: None,
+            cache: "".to_string(),
+        })?;
+
+        database.create_table::<Order>()?;
+        database.insert(&Order {
+            id: 1,
+            user_id: 1,
+            amount: 100,
+        })?;
+        database.insert(&Order {
+            id: 2,
+            user_id: 1,
+            amount: 200,
+        })?;
+        database.insert(&Order {
+            id: 3,
+            user_id: 2,
+            amount: 300,
+        })?;
+
+        let exists_count = database
+            .from::<User>()
+            .filter(kite_sql::orm::QueryExpr::exists(
+                database
+                    .from::<Order>()
+                    .project_value(Order::id())
+                    .eq(Order::id(), 1),
+            ))
+            .count()?;
+        assert_eq!(exists_count, 3);
+
+        let not_exists_count = database
+            .from::<User>()
+            .filter(kite_sql::orm::QueryExpr::not_exists(
+                database
+                    .from::<Order>()
+                    .project_value(Order::id())
+                    .eq(Order::id(), 99),
+            ))
+            .count()?;
+        assert_eq!(not_exists_count, 3);
+
+        let blocked_by_not_exists = database
+            .from::<User>()
+            .filter(kite_sql::orm::QueryExpr::not_exists(
+                database
+                    .from::<Order>()
+                    .project_value(Order::id())
+                    .eq(Order::id(), 1),
+            ))
+            .count()?;
+        assert_eq!(blocked_by_not_exists, 0);
+
+        let max_id_user = database
+            .from::<User>()
+            .eq(
+                User::id(),
+                QueryValue::subquery(database.from::<User>().project_value(max(User::id()))),
+            )
+            .get()?
+            .unwrap();
+        assert_eq!(max_id_user.id, 3);
+
+        let union_user = database
+            .from::<User>()
+            .eq(User::id(), 2)
+            .union(database.from::<User>().eq(User::id(), 2))
+            .all()
+            .get()?
+            .unwrap();
+        assert_eq!(union_user.id, 2);
+
+        let union_value = database
+            .from::<User>()
+            .project_value(User::id())
+            .eq(User::id(), 2)
+            .union(
+                database
+                    .from::<Order>()
+                    .project_value(Order::user_id())
+                    .eq(Order::user_id(), 2),
+            )
+            .all()
+            .get::<i32>()?;
+        assert_eq!(union_value, Some(2));
+
+        let union_tuple = database
+            .from::<User>()
+            .eq(User::id(), 2)
+            .project_tuple((User::id(), User::name()))
+            .union(
+                database
+                    .from::<User>()
+                    .eq(User::id(), 2)
+                    .project_tuple((User::id(), User::name())),
+            )
+            .all()
+            .get::<(i32, String)>()?;
+        assert_eq!(union_tuple, Some((2, "Bob".to_string())));
+
+        let union_projection = database
+            .from::<User>()
+            .eq(User::id(), 2)
+            .project::<UserSummary>()
+            .union(
+                database
+                    .from::<User>()
+                    .eq(User::id(), 2)
+                    .project::<UserSummary>(),
+            )
+            .all()
+            .get()?;
+        assert_eq!(
+            union_projection,
+            Some(UserSummary {
+                id: 2,
+                display_name: "Bob".to_string(),
+                age: Some(30),
+            })
+        );
+
+        database.drop_table::<Order>()?;
+        database.drop_table::<User>()?;
+
+        Ok(())
+    }
+
+    #[test]
     fn test_orm_group_by_builder() -> Result<(), DatabaseError> {
         let database = DataBaseBuilder::path(".").build_in_memory()?;
 

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -487,6 +487,10 @@ mod test {
             id: 3,
             balance: Decimal::new(1250, 2),
         })?;
+        database.insert(&Wallet {
+            id: 4,
+            balance: Decimal::new(9999, 2),
+        })?;
 
         let adults = database
             .from::<User>()
@@ -999,6 +1003,69 @@ mod test {
             vec![
                 ("Alice".to_string(), Decimal::new(5000, 2)),
                 ("A'lex".to_string(), Decimal::new(1250, 2)),
+            ]
+        );
+
+        let mut right_joined_rows = database
+            .from::<User>()
+            .right_join::<Wallet>()
+            .on(User::id().eq(Wallet::id()))
+            .project_tuple((User::name(), Wallet::id()))
+            .fetch::<(Option<String>, i32)>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        right_joined_rows.sort_by_key(|(_, wallet_id)| *wallet_id);
+        assert_eq!(
+            right_joined_rows,
+            vec![
+                (Some("Alice".to_string()), 1),
+                (Some("A'lex".to_string()), 3),
+                (None, 4),
+            ]
+        );
+
+        let mut full_joined_rows = database
+            .from::<User>()
+            .full_join::<Wallet>()
+            .using(User::id())
+            .project_tuple((User::id(), Wallet::id()))
+            .fetch::<(Option<i32>, Option<i32>)>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        full_joined_rows.sort_by_key(|(user_id, wallet_id)| {
+            (user_id.unwrap_or(i32::MAX), wallet_id.unwrap_or(i32::MAX))
+        });
+        assert_eq!(
+            full_joined_rows,
+            vec![
+                (Some(1), Some(1)),
+                (Some(2), None),
+                (Some(3), Some(3)),
+                (None, Some(4))
+            ]
+        );
+
+        let cross_joined_count = database.from::<User>().cross_join::<Wallet>().count()?;
+        assert_eq!(cross_joined_count, 9);
+
+        let cross_joined_rows = database
+            .from::<User>()
+            .cross_join::<Wallet>()
+            .project_tuple((User::id(), Wallet::id()))
+            .asc(User::id())
+            .asc(Wallet::id())
+            .fetch::<(i32, i32)>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            cross_joined_rows,
+            vec![
+                (1, 1),
+                (1, 3),
+                (1, 4),
+                (2, 1),
+                (2, 3),
+                (2, 4),
+                (3, 1),
+                (3, 3),
+                (3, 4),
             ]
         );
 

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -24,14 +24,19 @@ mod test {
     use kite_sql::expression::function::FunctionSummary;
     use kite_sql::expression::BinaryOperator;
     use kite_sql::expression::ScalarExpression;
-    use kite_sql::orm::{func, QueryValue};
+    use kite_sql::orm::{func, QueryExpr, QueryValue};
     use kite_sql::types::evaluator::EvaluatorFactory;
     use kite_sql::types::tuple::{SchemaRef, Tuple};
     use kite_sql::types::value::{DataValue, Utf8Type};
     use kite_sql::types::LogicalType;
     use kite_sql::{from_tuple, scala_function, table_function, Model};
     use rust_decimal::Decimal;
-    use sqlparser::ast::CharLengthUnits;
+    use sqlparser::ast::{
+        BinaryOperator as SqlBinaryOperator, CharLengthUnits, Expr as SqlExpr, Query as SqlQuery,
+        Statement as SqlStatement,
+    };
+    use sqlparser::dialect::PostgreSqlDialect;
+    use sqlparser::parser::Parser;
     use std::sync::Arc;
 
     fn build_tuple() -> (Tuple, SchemaRef) {
@@ -63,6 +68,15 @@ mod test {
         ];
 
         (Tuple::new(None, values), schema_ref)
+    }
+
+    fn parse_query(sql: &str) -> SqlQuery {
+        let dialect = PostgreSqlDialect {};
+        let mut parser = Parser::new(&dialect).try_with_sql(sql).unwrap();
+        match parser.parse_statement().unwrap() {
+            SqlStatement::Query(query) => *query,
+            statement => panic!("expected query statement, got {statement:?}"),
+        }
     }
 
     #[derive(Default, Debug, PartialEq)]
@@ -472,6 +486,28 @@ mod test {
             .count()?;
         assert_eq!(alice_only, 1);
 
+        let in_list = database
+            .select::<User>()
+            .in_list(User::id(), [1, 3])
+            .asc(User::id())
+            .fetch()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            in_list.iter().map(|user| user.id).collect::<Vec<_>>(),
+            vec![1, 3]
+        );
+
+        let not_between = database
+            .select::<User>()
+            .not_between(User::id(), 2, 2)
+            .asc(User::id())
+            .fetch()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            not_between.iter().map(|user| user.id).collect::<Vec<_>>(),
+            vec![1, 3]
+        );
+
         let either_named_a_or_missing_age = database
             .select::<User>()
             .or(User::name().like("A%"), User::age().is_null())
@@ -492,6 +528,44 @@ mod test {
             .get()?
             .unwrap();
         assert_eq!(udf_matched.id, 1);
+
+        let cast_matched = database
+            .select::<User>()
+            .eq(User::id().cast("BIGINT")?, 2_i64)
+            .get()?
+            .unwrap();
+        assert_eq!(cast_matched.id, 2);
+
+        let raw_ast_matched = database
+            .select::<User>()
+            .filter(QueryExpr::from_ast(SqlExpr::BinaryOp {
+                left: Box::new(QueryValue::from(User::id()).into_ast()),
+                op: SqlBinaryOperator::Eq,
+                right: Box::new(QueryValue::from(3).into_ast()),
+            }))
+            .get()?
+            .unwrap();
+        assert_eq!(raw_ast_matched.id, 3);
+
+        let exists_count = database
+            .select::<User>()
+            .where_exists(parse_query("select id from users where id = 2"))
+            .count()?;
+        assert_eq!(exists_count, 3);
+
+        let in_subquery = database
+            .select::<User>()
+            .in_subquery(
+                User::id(),
+                parse_query("select id from users where id in (1, 3)"),
+            )
+            .asc(User::id())
+            .fetch()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            in_subquery.iter().map(|user| user.id).collect::<Vec<_>>(),
+            vec![1, 3]
+        );
 
         let mut tx = database.new_transaction()?;
         let in_tx = tx.select::<User>().eq(User::id(), 2).get()?.unwrap();

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -1078,6 +1078,20 @@ mod test {
         union_ids.sort();
         assert_eq!(union_ids, vec![1, 2, 3]);
 
+        let union_count = database
+            .from::<User>()
+            .project_value(User::id())
+            .union(database.from::<Order>().project_value(Order::user_id()))
+            .count()?;
+        assert_eq!(union_count, 3);
+
+        let union_exists = database
+            .from::<User>()
+            .project_value(User::id())
+            .union(database.from::<Order>().project_value(Order::user_id()))
+            .exists()?;
+        assert!(union_exists);
+
         let mut union_all_ids = database
             .from::<User>()
             .project_value(User::id())
@@ -1088,6 +1102,14 @@ mod test {
         union_all_ids.sort();
         assert_eq!(union_all_ids, vec![1, 1, 1, 2, 2, 3]);
 
+        let union_all_count = database
+            .from::<User>()
+            .project_value(User::id())
+            .union(database.from::<Order>().project_value(Order::user_id()))
+            .all()
+            .count()?;
+        assert_eq!(union_all_count, 6);
+
         let except_ids = database
             .from::<Order>()
             .project_value(Order::user_id())
@@ -1095,6 +1117,13 @@ mod test {
             .fetch::<i32>()?
             .collect::<Result<Vec<_>, _>>()?;
         assert!(except_ids.is_empty());
+
+        let except_exists = database
+            .from::<Order>()
+            .project_value(Order::user_id())
+            .except(database.from::<User>().project_value(User::id()))
+            .exists()?;
+        assert!(!except_exists);
 
         let except_all_ids = database
             .from::<Order>()
@@ -1104,6 +1133,25 @@ mod test {
             .fetch::<i32>()?
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(except_all_ids, vec![1]);
+
+        let users_without_orders = database
+            .from::<User>()
+            .in_subquery(
+                User::id(),
+                database
+                    .from::<User>()
+                    .project_value(User::id())
+                    .except(database.from::<Order>().project_value(Order::user_id())),
+            )
+            .fetch()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            users_without_orders
+                .iter()
+                .map(|user| user.id)
+                .collect::<Vec<_>>(),
+            vec![3]
+        );
 
         let left_joined_rows = database
             .from::<User>()

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -1160,6 +1160,15 @@ mod test {
             .unwrap();
         assert_eq!(union_user.id, 2);
 
+        let ordered_union_user = database
+            .from::<User>()
+            .eq(User::id(), 1)
+            .union(database.from::<User>().eq(User::id(), 2))
+            .desc(User::id())
+            .get()?
+            .unwrap();
+        assert_eq!(ordered_union_user.id, 2);
+
         let union_value = database
             .from::<User>()
             .project_value(User::id())
@@ -1173,6 +1182,15 @@ mod test {
             .all()
             .get::<i32>()?;
         assert_eq!(union_value, Some(2));
+
+        let ordered_union_value = database
+            .from::<User>()
+            .project_value(User::id())
+            .union(database.from::<Order>().project_value(Order::user_id()))
+            .all()
+            .desc(User::id())
+            .get::<i32>()?;
+        assert_eq!(ordered_union_value, Some(3));
 
         let union_tuple = database
             .from::<User>()
@@ -1188,6 +1206,20 @@ mod test {
             .get::<(i32, String)>()?;
         assert_eq!(union_tuple, Some((2, "Bob".to_string())));
 
+        let ordered_union_tuple = database
+            .from::<User>()
+            .eq(User::id(), 1)
+            .project_tuple((User::id(), User::name()))
+            .union(
+                database
+                    .from::<User>()
+                    .eq(User::id(), 2)
+                    .project_tuple((User::id(), User::name())),
+            )
+            .desc(User::id())
+            .get::<(i32, String)>()?;
+        assert_eq!(ordered_union_tuple, Some((2, "Bob".to_string())));
+
         let union_projection = database
             .from::<User>()
             .eq(User::id(), 2)
@@ -1202,6 +1234,27 @@ mod test {
             .get()?;
         assert_eq!(
             union_projection,
+            Some(UserSummary {
+                id: 2,
+                display_name: "Bob".to_string(),
+                age: Some(30),
+            })
+        );
+
+        let ordered_union_projection = database
+            .from::<User>()
+            .eq(User::id(), 1)
+            .project::<UserSummary>()
+            .union(
+                database
+                    .from::<User>()
+                    .eq(User::id(), 2)
+                    .project::<UserSummary>(),
+            )
+            .desc(User::id())
+            .get()?;
+        assert_eq!(
+            ordered_union_projection,
             Some(UserSummary {
                 id: 2,
                 display_name: "Bob".to_string(),

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -116,6 +116,15 @@ mod test {
     }
 
     #[derive(Default, Debug, PartialEq, Model)]
+    #[model(table = "user_name_snapshots")]
+    struct UserNameSnapshot {
+        #[model(primary_key)]
+        id: i32,
+        #[model(rename = "user_name", varchar = 32)]
+        name: String,
+    }
+
+    #[derive(Default, Debug, PartialEq, Model)]
     #[model(table = "event_logs")]
     struct EventLog {
         #[model(primary_key)]
@@ -131,6 +140,19 @@ mod test {
         id: i32,
         user_id: i32,
         amount: i32,
+    }
+
+    #[derive(Default, Debug, PartialEq, Model)]
+    #[model(table = "archived_users")]
+    struct ArchivedUser {
+        #[model(primary_key)]
+        id: i32,
+        #[model(rename = "user_name", unique, varchar = 32)]
+        name: String,
+        #[model(default = "18")]
+        age: Option<i32>,
+        #[model(skip)]
+        cache: String,
     }
 
     #[derive(Default, Debug, PartialEq, Projection)]
@@ -1563,6 +1585,89 @@ mod test {
             limited_update,
             Err(DatabaseError::UnsupportedStmt(message)) if message.contains("limit")
         ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_orm_insert_query_builder() -> Result<(), DatabaseError> {
+        let database = DataBaseBuilder::path(".").build_in_memory()?;
+        database.create_table::<User>()?;
+        database.create_table::<ArchivedUser>()?;
+
+        for (id, name, age) in [(1, "Alice", Some(18)), (2, "Bob", Some(19))] {
+            database.insert(&ArchivedUser {
+                id,
+                name: name.to_string(),
+                age,
+                cache: String::new(),
+            })?;
+        }
+
+        database.from::<ArchivedUser>().insert::<User>()?;
+
+        let inserted_users = database
+            .from::<User>()
+            .asc(User::id())
+            .fetch()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(inserted_users.len(), 2);
+        assert_eq!(inserted_users[0].name, "Alice");
+        assert_eq!(inserted_users[1].name, "Bob");
+
+        database.create_table::<UserNameSnapshot>()?;
+        database
+            .from::<ArchivedUser>()
+            .project_tuple((ArchivedUser::id(), ArchivedUser::name()))
+            .insert_into::<UserNameSnapshot, _>((
+                UserNameSnapshot::id(),
+                UserNameSnapshot::name(),
+            ))?;
+
+        let snapshots = database
+            .from::<UserNameSnapshot>()
+            .asc(UserNameSnapshot::id())
+            .fetch()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(snapshots.len(), 2);
+        assert_eq!(snapshots[0].name, "Alice");
+        assert_eq!(snapshots[1].name, "Bob");
+
+        database
+            .from::<ArchivedUser>()
+            .eq(ArchivedUser::id(), 2)
+            .overwrite::<User>()?;
+
+        let overwritten_users = database
+            .from::<User>()
+            .asc(User::id())
+            .fetch()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(overwritten_users.len(), 2);
+        assert_eq!(overwritten_users[0].id, 1);
+        assert_eq!(overwritten_users[0].name, "Alice");
+        assert_eq!(overwritten_users[1].id, 2);
+        assert_eq!(overwritten_users[1].name, "Bob");
+
+        database
+            .from::<ArchivedUser>()
+            .eq(ArchivedUser::id(), 1)
+            .project_tuple((ArchivedUser::id(), ArchivedUser::name()))
+            .overwrite_into::<UserNameSnapshot, _>((
+                UserNameSnapshot::id(),
+                UserNameSnapshot::name(),
+            ))?;
+
+        let overwritten_snapshots = database
+            .from::<UserNameSnapshot>()
+            .asc(UserNameSnapshot::id())
+            .fetch()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(overwritten_snapshots.len(), 2);
+        assert_eq!(overwritten_snapshots[0].id, 1);
+        assert_eq!(overwritten_snapshots[0].name, "Alice");
+        assert_eq!(overwritten_snapshots[1].id, 2);
+        assert_eq!(overwritten_snapshots[1].name, "Bob");
 
         Ok(())
     }

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -24,7 +24,7 @@ mod test {
     use kite_sql::expression::function::FunctionSummary;
     use kite_sql::expression::BinaryOperator;
     use kite_sql::expression::ScalarExpression;
-    use kite_sql::orm::{func, QueryExpr, QueryValue};
+    use kite_sql::orm::{case_value, case_when, count_all, func, sum, QueryExpr, QueryValue};
     use kite_sql::types::evaluator::EvaluatorFactory;
     use kite_sql::types::tuple::{SchemaRef, Tuple};
     use kite_sql::types::value::{DataValue, Utf8Type};
@@ -534,6 +534,42 @@ mod test {
             .eq(User::id(), 1)
             .get::<String>()?;
         assert_eq!(projected_name.as_deref(), Some("Alice"));
+
+        let age_buckets = database
+            .project_value::<User, _>(case_when(
+                [
+                    (User::age().is_null(), "unknown"),
+                    (User::age().lt(20), "minor"),
+                ],
+                "adult",
+            ))
+            .asc(User::id())
+            .fetch::<String>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(age_buckets, vec!["minor", "adult", "unknown"]);
+
+        let id_labels = database
+            .project_value::<User, _>(case_value(User::id(), [(1, "one"), (2, "two")], "other"))
+            .asc(User::id())
+            .fetch::<String>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(id_labels, vec!["one", "two", "other"]);
+
+        let id_sum = database
+            .project_value::<User, _>(sum(User::id()))
+            .get::<i32>()?;
+        assert_eq!(id_sum, Some(6));
+
+        let total_users = database
+            .project_value::<User, _>(count_all().alias("total_users"))
+            .get::<i32>()?;
+        assert_eq!(total_users, Some(3));
+
+        let aliased_total_users = database
+            .project_value::<User, _>(count_all().alias("total_users"))
+            .raw()?;
+        assert_eq!(aliased_total_users.schema()[0].name(), "total_users");
+        aliased_total_users.done()?;
 
         let raw_ast_matched = database
             .select::<User>()

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -24,14 +24,14 @@ mod test {
     use kite_sql::expression::function::FunctionSummary;
     use kite_sql::expression::BinaryOperator;
     use kite_sql::expression::ScalarExpression;
-    use kite_sql::orm::{case_value, case_when, count_all, func, sum, QueryExpr, QueryValue};
+    use kite_sql::orm::{case_value, case_when, count_all, func, max, min, sum, QueryValue};
     use kite_sql::types::evaluator::EvaluatorFactory;
     use kite_sql::types::tuple::{SchemaRef, Tuple};
     use kite_sql::types::value::{DataValue, Utf8Type};
     use kite_sql::types::LogicalType;
     use kite_sql::{from_tuple, scala_function, table_function, Model, Projection};
     use rust_decimal::Decimal;
-    use sqlparser::ast::{BinaryOperator as SqlBinaryOperator, CharLengthUnits, Expr as SqlExpr};
+    use sqlparser::ast::{CharLengthUnits, DataType as SqlDataType};
     use std::sync::Arc;
 
     fn build_tuple() -> (Tuple, SchemaRef) {
@@ -532,12 +532,26 @@ mod test {
             .unwrap();
         assert_eq!(udf_matched.id, 1);
 
+        let query_value_function_matched = database
+            .from::<User>()
+            .eq(QueryValue::function("add_one", [User::id()]), 3)
+            .get()?
+            .unwrap();
+        assert_eq!(query_value_function_matched.id, 2);
+
         let cast_matched = database
             .from::<User>()
             .eq(User::id().cast("BIGINT")?, 2_i64)
             .get()?
             .unwrap();
         assert_eq!(cast_matched.id, 2);
+
+        let cast_to_matched = database
+            .from::<User>()
+            .eq(User::id().cast_to(SqlDataType::BigInt(None)), 3_i64)
+            .get()?
+            .unwrap();
+        assert_eq!(cast_to_matched.id, 3);
 
         let projected_ids = database
             .from::<User>()
@@ -568,6 +582,23 @@ mod test {
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(age_buckets, vec!["minor", "adult", "unknown"]);
 
+        let searched_case_buckets = database
+            .from::<User>()
+            .project_value(
+                QueryValue::searched_case(
+                    [
+                        (User::age().is_null(), "unknown"),
+                        (User::age().lt(20), "minor"),
+                    ],
+                    "adult",
+                )
+                .alias("age_bucket"),
+            )
+            .asc(User::id())
+            .fetch::<String>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(searched_case_buckets, vec!["minor", "adult", "unknown"]);
+
         let id_labels = database
             .from::<User>()
             .project_value(case_value(User::id(), [(1, "one"), (2, "two")], "other"))
@@ -575,6 +606,17 @@ mod test {
             .fetch::<String>()?
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(id_labels, vec!["one", "two", "other"]);
+
+        let simple_case_labels = database
+            .from::<User>()
+            .project_value(
+                QueryValue::simple_case(User::id(), [(1, "one"), (2, "two")], "other")
+                    .alias("id_label"),
+            )
+            .asc(User::id())
+            .fetch::<String>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(simple_case_labels, vec!["one", "two", "other"]);
 
         let id_sum = database
             .from::<User>()
@@ -587,6 +629,18 @@ mod test {
             .project_value(count_all().alias("total_users"))
             .get::<i32>()?;
         assert_eq!(total_users, Some(3));
+
+        let min_user_id = database
+            .from::<User>()
+            .project_value(min(User::id()).alias("min_user_id"))
+            .get::<i32>()?;
+        assert_eq!(min_user_id, Some(1));
+
+        let max_user_id = database
+            .from::<User>()
+            .project_value(max(User::id()).alias("max_user_id"))
+            .get::<i32>()?;
+        assert_eq!(max_user_id, Some(3));
 
         let projected_user_rows = database
             .from::<User>()
@@ -602,6 +656,35 @@ mod test {
                 (3, "A'lex".to_string()),
             ]
         );
+
+        let udf_projection = database
+            .from::<User>()
+            .project_tuple((
+                User::id(),
+                func("add_one", [QueryValue::from(User::id())]).alias("next_id"),
+            ))
+            .asc(User::id())
+            .fetch::<(i32, i32)>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(udf_projection, vec![(1, 2), (2, 3), (3, 4)]);
+
+        let udf_projection_schema = database
+            .from::<User>()
+            .project_tuple((
+                User::id(),
+                QueryValue::function("add_one", [User::id()]).alias("next_id"),
+            ))
+            .asc(User::id())
+            .raw()?;
+        assert_eq!(
+            udf_projection_schema
+                .schema()
+                .iter()
+                .map(|column| column.name().to_string())
+                .collect::<Vec<_>>(),
+            vec!["id", "next_id"]
+        );
+        udf_projection_schema.done()?;
 
         let projected_users = database
             .from::<User>()
@@ -662,17 +745,6 @@ mod test {
         );
         projected_schema.done()?;
 
-        let raw_ast_matched = database
-            .from::<User>()
-            .filter(QueryExpr::from_ast(SqlExpr::BinaryOp {
-                left: Box::new(QueryValue::from(User::id()).into_ast()),
-                op: SqlBinaryOperator::Eq,
-                right: Box::new(QueryValue::from(3).into_ast()),
-            }))
-            .get()?
-            .unwrap();
-        assert_eq!(raw_ast_matched.id, 3);
-
         let exists_count = database
             .from::<User>()
             .where_exists(
@@ -683,6 +755,28 @@ mod test {
             )
             .count()?;
         assert_eq!(exists_count, 3);
+
+        let not_exists_count = database
+            .from::<User>()
+            .where_not_exists(
+                database
+                    .from::<User>()
+                    .project_value(User::id())
+                    .eq(User::id(), 99),
+            )
+            .count()?;
+        assert_eq!(not_exists_count, 3);
+
+        let blocked_by_not_exists = database
+            .from::<User>()
+            .where_not_exists(
+                database
+                    .from::<User>()
+                    .project_value(User::id())
+                    .eq(User::id(), 2),
+            )
+            .count()?;
+        assert_eq!(blocked_by_not_exists, 0);
 
         let in_subquery = database
             .from::<User>()
@@ -699,6 +793,25 @@ mod test {
         assert_eq!(
             in_subquery.iter().map(|user| user.id).collect::<Vec<_>>(),
             vec![1, 3]
+        );
+
+        let not_in_subquery = database
+            .from::<User>()
+            .not_in_subquery(
+                User::id(),
+                database
+                    .from::<User>()
+                    .project_value(User::id())
+                    .in_list(User::id(), [1, 3]),
+            )
+            .fetch()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            not_in_subquery
+                .iter()
+                .map(|user| user.id)
+                .collect::<Vec<_>>(),
+            vec![2]
         );
 
         let mut tx = database.new_transaction()?;
@@ -764,6 +877,43 @@ mod test {
             grouped_scores,
             vec![("alpha".to_string(), 30), ("beta".to_string(), 5)]
         );
+
+        let grouped_stats = database
+            .from::<EventLog>()
+            .project_tuple((
+                EventLog::category(),
+                sum(EventLog::score()).alias("total_score"),
+                count_all().alias("total_count"),
+            ))
+            .group_by(EventLog::category())
+            .having(count_all().gt(0))
+            .asc(EventLog::category())
+            .fetch::<(String, i32, i32)>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            grouped_stats,
+            vec![("alpha".to_string(), 30, 2), ("beta".to_string(), 5, 1),]
+        );
+
+        let grouped_stats_schema = database
+            .from::<EventLog>()
+            .project_tuple((
+                EventLog::category(),
+                sum(EventLog::score()).alias("total_score"),
+                count_all().alias("total_count"),
+            ))
+            .group_by(EventLog::category())
+            .asc(EventLog::category())
+            .raw()?;
+        assert_eq!(
+            grouped_stats_schema
+                .schema()
+                .iter()
+                .map(|column| column.name().to_string())
+                .collect::<Vec<_>>(),
+            vec!["category", "total_score", "total_count"]
+        );
+        grouped_stats_schema.done()?;
 
         database.drop_table::<EventLog>()?;
 

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -1390,7 +1390,7 @@ mod test {
     }
 
     #[test]
-    fn test_orm_crud() -> Result<(), DatabaseError> {
+    fn test_orm_model_lifecycle() -> Result<(), DatabaseError> {
         let database = DataBaseBuilder::path(".").build_in_memory()?;
 
         database.create_table::<User>()?;
@@ -1399,7 +1399,7 @@ mod test {
         database.run("drop index users.users_age_index")?.done()?;
         database.create_table_if_not_exists::<User>()?;
 
-        let mut user = User {
+        let user = User {
             id: 1,
             name: "Alice".to_string(),
             age: Some(18),
@@ -1455,15 +1455,19 @@ mod test {
         let defaulted = database.get::<User>(&9)?.unwrap();
         assert_eq!(defaulted.age, Some(18));
 
-        user.name = "Bob".to_string();
-        user.age = None;
-        database.update(&user)?;
+        database
+            .from::<User>()
+            .eq(User::id(), 1)
+            .update()
+            .set(User::name(), "Bob")
+            .set(User::age(), None::<i32>)
+            .execute()?;
 
         let updated = database.get::<User>(&1)?.unwrap();
         assert_eq!(updated.name, "Bob");
         assert_eq!(updated.age, None);
 
-        database.delete_by_id::<User>(&1)?;
+        database.from::<User>().eq(User::id(), 1).delete()?;
         assert!(database.get::<User>(&1)?.is_none());
 
         database.insert(&User {
@@ -1484,11 +1488,81 @@ mod test {
             Err(DatabaseError::DuplicateUniqueValue)
         ));
 
-        database.delete_by_id::<User>(&2)?;
+        database.from::<User>().eq(User::id(), 2).delete()?;
         assert!(database.get::<User>(&2)?.is_none());
 
         database.drop_table::<User>()?;
         database.drop_table_if_exists::<User>()?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_orm_update_delete_builder() -> Result<(), DatabaseError> {
+        let database = DataBaseBuilder::path(".").build_in_memory()?;
+        database.create_table::<User>()?;
+
+        for (id, name, age) in [
+            (1, "Alice", Some(18)),
+            (2, "Bob", Some(19)),
+            (3, "Carol", Some(20)),
+        ] {
+            database.insert(&User {
+                id,
+                name: name.to_string(),
+                age,
+                cache: String::new(),
+            })?;
+        }
+
+        database
+            .from::<User>()
+            .alias("u")
+            .eq(User::id().qualify("u"), 1)
+            .update()
+            .set(User::name(), "BuilderAlice")
+            .set(User::age(), None::<i32>)
+            .execute()?;
+
+        let updated = database.get::<User>(&1)?.unwrap();
+        assert_eq!(updated.name, "BuilderAlice");
+        assert_eq!(updated.age, None);
+
+        database
+            .from::<User>()
+            .eq(User::id(), 2)
+            .update()
+            .set_expr(User::age(), User::id().add(20))
+            .execute()?;
+
+        assert_eq!(database.get::<User>(&2)?.unwrap().age, Some(22));
+
+        database
+            .from::<User>()
+            .alias("u")
+            .eq(User::name().qualify("u"), "Carol")
+            .delete()?;
+        assert!(database.get::<User>(&3)?.is_none());
+
+        let empty_update = database.from::<User>().eq(User::id(), 1).update().execute();
+        assert!(matches!(empty_update, Err(DatabaseError::ColumnsEmpty)));
+
+        let ordered_delete = database.from::<User>().asc(User::id()).delete();
+        assert!(matches!(
+            ordered_delete,
+            Err(DatabaseError::UnsupportedStmt(message)) if message.contains("order by")
+        ));
+
+        let limited_update = database
+            .from::<User>()
+            .limit(1)
+            .update()
+            .set(User::name(), "ignored")
+            .execute();
+        assert!(matches!(
+            limited_update,
+            Err(DatabaseError::UnsupportedStmt(message)) if message.contains("limit")
+        ));
 
         Ok(())
     }

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -1281,6 +1281,43 @@ mod test {
             .count()?;
         assert_eq!(blocked_by_not_exists, 0);
 
+        let users_with_orders = database
+            .from::<User>()
+            .filter(kite_sql::orm::QueryExpr::exists(
+                database
+                    .from::<Order>()
+                    .project_value(Order::id())
+                    .eq(Order::user_id(), User::id()),
+            ))
+            .asc(User::id())
+            .fetch()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            users_with_orders
+                .iter()
+                .map(|user| user.id)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+
+        let users_without_orders = database
+            .from::<User>()
+            .filter(kite_sql::orm::QueryExpr::not_exists(
+                database
+                    .from::<Order>()
+                    .project_value(Order::id())
+                    .eq(Order::user_id(), User::id()),
+            ))
+            .fetch()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            users_without_orders
+                .iter()
+                .map(|user| user.id)
+                .collect::<Vec<_>>(),
+            vec![3]
+        );
+
         let max_id_user = database
             .from::<User>()
             .eq(

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -1791,6 +1791,70 @@ mod test {
     }
 
     #[test]
+    fn test_orm_introspection_helpers() -> Result<(), DatabaseError> {
+        let database = DataBaseBuilder::path(".").build_in_memory()?;
+        database.create_table::<User>()?;
+        database.create_table::<Wallet>()?;
+        database.create_view(
+            "user_names",
+            database
+                .from::<User>()
+                .project_tuple((User::id(), User::name())),
+        )?;
+
+        let tables = database.show_tables()?.collect::<Result<Vec<_>, _>>()?;
+        assert!(tables.iter().any(|name| name == "users"));
+        assert!(tables.iter().any(|name| name == "wallets"));
+
+        let views = database.show_views()?.collect::<Result<Vec<_>, _>>()?;
+        assert!(views.iter().any(|name| name == "user_names"));
+
+        let describe_rows = database
+            .describe::<User>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert!(describe_rows.iter().any(|column| column.field == "id"));
+        assert!(describe_rows
+            .iter()
+            .any(|column| column.field == "user_name"));
+        assert!(
+            describe_rows
+                .iter()
+                .find(|column| column.field == "id")
+                .map(|column| column.key.as_str())
+                == Some("PRIMARY")
+        );
+
+        let plan = database
+            .from::<User>()
+            .eq(User::id(), 1)
+            .project_value(User::name())
+            .explain()?;
+        assert_eq!(
+            plan,
+            "Projection [users.user_name] [Project => (Sort Option: Follow)]\n  Filter (users.id = 1), Is Having: false [Filter => (Sort Option: Follow)]\n    TableScan users -> [id, user_name] [SeqScan => (Sort Option: None)]"
+        );
+
+        let set_plan = database
+            .from::<User>()
+            .project_value(User::id())
+            .union(database.from::<Wallet>().project_value(Wallet::id()))
+            .explain()?;
+        assert_eq!(
+            set_plan,
+            "Aggregate [] -> Group By [users.id] [HashAggregate => (Sort Option: None)]\n  Union: [id]\n    Projection [users.id] [Project => (Sort Option: Follow)]\n      TableScan users -> [id] [SeqScan => (Sort Option: None)]\n    Projection [wallets.id] [Project => (Sort Option: Follow)]\n      TableScan wallets -> [id] [SeqScan => (Sort Option: None)]"
+        );
+
+        let mut tx = database.new_transaction()?;
+        let tx_tables = tx.show_tables()?.collect::<Result<Vec<_>, _>>()?;
+        assert!(tx_tables.iter().any(|name| name == "users"));
+        let tx_describe = tx.describe::<Wallet>()?.collect::<Result<Vec<_>, _>>()?;
+        assert!(tx_describe.iter().any(|column| column.field == "balance"));
+        tx.commit()?;
+
+        Ok(())
+    }
+
+    #[test]
     fn test_orm_drop_index() -> Result<(), DatabaseError> {
         let database = DataBaseBuilder::path(".").build_in_memory()?;
 

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -574,6 +574,20 @@ mod test {
             .get::<i32>()?;
         assert_eq!(total_users, Some(3));
 
+        let projected_user_rows = database
+            .project_tuple::<User, _>((User::id(), User::name()))
+            .asc(User::id())
+            .fetch::<(i32, String)>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            projected_user_rows,
+            vec![
+                (1, "Alice".to_string()),
+                (2, "Bob".to_string()),
+                (3, "A'lex".to_string()),
+            ]
+        );
+
         let aliased_total_users = database
             .project_value::<User, _>(count_all().alias("total_users"))
             .raw()?;
@@ -662,6 +676,21 @@ mod test {
             .having(count_all().gt(1))
             .count()?;
         assert_eq!(grouped_count, 1);
+
+        let grouped_scores = database
+            .project_tuple::<EventLog, _>((
+                EventLog::category(),
+                sum(EventLog::score()).alias("total_score"),
+            ))
+            .group_by(EventLog::category())
+            .having(count_all().gt(0))
+            .asc(EventLog::category())
+            .fetch::<(String, i32)>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            grouped_scores,
+            vec![("alpha".to_string(), 30), ("beta".to_string(), 5)]
+        );
 
         database.drop_table::<EventLog>()?;
 

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -1110,6 +1110,28 @@ mod test {
             .count()?;
         assert_eq!(union_all_count, 6);
 
+        let ordered_union_ids = database
+            .from::<User>()
+            .project_value(User::id())
+            .union(database.from::<Order>().project_value(Order::user_id()))
+            .all()
+            .asc(User::id())
+            .offset(1)
+            .limit(3)
+            .fetch::<i32>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(ordered_union_ids, vec![1, 1, 2]);
+
+        let ordered_union_count = database
+            .from::<User>()
+            .project_value(User::id())
+            .union(database.from::<Order>().project_value(Order::user_id()))
+            .all()
+            .asc(User::id())
+            .limit(2)
+            .count()?;
+        assert_eq!(ordered_union_count, 2);
+
         let except_ids = database
             .from::<Order>()
             .project_value(Order::user_id())
@@ -1130,6 +1152,7 @@ mod test {
             .project_value(Order::user_id())
             .except(database.from::<User>().project_value(User::id()))
             .all()
+            .asc(Order::user_id())
             .fetch::<i32>()?
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(except_all_ids, vec![1]);

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -124,6 +124,15 @@ mod test {
         score: i32,
     }
 
+    #[derive(Default, Debug, PartialEq, Model)]
+    #[model(table = "orders")]
+    struct Order {
+        #[model(primary_key)]
+        id: i32,
+        user_id: i32,
+        amount: i32,
+    }
+
     #[derive(Default, Debug, PartialEq, Projection)]
     struct UserSummary {
         id: i32,
@@ -442,6 +451,23 @@ mod test {
             name: "A'lex".to_string(),
             age: None,
             cache: "".to_string(),
+        })?;
+
+        database.create_table::<Order>()?;
+        database.insert(&Order {
+            id: 1,
+            user_id: 1,
+            amount: 100,
+        })?;
+        database.insert(&Order {
+            id: 2,
+            user_id: 1,
+            amount: 200,
+        })?;
+        database.insert(&Order {
+            id: 3,
+            user_id: 2,
+            amount: 300,
         })?;
 
         let adults = database
@@ -863,14 +889,16 @@ mod test {
         );
 
         let aliased_user = database
-            .from_alias::<User>("u")
+            .from::<User>()
+            .alias("u")
             .eq(User::id().qualify("u"), 2)
             .get()?
             .unwrap();
         assert_eq!(aliased_user.name, "Bob");
 
         let aliased_projection = database
-            .from_alias::<User>("u")
+            .from::<User>()
+            .alias("u")
             .project::<UserSummary>()
             .eq(User::id().qualify("u"), 2)
             .get()?;
@@ -883,11 +911,62 @@ mod test {
             })
         );
 
+        let joined_rows = database
+            .from::<User>()
+            .alias("u")
+            .inner_join::<Order>()
+            .alias("o")
+            .on(User::id().qualify("u").eq(Order::user_id().qualify("o")))
+            .project_tuple((
+                User::name().qualify("u").alias("user_name"),
+                Order::amount().qualify("o").alias("order_amount"),
+            ))
+            .asc(Order::id().qualify("o"))
+            .fetch::<(String, i32)>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            joined_rows,
+            vec![
+                ("Alice".to_string(), 100),
+                ("Alice".to_string(), 200),
+                ("Bob".to_string(), 300),
+            ]
+        );
+
+        let joined_count = database
+            .from::<User>()
+            .alias("u")
+            .inner_join::<Order>()
+            .alias("o")
+            .on(User::id().qualify("u").eq(Order::user_id().qualify("o")))
+            .count()?;
+        assert_eq!(joined_count, 3);
+
+        let left_joined_rows = database
+            .from::<User>()
+            .alias("u")
+            .left_join::<Order>()
+            .alias("o")
+            .on(User::id().qualify("u").eq(Order::user_id().qualify("o")))
+            .project_tuple((
+                User::id().qualify("u").alias("user_id"),
+                Order::amount().qualify("o").alias("order_amount"),
+            ))
+            .asc(User::id().qualify("u"))
+            .asc(Order::id().qualify("o"))
+            .fetch::<(i32, Option<i32>)>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            left_joined_rows,
+            vec![(1, Some(100)), (1, Some(200)), (2, Some(300)), (3, None)]
+        );
+
         let mut tx = database.new_transaction()?;
         let in_tx = tx.from::<User>().eq(User::id(), 2).get()?.unwrap();
         assert_eq!(in_tx.name, "Bob");
         tx.commit()?;
 
+        database.drop_table::<Order>()?;
         database.drop_table::<User>()?;
 
         Ok(())

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -141,6 +141,14 @@ mod test {
         age: Option<i32>,
     }
 
+    #[derive(Default, Debug, PartialEq, Projection)]
+    struct UserOrderSummary {
+        #[projection(from = "users", rename = "user_name")]
+        display_name: String,
+        #[projection(from = "orders")]
+        amount: i32,
+    }
+
     #[derive(Default, Debug, PartialEq, Model)]
     #[model(table = "migrating_users")]
     struct MigratingUserV1 {
@@ -941,6 +949,32 @@ mod test {
             .on(User::id().qualify("u").eq(Order::user_id().qualify("o")))
             .count()?;
         assert_eq!(joined_count, 3);
+
+        let joined_projection = database
+            .from::<User>()
+            .inner_join::<Order>()
+            .on(User::id().eq(Order::user_id()))
+            .project::<UserOrderSummary>()
+            .asc(Order::id())
+            .fetch()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            joined_projection,
+            vec![
+                UserOrderSummary {
+                    display_name: "Alice".to_string(),
+                    amount: 100,
+                },
+                UserOrderSummary {
+                    display_name: "Alice".to_string(),
+                    amount: 200,
+                },
+                UserOrderSummary {
+                    display_name: "Bob".to_string(),
+                    amount: 300,
+                },
+            ]
+        );
 
         let left_joined_rows = database
             .from::<User>()

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -854,6 +854,31 @@ mod test {
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(repeated_categories, vec!["alpha"]);
 
+        let distinct_categories = database
+            .from::<EventLog>()
+            .distinct()
+            .project_value(EventLog::category())
+            .asc(EventLog::category())
+            .fetch::<String>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(distinct_categories, vec!["alpha", "beta"]);
+
+        let distinct_category_count = database
+            .from::<EventLog>()
+            .distinct()
+            .project_value(EventLog::category())
+            .count()?;
+        assert_eq!(distinct_category_count, 2);
+
+        let distinct_limited_count = database
+            .from::<EventLog>()
+            .distinct()
+            .project_value(EventLog::category())
+            .asc(EventLog::category())
+            .limit(1)
+            .count()?;
+        assert_eq!(distinct_limited_count, 1);
+
         let grouped_count = database
             .from::<EventLog>()
             .project_value(EventLog::category())

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -1069,6 +1069,42 @@ mod test {
             ]
         );
 
+        let mut union_ids = database
+            .from::<User>()
+            .project_value(User::id())
+            .union(database.from::<Order>().project_value(Order::user_id()))
+            .fetch::<i32>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        union_ids.sort();
+        assert_eq!(union_ids, vec![1, 2, 3]);
+
+        let mut union_all_ids = database
+            .from::<User>()
+            .project_value(User::id())
+            .union(database.from::<Order>().project_value(Order::user_id()))
+            .all()
+            .fetch::<i32>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        union_all_ids.sort();
+        assert_eq!(union_all_ids, vec![1, 1, 1, 2, 2, 3]);
+
+        let except_ids = database
+            .from::<Order>()
+            .project_value(Order::user_id())
+            .except(database.from::<User>().project_value(User::id()))
+            .fetch::<i32>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert!(except_ids.is_empty());
+
+        let except_all_ids = database
+            .from::<Order>()
+            .project_value(Order::user_id())
+            .except(database.from::<User>().project_value(User::id()))
+            .all()
+            .fetch::<i32>()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(except_all_ids, vec![1]);
+
         let left_joined_rows = database
             .from::<User>()
             .alias("u")

--- a/tests/macros-test/src/main.rs
+++ b/tests/macros-test/src/main.rs
@@ -29,7 +29,7 @@ mod test {
     use kite_sql::types::tuple::{SchemaRef, Tuple};
     use kite_sql::types::value::{DataValue, Utf8Type};
     use kite_sql::types::LogicalType;
-    use kite_sql::{from_tuple, scala_function, table_function, Model};
+    use kite_sql::{from_tuple, scala_function, table_function, Model, Projection};
     use rust_decimal::Decimal;
     use sqlparser::ast::{BinaryOperator as SqlBinaryOperator, CharLengthUnits, Expr as SqlExpr};
     use std::sync::Arc;
@@ -122,6 +122,14 @@ mod test {
         id: i32,
         category: String,
         score: i32,
+    }
+
+    #[derive(Default, Debug, PartialEq, Projection)]
+    struct UserSummary {
+        id: i32,
+        #[projection(rename = "user_name")]
+        display_name: String,
+        age: Option<i32>,
     }
 
     #[derive(Default, Debug, PartialEq, Model)]
@@ -595,12 +603,64 @@ mod test {
             ]
         );
 
+        let projected_users = database
+            .from::<User>()
+            .project::<UserSummary>()
+            .asc(User::id())
+            .fetch()?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            projected_users,
+            vec![
+                UserSummary {
+                    id: 1,
+                    display_name: "Alice".to_string(),
+                    age: Some(18),
+                },
+                UserSummary {
+                    id: 2,
+                    display_name: "Bob".to_string(),
+                    age: Some(30),
+                },
+                UserSummary {
+                    id: 3,
+                    display_name: "A'lex".to_string(),
+                    age: None,
+                },
+            ]
+        );
+
+        let projected_user = database
+            .from::<User>()
+            .project::<UserSummary>()
+            .eq(User::id(), 1)
+            .get()?;
+        assert_eq!(
+            projected_user,
+            Some(UserSummary {
+                id: 1,
+                display_name: "Alice".to_string(),
+                age: Some(18),
+            })
+        );
+
         let aliased_total_users = database
             .from::<User>()
             .project_value(count_all().alias("total_users"))
             .raw()?;
         assert_eq!(aliased_total_users.schema()[0].name(), "total_users");
         aliased_total_users.done()?;
+
+        let projected_schema = database.from::<User>().project::<UserSummary>().raw()?;
+        assert_eq!(
+            projected_schema
+                .schema()
+                .iter()
+                .map(|column| column.name().to_string())
+                .collect::<Vec<_>>(),
+            vec!["id", "display_name", "age"]
+        );
+        projected_schema.done()?;
 
         let raw_ast_matched = database
             .from::<User>()

--- a/tests/slt/insert.slt
+++ b/tests/slt/insert.slt
@@ -31,12 +31,22 @@ insert into t values (8,NULL,NULL,NULL)
 statement ok
 insert overwrite t values (1, 9, 9, 9)
 
+statement ok
+insert into t(id, v2) select id + 10, cast(v1 as varchar) from t where id < 2
+
+statement ok
+insert into t select id + 20, v1, v2, v3 from t where id in (0, 1)
+
 query IIII rowsort
 select * from t
 ----
 0 1 10 100
 1 9 9 9
+10 null 1 null
+11 null 9 null
 2 2 20 200
+20 1 10 100
+21 9 9 9
 3 3 30 300
 4 4 40 400
 5 1 10 100

--- a/tests/slt/subquery.slt
+++ b/tests/slt/subquery.slt
@@ -96,3 +96,74 @@ drop table t2;
 
 statement ok
 drop table t3;
+
+statement ok
+create table users(id int primary key, age int);
+
+statement ok
+create table orders(id int primary key, user_id int, amount int);
+
+statement ok
+insert into users values (1, 18), (2, 30), (3, 40);
+
+statement ok
+insert into orders values (1, 1, 100), (2, 1, 200), (3, 2, 300);
+
+query I rowsort
+select id from users
+where exists (
+    select 1 from orders where orders.user_id = users.id
+);
+----
+1
+2
+
+query I rowsort
+select id from users
+where not exists (
+    select 1 from orders where orders.user_id = users.id
+);
+----
+3
+
+query I rowsort
+select id from users
+where id in (
+    select user_id from orders where orders.user_id = users.id
+);
+----
+1
+2
+
+query I rowsort
+select id from users
+where id not in (
+    select user_id from orders where orders.user_id = users.id
+);
+----
+3
+
+query I rowsort
+select id from users
+where id in (
+    select user_id from orders where amount = 100
+    union all
+    select user_id from orders where amount = 300
+);
+----
+1
+2
+
+statement error
+select count(*) from users
+where exists (
+    select id from orders where orders.user_id = users.id
+    union
+    select id from orders where amount = 300
+);
+
+statement ok
+drop table users;
+
+statement ok
+drop table orders;

--- a/tests/slt/union.slt
+++ b/tests/slt/union.slt
@@ -53,5 +53,33 @@ select id from t1 union all select v1 from t1
 4
 4
 
+query I
+select id from t1 union all select v1 from t1 order by id desc limit 3 offset 1
+----
+4
+3
+3
+
+statement ok
+create table t2(id int primary key, v1 int unique)
+
+statement ok
+insert into t2 values (2,20), (4,40)
+
+query I rowsort
+select id from t1 except select id from t2
+----
+1
+3
+
+query I
+select id from t1 except select id from t2 order by id desc
+----
+3
+1
+
+statement ok
+drop table t2
+
 statement ok
 drop table t1


### PR DESCRIPTION
### What problem does this PR solve?

KiteSQL already had the first piece of ORM support, but it still could not cover most of KiteSQL's query and maintenance capabilities through a consistent high-level API.

This PR completes that layer so model-driven workflows can stay inside the ORM for projections, joins, subqueries, set queries, mutations, introspection, and related documentation/tests, instead of falling back to raw SQL or exposed AST details.

Issue link:

### What is changed and how it works?

#### ORM query builder
- Rebuild ORM DQL/DML/DDL construction on top of `sqlparser` AST while keeping AST details hidden from end users
- Expand expression support with function calls, arithmetic, aggregates, `CASE`, aliased values, `DISTINCT`, and richer subquery predicates
- Add `group_by`, `having`, tuple/value projections, and DTO projections via `#[derive(Projection)]`
- Add source aliasing, typed joins, `USING`, cross joins, and join-aware struct projections
- Unify composable query sources under `QueryOperand` and support `UNION` / `EXCEPT` with result-level ordering, limits, `count`, `exists`, `get`, and `explain`

#### ORM mutations and maintenance
- Unify query-driven mutations under `from::<M>()...update()/delete()`
- Add `INSERT ... SELECT` support and ORM-side insert/overwrite builders at the end of query chains
- Add convenience helpers such as `insert_many`, `truncate`, `create_view`, `create_or_replace_view`, `drop_view`, `show_tables`, `show_views`, `describe`, and `explain`
- Keep the ORM surface focused on high-level model/query workflows rather than explicit AST export APIs

#### Fixes, docs, and tests
- Fix correlated `IN` subqueries, set-query binding/top-level ordering, and `EXCEPT DISTINCT` / `EXCEPT ALL` semantics
- Expand ORM macro tests and add SLT coverage for subqueries, unions/except, and insert-from-query cases
- Rework ORM rustdoc and README so the final API surface is documented around the current builder design

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer

This PR is large because it carries the whole ORM completion pass on top of the initial model-driven ORM groundwork. The main thread is: finish the ORM around the existing KiteSQL capability surface, keep AST details internal, and add enough tests/docs to make the new builder flow stable and understandable.
