### PR TITLE
refactor: split statistics sketch storage and add RocksDB diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "kite_sql"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name          = "kite_sql"
-version       = "0.1.7"
+version       = "0.1.8"
 edition       = "2021"
 authors       = ["Kould <kould2333@gmail.com>", "Xwg <loloxwg@gmail.com>"]
 description   = "SQL as a Function for Rust"

--- a/src/execution/dml/analyze.rs
+++ b/src/execution/dml/analyze.rs
@@ -167,9 +167,9 @@ impl Analyze {
         {
             let (histogram, sketch) =
                 builder.build(histogram_buckets.unwrap_or(DEFAULT_NUM_OF_BUCKETS))?;
-            let meta = StatisticsMeta::new(histogram, sketch);
+            let meta = StatisticsMeta::new(histogram);
 
-            unsafe { &mut (*transaction) }.save_statistics_meta(cache, table_name, meta)?;
+            unsafe { &mut (*transaction) }.save_statistics_meta(cache, table_name, meta, sketch)?;
             values.push(DataValue::Utf8 {
                 value: format!("{table_name}/{index_id}"),
                 ty: Utf8Type::Variable(None),
@@ -196,7 +196,10 @@ mod test {
     use crate::db::{DataBaseBuilder, ResultIter};
     use crate::errors::DatabaseError;
     use crate::execution::dml::analyze::DEFAULT_NUM_OF_BUCKETS;
+    use crate::expression::range_detacher::Range;
+    use crate::optimizer::core::cm_sketch::COUNT_MIN_SKETCH_STORAGE_PAGE_LEN;
     use crate::storage::{InnerIter, Storage, Transaction};
+    use crate::types::value::DataValue;
     use std::ops::Bound;
     use tempfile::TempDir;
 
@@ -204,6 +207,7 @@ mod test {
     fn test_analyze() -> Result<(), DatabaseError> {
         test_statistics_meta_roundtrip()?;
         test_meta_loader_uses_cache()?;
+        test_meta_loader_negative_cache()?;
         test_clean_expired_index()?;
 
         Ok(())
@@ -268,12 +272,16 @@ mod test {
         kite_sql.run("analyze table t1")?.done()?;
 
         let table_name = "t1".to_string().into();
-        let mut transaction = kite_sql.storage.transaction()?;
-        assert!(transaction
-            .meta_loader(kite_sql.state.meta_cache())
-            .load(&table_name, 1)?
-            .is_some());
+        let transaction = kite_sql.storage.transaction()?;
+        let loader = transaction.meta_loader(kite_sql.state.meta_cache());
+        assert!(loader.load(&table_name, 1)?.is_some());
+        assert_eq!(
+            loader.collect_count(&table_name, 1, &Range::Eq(DataValue::Int32(7)))?,
+            Some(1)
+        );
+        drop(transaction);
 
+        let mut transaction = kite_sql.storage.transaction()?;
         let (min, max) = unsafe { &*transaction.table_codec() }.statistics_index_bound("t1", 1);
         let mut iter = transaction.range(Bound::Included(min), Bound::Included(max))?;
         let mut keys: Vec<Vec<u8>> = Vec::new();
@@ -285,10 +293,37 @@ mod test {
             transaction.remove(&key)?;
         }
 
-        assert!(transaction
-            .meta_loader(kite_sql.state.meta_cache())
-            .load(&table_name, 1)?
-            .is_some());
+        let transaction = kite_sql.storage.transaction()?;
+        let loader = transaction.meta_loader(kite_sql.state.meta_cache());
+        assert!(loader.load(&table_name, 1)?.is_some());
+        assert_eq!(
+            loader.collect_count(&table_name, 1, &Range::Eq(DataValue::Int32(7)))?,
+            Some(1)
+        );
+
+        Ok(())
+    }
+
+    fn test_meta_loader_negative_cache() -> Result<(), DatabaseError> {
+        let temp_dir = TempDir::new().expect("unable to create temporary working directory");
+        let kite_sql = DataBaseBuilder::path(temp_dir.path()).build()?;
+
+        kite_sql
+            .run("create table t1 (a int primary key, b int)")?
+            .done()?;
+        kite_sql.run("create index b_index on t1 (b)")?.done()?;
+
+        let table_name = "t1".to_string().into();
+        let transaction = kite_sql.storage.transaction()?;
+        let loader = transaction.meta_loader(kite_sql.state.meta_cache());
+        assert!(loader.load(&table_name, 1)?.is_none());
+
+        let entry = kite_sql
+            .state
+            .meta_cache()
+            .get(&(table_name.clone(), 1))
+            .expect("missing statistics cache entry");
+        assert!(entry.is_none());
 
         Ok(())
     }
@@ -330,7 +365,17 @@ mod test {
         while iter.try_next()?.is_some() {
             keys += 1;
         }
-        assert_eq!(keys, 1 + DEFAULT_NUM_OF_BUCKETS.min(DEFAULT_NUM_OF_BUCKETS));
+        let table_name = "t1".to_string().into();
+        let loader = transaction.meta_loader(kite_sql.state.meta_cache());
+        let statistics_meta = loader.load(&table_name, 0)?.unwrap();
+        let statistics_sketch = transaction
+            .statistics_sketch(table_name.as_ref(), 0)?
+            .unwrap();
+        let expected_keys = 1
+            + 1
+            + statistics_sketch.storage_page_count(COUNT_MIN_SKETCH_STORAGE_PAGE_LEN)
+            + statistics_meta.histogram().buckets_len();
+        assert_eq!(keys, expected_keys);
 
         Ok(())
     }

--- a/src/optimizer/core/cm_sketch.rs
+++ b/src/optimizer/core/cm_sketch.rs
@@ -132,7 +132,7 @@ impl<K> CountMinSketch<K> {
 
     pub fn from_storage_parts(
         meta: CountMinSketchMeta,
-        mut pages: Vec<CountMinSketchPage>,
+        pages: Vec<CountMinSketchPage>,
     ) -> Result<Self, DatabaseError> {
         let width = meta.width;
         let k_num = meta.k_num;
@@ -148,7 +148,6 @@ impl<K> CountMinSketch<K> {
             ));
         }
 
-        pages.sort_by_key(|page| (page.row_idx, page.page_idx));
         let mut counters = vec![Vec::with_capacity(width); k_num];
         let mut expected_page_idx = vec![0usize; k_num];
 

--- a/src/optimizer/core/cm_sketch.rs
+++ b/src/optimizer/core/cm_sketch.rs
@@ -17,6 +17,7 @@ use crate::expression::range_detacher::Range;
 use crate::serdes::{ReferenceSerialization, ReferenceTables};
 use crate::storage::{TableCache, Transaction};
 use crate::types::value::DataValue;
+use kite_sql_serde_macros::ReferenceSerialization;
 use siphasher::sip::SipHasher13;
 use std::borrow::Borrow;
 use std::hash::{Hash, Hasher};
@@ -25,6 +26,51 @@ use std::marker::PhantomData;
 use std::{cmp, mem};
 
 pub(crate) type FastHasher = SipHasher13;
+pub(crate) const COUNT_MIN_SKETCH_STORAGE_PAGE_LEN: usize = 16 * 1024;
+
+#[derive(Debug, Clone, ReferenceSerialization)]
+pub struct CountMinSketchMeta {
+    width: usize,
+    k_num: usize,
+    page_len: usize,
+    hasher_0: FastHasher,
+    hasher_1: FastHasher,
+}
+
+impl CountMinSketchMeta {
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    pub fn k_num(&self) -> usize {
+        self.k_num
+    }
+
+    pub fn page_len(&self) -> usize {
+        self.page_len
+    }
+}
+
+impl CountMinSketchPage {
+    pub fn row_idx(&self) -> usize {
+        self.row_idx
+    }
+
+    pub fn page_idx(&self) -> usize {
+        self.page_idx
+    }
+
+    pub fn counters(&self) -> &[usize] {
+        &self.counters
+    }
+}
+
+#[derive(Debug, Clone, ReferenceSerialization)]
+pub struct CountMinSketchPage {
+    row_idx: usize,
+    page_idx: usize,
+    counters: Vec<usize>,
+}
 
 // https://github.com/jedisct1/rust-count-min-sketch
 #[derive(Debug, Clone)]
@@ -35,6 +81,122 @@ pub struct CountMinSketch<K> {
     mask: usize,
     k_num: usize,
     phantom_k: PhantomData<K>,
+}
+
+impl<K> CountMinSketch<K> {
+    pub fn storage_page_count(&self, page_len: usize) -> usize {
+        self.counters
+            .iter()
+            .map(|row| row.len().div_ceil(page_len))
+            .sum()
+    }
+
+    pub fn into_storage_parts(
+        self,
+        page_len: usize,
+    ) -> (CountMinSketchMeta, impl Iterator<Item = CountMinSketchPage>) {
+        let CountMinSketch {
+            counters,
+            hashers,
+            mask,
+            k_num,
+            ..
+        } = self;
+        let width = mask + 1;
+        let meta = CountMinSketchMeta {
+            width,
+            k_num,
+            page_len,
+            hasher_0: hashers[0].clone(),
+            hasher_1: hashers[1].clone(),
+        };
+        let pages = counters
+            .into_iter()
+            .enumerate()
+            .flat_map(move |(row_idx, counters)| {
+                let page_count = counters.len().div_ceil(page_len);
+                (0..page_count).map(move |page_idx| {
+                    let start = page_idx * page_len;
+                    let end = ((page_idx + 1) * page_len).min(counters.len());
+
+                    CountMinSketchPage {
+                        row_idx,
+                        page_idx,
+                        counters: counters[start..end].to_vec(),
+                    }
+                })
+            });
+
+        (meta, pages)
+    }
+
+    pub fn from_storage_parts(
+        meta: CountMinSketchMeta,
+        mut pages: Vec<CountMinSketchPage>,
+    ) -> Result<Self, DatabaseError> {
+        let width = meta.width;
+        let k_num = meta.k_num;
+        let page_len = meta.page_len;
+        if width == 0 || k_num == 0 || page_len == 0 {
+            return Err(DatabaseError::InvalidValue(
+                "count-min sketch storage meta is invalid".to_string(),
+            ));
+        }
+        if !width.is_power_of_two() {
+            return Err(DatabaseError::InvalidValue(
+                "count-min sketch width must be a power of two".to_string(),
+            ));
+        }
+
+        pages.sort_by_key(|page| (page.row_idx, page.page_idx));
+        let mut counters = vec![Vec::with_capacity(width); k_num];
+        let mut expected_page_idx = vec![0usize; k_num];
+
+        for CountMinSketchPage {
+            row_idx,
+            page_idx,
+            counters: page_counters,
+        } in pages
+        {
+            if row_idx >= k_num {
+                return Err(DatabaseError::InvalidValue(format!(
+                    "count-min sketch row index out of bounds: {row_idx}"
+                )));
+            }
+            if page_idx != expected_page_idx[row_idx] {
+                return Err(DatabaseError::InvalidValue(format!(
+                    "count-min sketch page sequence is invalid: row={row_idx}, page={page_idx}, expected={}",
+                    expected_page_idx[row_idx]
+                )));
+            }
+            if page_counters.len() > page_len {
+                return Err(DatabaseError::InvalidValue(format!(
+                    "count-min sketch page is too large: row={row_idx}, page={page_idx}"
+                )));
+            }
+
+            counters[row_idx].extend(page_counters);
+            expected_page_idx[row_idx] += 1;
+        }
+
+        for (row_idx, row) in counters.iter().enumerate() {
+            if row.len() != width {
+                return Err(DatabaseError::InvalidValue(format!(
+                    "count-min sketch row width mismatch: row={row_idx}, expected={width}, actual={}",
+                    row.len()
+                )));
+            }
+        }
+
+        Ok(CountMinSketch {
+            counters,
+            offsets: vec![0; k_num],
+            hashers: [meta.hasher_0, meta.hasher_1],
+            mask: width - 1,
+            k_num,
+            phantom_k: Default::default(),
+        })
+    }
 }
 
 impl CountMinSketch<DataValue> {
@@ -254,6 +416,27 @@ mod tests {
                 }
             ]),
             300
+        );
+    }
+
+    #[test]
+    fn test_storage_parts_roundtrip() {
+        let mut cms = CountMinSketch::<DataValue>::new(128, 0.95, 10.0);
+        for i in 0..256 {
+            cms.increment(&DataValue::Int32(i % 17));
+        }
+
+        let (meta, pages) = cms.clone().into_storage_parts(8);
+        let rebuilt =
+            CountMinSketch::<DataValue>::from_storage_parts(meta, pages.collect()).unwrap();
+
+        assert_eq!(
+            cms.estimate(&DataValue::Int32(3)),
+            rebuilt.estimate(&DataValue::Int32(3))
+        );
+        assert_eq!(
+            cms.estimate(&DataValue::Int32(9)),
+            rebuilt.estimate(&DataValue::Int32(9))
         );
     }
 }

--- a/src/optimizer/core/histogram.rs
+++ b/src/optimizer/core/histogram.rs
@@ -316,11 +316,14 @@ impl Histogram {
         self.meta.buckets_len
     }
 
-    pub fn collect_count(
+    pub fn collect_count<F>(
         &self,
         ranges: &[Range],
-        sketch: &CountMinSketch<DataValue>,
-    ) -> Result<usize, DatabaseError> {
+        estimate: &mut F,
+    ) -> Result<usize, DatabaseError>
+    where
+        F: FnMut(&DataValue) -> Result<usize, DatabaseError>,
+    {
         if self.buckets.is_empty() || ranges.is_empty() {
             return Ok(0);
         }
@@ -337,7 +340,7 @@ impl Histogram {
                 &mut bucket_i,
                 &mut bucket_idxs,
                 &mut count,
-                sketch,
+                estimate,
             )?;
             if is_dummy {
                 return Ok(0);
@@ -351,15 +354,18 @@ impl Histogram {
             + count)
     }
 
-    fn _collect_count(
+    fn _collect_count<F>(
         &self,
         ranges: &[Range],
         binary_i: &mut usize,
         bucket_i: &mut usize,
         bucket_idxs: &mut Vec<usize>,
         count: &mut usize,
-        sketch: &CountMinSketch<DataValue>,
-    ) -> Result<bool, DatabaseError> {
+        estimate: &mut F,
+    ) -> Result<bool, DatabaseError>
+    where
+        F: FnMut(&DataValue) -> Result<usize, DatabaseError>,
+    {
         let float_value = |value: &DataValue, prefix_len: usize| {
             let value = match value.logical_type() {
                 LogicalType::Varchar(..) | LogicalType::Char(..) => match value {
@@ -481,7 +487,7 @@ impl Histogram {
                         }
                         Bound::Excluded(val) => (
                             calc_fraction(&bucket.lower, &bucket.upper, val)?,
-                            Some(sketch.estimate(val)),
+                            Some(estimate(val)?),
                         ),
                         Bound::Unbounded => unreachable!(),
                     };
@@ -498,7 +504,7 @@ impl Histogram {
                         }
                         Bound::Excluded(val) => (
                             calc_fraction(&bucket.lower, &bucket.upper, val)?,
-                            Some(sketch.estimate(val)),
+                            Some(estimate(val)?),
                         ),
                         Bound::Unbounded => unreachable!(),
                     };
@@ -515,7 +521,7 @@ impl Histogram {
                         }
                         Bound::Excluded(val) => (
                             calc_fraction(&bucket.lower, &bucket.upper, val)?,
-                            Some(sketch.estimate(val)),
+                            Some(estimate(val)?),
                         ),
                         Bound::Unbounded => unreachable!(),
                     };
@@ -525,7 +531,7 @@ impl Histogram {
                         }
                         Bound::Excluded(val) => (
                             calc_fraction(&bucket.lower, &bucket.upper, val)?,
-                            Some(sketch.estimate(val)),
+                            Some(estimate(val)?),
                         ),
                         Bound::Unbounded => unreachable!(),
                     };
@@ -543,7 +549,7 @@ impl Histogram {
                 *count += cmp::max(temp_count, 0);
             }
             Range::Eq(value) => {
-                *count += sketch.estimate(value);
+                *count += estimate(value)?;
                 *binary_i += 1
             }
             Range::Dummy => return Ok(true),
@@ -817,6 +823,7 @@ mod tests {
         builder.append(&DataValue::Null)?;
 
         let (histogram, sketch) = builder.build(4)?;
+        let mut estimate = |value: &DataValue| Ok(sketch.estimate(value));
 
         let count_1 = histogram.collect_count(
             &[
@@ -826,7 +833,7 @@ mod tests {
                     max: Bound::Excluded(DataValue::Int32(12)),
                 },
             ],
-            &sketch,
+            &mut estimate,
         )?;
 
         assert_eq!(count_1, 9);
@@ -836,7 +843,7 @@ mod tests {
                 min: Bound::Included(DataValue::Int32(4)),
                 max: Bound::Unbounded,
             }],
-            &sketch,
+            &mut estimate,
         )?;
 
         assert_eq!(count_2, 11);
@@ -846,7 +853,7 @@ mod tests {
                 min: Bound::Excluded(DataValue::Int32(7)),
                 max: Bound::Unbounded,
             }],
-            &sketch,
+            &mut estimate,
         )?;
 
         assert_eq!(count_3, 7);
@@ -856,7 +863,7 @@ mod tests {
                 min: Bound::Unbounded,
                 max: Bound::Included(DataValue::Int32(11)),
             }],
-            &sketch,
+            &mut estimate,
         )?;
 
         assert_eq!(count_4, 12);
@@ -866,7 +873,7 @@ mod tests {
                 min: Bound::Unbounded,
                 max: Bound::Excluded(DataValue::Int32(8)),
             }],
-            &sketch,
+            &mut estimate,
         )?;
 
         assert_eq!(count_5, 8);
@@ -876,7 +883,7 @@ mod tests {
                 min: Bound::Included(DataValue::Int32(2)),
                 max: Bound::Unbounded,
             }],
-            &sketch,
+            &mut estimate,
         )?;
 
         assert_eq!(count_6, 13);
@@ -886,7 +893,7 @@ mod tests {
                 min: Bound::Excluded(DataValue::Int32(1)),
                 max: Bound::Unbounded,
             }],
-            &sketch,
+            &mut estimate,
         )?;
 
         assert_eq!(count_7, 13);
@@ -896,7 +903,7 @@ mod tests {
                 min: Bound::Unbounded,
                 max: Bound::Included(DataValue::Int32(12)),
             }],
-            &sketch,
+            &mut estimate,
         )?;
 
         assert_eq!(count_8, 13);
@@ -906,7 +913,7 @@ mod tests {
                 min: Bound::Unbounded,
                 max: Bound::Excluded(DataValue::Int32(13)),
             }],
-            &sketch,
+            &mut estimate,
         )?;
 
         assert_eq!(count_9, 13);
@@ -916,7 +923,7 @@ mod tests {
                 min: Bound::Excluded(DataValue::Int32(0)),
                 max: Bound::Excluded(DataValue::Int32(3)),
             }],
-            &sketch,
+            &mut estimate,
         )?;
 
         assert_eq!(count_10, 2);
@@ -926,7 +933,7 @@ mod tests {
                 min: Bound::Included(DataValue::Int32(1)),
                 max: Bound::Included(DataValue::Int32(2)),
             }],
-            &sketch,
+            &mut estimate,
         )?;
 
         assert_eq!(count_11, 2);

--- a/src/optimizer/core/statistics_meta.rs
+++ b/src/optimizer/core/statistics_meta.rs
@@ -39,8 +39,10 @@ impl<'a, T: Transaction> StatisticMetaLoader<'a, T> {
         index_id: IndexId,
     ) -> Result<Option<&StatisticsMeta>, DatabaseError> {
         let key = (table_name.clone(), index_id);
-        if let Some(entry) = self.cache.get(&key) {
-            return Ok(entry.as_ref().map(|entry| entry.meta()));
+        match self.cache.get(&key) {
+            Some(Some(entry)) => return Ok(Some(entry.meta())),
+            Some(None) => return Ok(None),
+            None => {}
         }
 
         let Some(statistics_meta) = self.tx.statistics_meta(table_name.as_ref(), index_id)? else {
@@ -97,43 +99,40 @@ impl<'a, T: Transaction> StatisticMetaLoader<'a, T> {
         index_id: IndexId,
     ) -> Result<Option<&CountMinSketch<DataValue>>, DatabaseError> {
         let key = (table_name.clone(), index_id);
-        if let Some(entry) = self.cache.get(&key) {
-            if let Some(entry) = entry.as_ref() {
+        match self.cache.get(&key) {
+            Some(Some(entry)) => {
                 if let Some(sketch) = entry.sketch() {
                     return Ok(Some(sketch));
                 }
-            } else {
-                return Ok(None);
             }
+            Some(None) => return Ok(None),
+            None => {}
         }
 
         let Some(sketch) = self.tx.statistics_sketch(table_name.as_ref(), index_id)? else {
             return Ok(None);
         };
-        let meta = if let Some(entry) = self.cache.get(&key) {
-            if let Some(entry) = entry.as_ref() {
-                entry.meta().clone()
-            } else {
+        let meta = match self.cache.get(&key) {
+            Some(Some(entry)) => entry.meta().clone(),
+            Some(None) | None => {
                 let Some(meta) = self.tx.statistics_meta(table_name.as_ref(), index_id)? else {
+                    self.cache.put(key, None);
                     return Ok(None);
                 };
                 meta
             }
-        } else {
-            let Some(meta) = self.tx.statistics_meta(table_name.as_ref(), index_id)? else {
-                return Ok(None);
-            };
-            meta
         };
         self.cache.put(
             key.clone(),
             Some(StatisticsMetaCacheValue::new(meta).with_sketch(sketch)),
         );
 
-        Ok(self
-            .cache
-            .get(&key)
-            .and_then(|entry| entry.as_ref().and_then(|entry| entry.sketch())))
+        Ok(match self.cache.get(&key) {
+            Some(Some(entry)) => entry.sketch(),
+            Some(None) | None => {
+                return Ok(None);
+            }
+        })
     }
 }
 

--- a/src/optimizer/core/statistics_meta.rs
+++ b/src/optimizer/core/statistics_meta.rs
@@ -47,8 +47,10 @@ impl<'a, T: Transaction> StatisticMetaLoader<'a, T> {
             self.cache.put(key, None);
             return Ok(None);
         };
-        self.cache
-            .put(key.clone(), Some(StatisticsMetaCacheValue::new(statistics_meta)));
+        self.cache.put(
+            key.clone(),
+            Some(StatisticsMetaCacheValue::new(statistics_meta)),
+        );
 
         Ok(self
             .cache
@@ -207,10 +209,7 @@ pub struct StatisticsMetaCacheValue {
 
 impl StatisticsMetaCacheValue {
     pub fn new(meta: StatisticsMeta) -> Self {
-        Self {
-            meta,
-            sketch: None,
-        }
+        Self { meta, sketch: None }
     }
 
     pub fn with_sketch(mut self, sketch: CountMinSketch<DataValue>) -> Self {

--- a/src/optimizer/core/statistics_meta.rs
+++ b/src/optimizer/core/statistics_meta.rs
@@ -16,7 +16,7 @@ use crate::catalog::TableName;
 use crate::errors::DatabaseError;
 use crate::expression::range_detacher::Range;
 use crate::optimizer::core::cm_sketch::CountMinSketch;
-use crate::optimizer::core::histogram::{Histogram, HistogramMeta};
+use crate::optimizer::core::histogram::{Bucket, Histogram, HistogramMeta};
 use crate::storage::{StatisticsMetaCache, Transaction};
 use crate::types::index::IndexId;
 use crate::types::value::DataValue;
@@ -39,16 +39,99 @@ impl<'a, T: Transaction> StatisticMetaLoader<'a, T> {
         index_id: IndexId,
     ) -> Result<Option<&StatisticsMeta>, DatabaseError> {
         let key = (table_name.clone(), index_id);
-        if let Some(statistics_meta) = self.cache.get(&key) {
-            return Ok(Some(statistics_meta));
+        if let Some(entry) = self.cache.get(&key) {
+            return Ok(entry.as_ref().map(|entry| entry.meta()));
         }
 
         let Some(statistics_meta) = self.tx.statistics_meta(table_name.as_ref(), index_id)? else {
+            self.cache.put(key, None);
             return Ok(None);
         };
-        self.cache.put(key.clone(), statistics_meta);
+        self.cache
+            .put(key.clone(), Some(StatisticsMetaCacheValue::new(statistics_meta)));
 
-        Ok(self.cache.get(&key))
+        Ok(self
+            .cache
+            .get(&key)
+            .and_then(|entry| entry.as_ref().map(|entry| entry.meta())))
+    }
+
+    pub fn collect_count(
+        &self,
+        table_name: &TableName,
+        index_id: IndexId,
+        range: &Range,
+    ) -> Result<Option<usize>, DatabaseError> {
+        let Some(statistics_meta) = self.load(table_name, index_id)? else {
+            return Ok(None);
+        };
+        let ranges = if let Range::SortedRanges(ranges) = range {
+            ranges.as_slice()
+        } else {
+            slice::from_ref(range)
+        };
+        let mut sketch = None;
+        let mut estimate = |value: &DataValue| -> Result<usize, DatabaseError> {
+            if sketch.is_none() {
+                sketch = self.load_sketch(table_name, index_id)?;
+            }
+            sketch
+                .as_ref()
+                .ok_or_else(|| {
+                    DatabaseError::InvalidValue("statistics sketch is incomplete".to_string())
+                })
+                .map(|sketch| sketch.estimate(value))
+        };
+
+        statistics_meta
+            .histogram()
+            .collect_count(ranges, &mut estimate)
+            .map(Some)
+    }
+
+    fn load_sketch(
+        &self,
+        table_name: &TableName,
+        index_id: IndexId,
+    ) -> Result<Option<&CountMinSketch<DataValue>>, DatabaseError> {
+        let key = (table_name.clone(), index_id);
+        if let Some(entry) = self.cache.get(&key) {
+            if let Some(entry) = entry.as_ref() {
+                if let Some(sketch) = entry.sketch() {
+                    return Ok(Some(sketch));
+                }
+            } else {
+                return Ok(None);
+            }
+        }
+
+        let Some(sketch) = self.tx.statistics_sketch(table_name.as_ref(), index_id)? else {
+            return Ok(None);
+        };
+        let meta = if let Some(entry) = self.cache.get(&key) {
+            if let Some(entry) = entry.as_ref() {
+                entry.meta().clone()
+            } else {
+                let Some(meta) = self.tx.statistics_meta(table_name.as_ref(), index_id)? else {
+                    return Ok(None);
+                };
+                meta
+            }
+        } else {
+            let Some(meta) = self.tx.statistics_meta(table_name.as_ref(), index_id)? else {
+                return Ok(None);
+            };
+            meta
+        };
+        self.cache.put(
+            key.clone(),
+            Some(StatisticsMetaCacheValue::new(meta).with_sketch(sketch)),
+        );
+
+        Ok(self
+            .cache
+            .get(&key)
+            .and_then(|entry| entry.as_ref().and_then(|entry| entry.sketch())))
     }
 }
 
@@ -56,15 +139,13 @@ impl<'a, T: Transaction> StatisticMetaLoader<'a, T> {
 pub struct StatisticsMetaRoot {
     index_id: IndexId,
     histogram_meta: HistogramMeta,
-    cm_sketch: CountMinSketch<DataValue>,
 }
 
 impl StatisticsMetaRoot {
-    pub fn new(histogram_meta: HistogramMeta, cm_sketch: CountMinSketch<DataValue>) -> Self {
+    pub fn new(histogram_meta: HistogramMeta) -> Self {
         Self {
             index_id: histogram_meta.index_id(),
             histogram_meta,
-            cm_sketch,
         }
     }
 
@@ -76,12 +157,8 @@ impl StatisticsMetaRoot {
         &self.histogram_meta
     }
 
-    pub fn cm_sketch(&self) -> &CountMinSketch<DataValue> {
-        &self.cm_sketch
-    }
-
-    pub fn into_parts(self) -> (HistogramMeta, CountMinSketch<DataValue>) {
-        (self.histogram_meta, self.cm_sketch)
+    pub fn into_histogram_meta(self) -> HistogramMeta {
+        self.histogram_meta
     }
 }
 
@@ -89,39 +166,28 @@ impl StatisticsMetaRoot {
 pub struct StatisticsMeta {
     index_id: IndexId,
     histogram: Histogram,
-    cm_sketch: CountMinSketch<DataValue>,
 }
 
 impl StatisticsMeta {
-    pub fn new(histogram: Histogram, cm_sketch: CountMinSketch<DataValue>) -> Self {
+    pub fn new(histogram: Histogram) -> Self {
         StatisticsMeta {
             index_id: histogram.index_id(),
             histogram,
-            cm_sketch,
         }
     }
 
     pub fn from_parts(
         root: StatisticsMetaRoot,
-        buckets: Vec<crate::optimizer::core::histogram::Bucket>,
+        buckets: Vec<Bucket>,
     ) -> Result<Self, DatabaseError> {
-        let (histogram_meta, cm_sketch) = root.into_parts();
-        let histogram = Histogram::from_parts(histogram_meta, buckets)?;
+        let histogram = Histogram::from_parts(root.into_histogram_meta(), buckets)?;
 
-        Ok(Self::new(histogram, cm_sketch))
+        Ok(Self::new(histogram))
     }
 
-    pub fn into_parts(
-        self,
-    ) -> (
-        StatisticsMetaRoot,
-        Vec<crate::optimizer::core::histogram::Bucket>,
-    ) {
+    pub fn into_parts(self) -> (StatisticsMetaRoot, Vec<Bucket>) {
         let (histogram_meta, buckets) = self.histogram.into_parts();
-        (
-            StatisticsMetaRoot::new(histogram_meta, self.cm_sketch),
-            buckets,
-        )
+        (StatisticsMetaRoot::new(histogram_meta), buckets)
     }
 
     pub fn index_id(&self) -> IndexId {
@@ -131,17 +197,33 @@ impl StatisticsMeta {
     pub fn histogram(&self) -> &Histogram {
         &self.histogram
     }
+}
 
-    pub fn collect_count(&self, range: &Range) -> Result<usize, DatabaseError> {
-        let mut count = 0;
+#[derive(Debug, Clone)]
+pub struct StatisticsMetaCacheValue {
+    meta: StatisticsMeta,
+    sketch: Option<CountMinSketch<DataValue>>,
+}
 
-        let ranges = if let Range::SortedRanges(ranges) = range {
-            ranges.as_slice()
-        } else {
-            slice::from_ref(range)
-        };
-        count += self.histogram.collect_count(ranges, &self.cm_sketch)?;
-        Ok(count)
+impl StatisticsMetaCacheValue {
+    pub fn new(meta: StatisticsMeta) -> Self {
+        Self {
+            meta,
+            sketch: None,
+        }
+    }
+
+    pub fn with_sketch(mut self, sketch: CountMinSketch<DataValue>) -> Self {
+        self.sketch = Some(sketch);
+        self
+    }
+
+    pub fn meta(&self) -> &StatisticsMeta {
+        &self.meta
+    }
+
+    pub fn sketch(&self) -> Option<&CountMinSketch<DataValue>> {
+        self.sketch.as_ref()
     }
 }
 
@@ -188,16 +270,12 @@ mod tests {
         builder.append(&Arc::new(DataValue::Null))?;
         builder.append(&Arc::new(DataValue::Null))?;
 
-        let (histogram, sketch) = builder.build(4)?;
-        let meta = StatisticsMeta::new(histogram.clone(), sketch.clone());
+        let (histogram, _) = builder.build(4)?;
+        let meta = StatisticsMeta::new(histogram.clone());
         let (root, buckets) = meta.into_parts();
         let statistics_meta = StatisticsMeta::from_parts(root, buckets)?;
 
         assert_eq!(histogram, statistics_meta.histogram);
-        assert_eq!(
-            sketch.estimate(&DataValue::Null),
-            statistics_meta.cm_sketch.estimate(&DataValue::Null)
-        );
 
         Ok(())
     }

--- a/src/optimizer/rule/implementation/dql/table_scan.rs
+++ b/src/optimizer/rule/implementation/dql/table_scan.rs
@@ -87,10 +87,9 @@ impl<T: Transaction> ImplementationRule<T> for IndexScanImplementation {
                 let mut cost = None;
 
                 if let Some(range) = &index_info.range {
-                    if let Some(statistics_meta) =
-                        loader.load(&scan_op.table_name, index_info.meta.id)?
+                    if let Some(mut row_count) =
+                        loader.collect_count(&scan_op.table_name, index_info.meta.id, range)?
                     {
-                        let mut row_count = statistics_meta.collect_count(range)?;
                         if index_info.covered_deserializers.is_none()
                             && !matches!(index_info.meta.ty, IndexType::PrimaryKey { .. })
                         {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -22,10 +22,15 @@ use crate::catalog::{ColumnCatalog, ColumnRef, TableCatalog, TableMeta, TableNam
 use crate::errors::DatabaseError;
 use crate::expression::range_detacher::Range;
 use crate::expression::ScalarExpression;
-use crate::optimizer::core::statistics_meta::{StatisticMetaLoader, StatisticsMeta};
+use crate::optimizer::core::cm_sketch::{
+    CountMinSketch, CountMinSketchPage, COUNT_MIN_SKETCH_STORAGE_PAGE_LEN,
+};
+use crate::optimizer::core::statistics_meta::{
+    StatisticMetaLoader, StatisticsMeta, StatisticsMetaCacheValue,
+};
 use crate::planner::operator::alter_table::change_column::{DefaultChange, NotNullChange};
 use crate::serdes::ReferenceTables;
-use crate::storage::table_codec::{BumpBytes, Bytes, TableCodec};
+use crate::storage::table_codec::{BumpBytes, Bytes, StatisticsCodecType, TableCodec};
 use crate::types::index::{Index, IndexId, IndexMeta, IndexMetaRef, IndexType};
 use crate::types::serialize::TupleValueSerializableImpl;
 use crate::types::tuple::{Tuple, TupleId};
@@ -42,7 +47,8 @@ use std::sync::Arc;
 use std::vec::IntoIter;
 use ulid::Generator;
 
-pub(crate) type StatisticsMetaCache = SharedLruCache<(TableName, IndexId), StatisticsMeta>;
+pub(crate) type StatisticsMetaCache =
+    SharedLruCache<(TableName, IndexId), Option<StatisticsMetaCacheValue>>;
 pub(crate) type TableCache = SharedLruCache<TableName, TableCatalog>;
 pub(crate) type ViewCache = SharedLruCache<TableName, View>;
 
@@ -767,12 +773,30 @@ pub trait Transaction: Sized {
         meta_cache: &StatisticsMetaCache,
         table_name: &TableName,
         statistics_meta: StatisticsMeta,
+        cm_sketch: CountMinSketch<DataValue>,
     ) -> Result<(), DatabaseError> {
         let index_id = statistics_meta.index_id();
         let (root, buckets) = statistics_meta.clone().into_parts();
         let (key, value) =
             unsafe { &*self.table_codec() }.encode_statistics_meta(table_name.as_ref(), &root)?;
         self.set(key, value)?;
+        let cached_sketch = cm_sketch.clone();
+        let (sketch_meta, sketch_pages) =
+            cm_sketch.into_storage_parts(COUNT_MIN_SKETCH_STORAGE_PAGE_LEN);
+        let (key, value) = unsafe { &*self.table_codec() }.encode_statistics_sketch_meta(
+            table_name.as_ref(),
+            index_id,
+            &sketch_meta,
+        )?;
+        self.set(key, value)?;
+        for sketch_page in sketch_pages {
+            let (key, value) = unsafe { &*self.table_codec() }.encode_statistics_sketch_page(
+                table_name.as_ref(),
+                index_id,
+                &sketch_page,
+            )?;
+            self.set(key, value)?;
+        }
 
         for (ordinal, bucket) in buckets.iter().enumerate() {
             let (key, value) = unsafe { &*self.table_codec() }.encode_statistics_bucket(
@@ -784,7 +808,10 @@ pub trait Transaction: Sized {
             self.set(key, value)?;
         }
 
-        meta_cache.put((table_name.clone(), index_id), statistics_meta);
+        meta_cache.put(
+            (table_name.clone(), index_id),
+            Some(StatisticsMetaCacheValue::new(statistics_meta).with_sketch(cached_sketch)),
+        );
 
         Ok(())
     }
@@ -799,21 +826,70 @@ pub trait Transaction: Sized {
         let mut iter = self.range(Bound::Included(min), Bound::Included(max))?;
         let mut root = None;
         let mut buckets = Vec::new();
+        let mut has_extra = false;
 
         while let Some((key, value)) = iter.try_next()? {
-            if key.len()
-                == unsafe { &*self.table_codec() }
-                    .encode_statistics_meta_key(table_name, index_id)
-                    .len()
+            match unsafe { &*self.table_codec() }
+                .decode_statistics_codec_type(table_name, index_id, &key)?
             {
-                root = Some(TableCodec::decode_statistics_meta::<Self>(&value)?);
-            } else {
-                buckets.push(TableCodec::decode_statistics_bucket::<Self>(&value)?);
+                StatisticsCodecType::Root => {
+                    root = Some(TableCodec::decode_statistics_meta::<Self>(&value)?);
+                }
+                StatisticsCodecType::SketchMeta | StatisticsCodecType::SketchPage => {
+                    has_extra = true
+                }
+                StatisticsCodecType::Bucket => {
+                    buckets.push(TableCodec::decode_statistics_bucket::<Self>(&value)?);
+                }
             }
         }
 
-        root.map(|root| StatisticsMeta::from_parts(root, buckets))
-            .transpose()
+        match root {
+            Some(root) => StatisticsMeta::from_parts(root, buckets).map(Some),
+            None if !has_extra && buckets.is_empty() => Ok(None),
+            _ => Err(DatabaseError::InvalidValue(
+                "statistics meta is incomplete".to_string(),
+            )),
+        }
+    }
+
+    fn statistics_sketch(
+        &self,
+        table_name: &str,
+        index_id: IndexId,
+    ) -> Result<Option<CountMinSketch<DataValue>>, DatabaseError> {
+        let (min, max) =
+            unsafe { &*self.table_codec() }.statistics_index_bound(table_name, index_id);
+        let mut iter = self.range(Bound::Included(min), Bound::Included(max))?;
+        let mut sketch_meta = None;
+        let mut sketch_pages = Vec::<CountMinSketchPage>::new();
+        let mut has_root_or_bucket = false;
+
+        while let Some((key, value)) = iter.try_next()? {
+            match unsafe { &*self.table_codec() }
+                .decode_statistics_codec_type(table_name, index_id, &key)?
+            {
+                StatisticsCodecType::Root | StatisticsCodecType::Bucket => {
+                    has_root_or_bucket = true
+                }
+                StatisticsCodecType::SketchMeta => {
+                    sketch_meta = Some(TableCodec::decode_statistics_sketch_meta::<Self>(&value)?);
+                }
+                StatisticsCodecType::SketchPage => {
+                    sketch_pages.push(TableCodec::decode_statistics_sketch_page::<Self>(&value)?);
+                }
+            }
+        }
+
+        match sketch_meta {
+            Some(sketch_meta) => {
+                CountMinSketch::from_storage_parts(sketch_meta, sketch_pages).map(Some)
+            }
+            None if !has_root_or_bucket && sketch_pages.is_empty() => Ok(None),
+            _ => Err(DatabaseError::InvalidValue(
+                "statistics sketch is incomplete".to_string(),
+            )),
+        }
     }
 
     fn remove_statistics_meta(
@@ -1547,8 +1623,6 @@ mod test {
     use crate::db::test::build_table;
     use crate::errors::DatabaseError;
     use crate::expression::range_detacher::Range;
-    use crate::expression::ScalarExpression;
-    use crate::planner::operator::alter_table::change_column::{DefaultChange, NotNullChange};
     use crate::storage::rocksdb::{RocksStorage, RocksTransaction};
     use crate::storage::table_codec::TableCodec;
     use crate::storage::{

--- a/src/storage/rocksdb.rs
+++ b/src/storage/rocksdb.rs
@@ -35,6 +35,12 @@ const ROCKSDB_MEMTABLE_PREFIX_BLOOM_RATIO: f64 = 0.10;
 pub struct RocksDbMetrics {
     pub block_cache_hit: Option<u64>,
     pub block_cache_miss: Option<u64>,
+    pub block_cache_data_hit: Option<u64>,
+    pub block_cache_data_miss: Option<u64>,
+    pub block_cache_index_hit: Option<u64>,
+    pub block_cache_index_miss: Option<u64>,
+    pub block_cache_filter_hit: Option<u64>,
+    pub block_cache_filter_miss: Option<u64>,
     pub stall_micros: Option<u64>,
     pub compaction_pending_bytes: Option<u64>,
     pub write_amp: Option<f64>,
@@ -57,6 +63,60 @@ impl RocksDbMetrics {
 
         Some(hit as f64 / total as f64)
     }
+
+    #[inline]
+    pub fn delta_since(&self, base: &Self) -> Self {
+        Self {
+            block_cache_hit: subtract_optional_u64(self.block_cache_hit, base.block_cache_hit),
+            block_cache_miss: subtract_optional_u64(self.block_cache_miss, base.block_cache_miss),
+            block_cache_data_hit: subtract_optional_u64(
+                self.block_cache_data_hit,
+                base.block_cache_data_hit,
+            ),
+            block_cache_data_miss: subtract_optional_u64(
+                self.block_cache_data_miss,
+                base.block_cache_data_miss,
+            ),
+            block_cache_index_hit: subtract_optional_u64(
+                self.block_cache_index_hit,
+                base.block_cache_index_hit,
+            ),
+            block_cache_index_miss: subtract_optional_u64(
+                self.block_cache_index_miss,
+                base.block_cache_index_miss,
+            ),
+            block_cache_filter_hit: subtract_optional_u64(
+                self.block_cache_filter_hit,
+                base.block_cache_filter_hit,
+            ),
+            block_cache_filter_miss: subtract_optional_u64(
+                self.block_cache_filter_miss,
+                base.block_cache_filter_miss,
+            ),
+            stall_micros: subtract_optional_u64(self.stall_micros, base.stall_micros),
+            compaction_pending_bytes: self.compaction_pending_bytes,
+            write_amp: self.write_amp,
+        }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        [
+            self.block_cache_hit,
+            self.block_cache_miss,
+            self.block_cache_data_hit,
+            self.block_cache_data_miss,
+            self.block_cache_index_hit,
+            self.block_cache_index_miss,
+            self.block_cache_filter_hit,
+            self.block_cache_filter_miss,
+            self.stall_micros,
+            self.compaction_pending_bytes,
+        ]
+        .into_iter()
+        .flatten()
+        .all(|value| value == 0)
+    }
 }
 
 impl Display for RocksDbMetrics {
@@ -68,6 +128,16 @@ impl Display for RocksDbMetrics {
             format_optional_u64(self.block_cache_hit),
             format_optional_u64(self.block_cache_miss),
             format_optional_pct(self.block_cache_hit_rate()),
+        )?;
+        writeln!(
+            f,
+            "block_cache_data_hit={} block_cache_data_miss={} block_cache_index_hit={} block_cache_index_miss={} block_cache_filter_hit={} block_cache_filter_miss={}",
+            format_optional_u64(self.block_cache_data_hit),
+            format_optional_u64(self.block_cache_data_miss),
+            format_optional_u64(self.block_cache_index_hit),
+            format_optional_u64(self.block_cache_index_miss),
+            format_optional_u64(self.block_cache_filter_hit),
+            format_optional_u64(self.block_cache_filter_miss),
         )?;
         write!(
             f,
@@ -144,6 +214,12 @@ fn collect_metrics(
 ) -> RocksDbMetrics {
     let block_cache_hit = Some(options.get_ticker_count(Ticker::BlockCacheHit));
     let block_cache_miss = Some(options.get_ticker_count(Ticker::BlockCacheMiss));
+    let block_cache_data_hit = Some(options.get_ticker_count(Ticker::BlockCacheDataHit));
+    let block_cache_data_miss = Some(options.get_ticker_count(Ticker::BlockCacheDataMiss));
+    let block_cache_index_hit = Some(options.get_ticker_count(Ticker::BlockCacheIndexHit));
+    let block_cache_index_miss = Some(options.get_ticker_count(Ticker::BlockCacheIndexMiss));
+    let block_cache_filter_hit = Some(options.get_ticker_count(Ticker::BlockCacheFilterHit));
+    let block_cache_filter_miss = Some(options.get_ticker_count(Ticker::BlockCacheFilterMiss));
     let stall_micros = Some(options.get_ticker_count(Ticker::StallMicros));
     let compaction_pending_bytes = int_property("rocksdb.estimate-pending-compaction-bytes")
         .ok()
@@ -153,6 +229,12 @@ fn collect_metrics(
     RocksDbMetrics {
         block_cache_hit,
         block_cache_miss,
+        block_cache_data_hit,
+        block_cache_data_miss,
+        block_cache_index_hit,
+        block_cache_index_miss,
+        block_cache_filter_hit,
+        block_cache_filter_miss,
         stall_micros,
         compaction_pending_bytes,
         write_amp,
@@ -197,6 +279,14 @@ fn format_optional_pct(value: Option<f64>) -> String {
     value
         .map(|v| format!("{:.2}%", v * 100.0))
         .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn subtract_optional_u64(lhs: Option<u64>, rhs: Option<u64>) -> Option<u64> {
+    match (lhs, rhs) {
+        (Some(lhs), Some(rhs)) => Some(lhs.saturating_sub(rhs)),
+        (Some(lhs), None) => Some(lhs),
+        _ => None,
+    }
 }
 
 fn default_opts(config: StorageConfig) -> Options {

--- a/src/storage/table_codec.rs
+++ b/src/storage/table_codec.rs
@@ -15,6 +15,7 @@
 use crate::catalog::view::View;
 use crate::catalog::{ColumnRef, ColumnRelation, TableMeta};
 use crate::errors::DatabaseError;
+use crate::optimizer::core::cm_sketch::{CountMinSketchMeta, CountMinSketchPage};
 use crate::optimizer::core::histogram::Bucket;
 use crate::optimizer::core::statistics_meta::StatisticsMetaRoot;
 use crate::serdes::{ReferenceSerialization, ReferenceTables};
@@ -64,6 +65,37 @@ enum CodecType {
     Tuple,
     Root,
     Hash,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StatisticsCodecType {
+    Root,
+    SketchMeta,
+    SketchPage,
+    Bucket,
+}
+
+impl StatisticsCodecType {
+    fn tag(self) -> u8 {
+        match self {
+            StatisticsCodecType::Root => b'0',
+            StatisticsCodecType::SketchMeta => b'1',
+            StatisticsCodecType::SketchPage => b'2',
+            StatisticsCodecType::Bucket => b'3',
+        }
+    }
+
+    fn from_tag(tag: u8) -> Result<Self, DatabaseError> {
+        match tag {
+            b'0' => Ok(StatisticsCodecType::Root),
+            b'1' => Ok(StatisticsCodecType::SketchMeta),
+            b'2' => Ok(StatisticsCodecType::SketchPage),
+            b'3' => Ok(StatisticsCodecType::Bucket),
+            _ => Err(DatabaseError::InvalidValue(format!(
+                "invalid statistics codec tag: {tag}"
+            ))),
+        }
+    }
 }
 
 impl TableCodec {
@@ -133,11 +165,11 @@ impl TableCodec {
             CodecType::IndexMeta => {
                 table_bytes.push(b'1');
             }
-            CodecType::Index => {
+            CodecType::Statistics => {
                 table_bytes.push(b'3');
             }
-            CodecType::Statistics => {
-                table_bytes.push(b'4');
+            CodecType::Index => {
+                table_bytes.push(b'7');
             }
             CodecType::Tuple => {
                 table_bytes.push(b'8');
@@ -483,18 +515,105 @@ impl TableCodec {
         Ok((key, value))
     }
 
-    pub fn encode_statistics_meta_key(&self, table_name: &str, index_id: IndexId) -> BumpBytes<'_> {
-        let mut key_prefix = self.key_prefix(CodecType::Statistics, table_name);
+    fn encode_statistics_index_prefix(&self, table_name: &str, index_id: IndexId) -> BumpBytes<'_> {
+        let mut key = self.key_prefix(CodecType::Statistics, table_name);
 
-        key_prefix.push(BOUND_MIN_TAG);
-        key_prefix.extend(index_id.to_le_bytes());
-        key_prefix
+        key.push(BOUND_MIN_TAG);
+        key.extend(index_id.to_le_bytes());
+        key
+    }
+
+    fn encode_statistics_key_prefix(
+        &self,
+        table_name: &str,
+        index_id: IndexId,
+        ty: StatisticsCodecType,
+    ) -> BumpBytes<'_> {
+        let mut key = self.encode_statistics_index_prefix(table_name, index_id);
+        key.push(ty.tag());
+        key
+    }
+
+    pub fn encode_statistics_meta_key(&self, table_name: &str, index_id: IndexId) -> BumpBytes<'_> {
+        self.encode_statistics_key_prefix(table_name, index_id, StatisticsCodecType::Root)
     }
 
     pub fn decode_statistics_meta<T: Transaction>(
         bytes: &[u8],
     ) -> Result<StatisticsMetaRoot, DatabaseError> {
         StatisticsMetaRoot::decode::<T, _>(&mut Cursor::new(bytes), None, &ReferenceTables::new())
+    }
+
+    /// Key: {TableName}{STATISTICS_TAG}{BOUND_MIN_TAG}{INDEX_ID}{SKETCH_META_TAG}
+    /// Value: CountMinSketchMeta
+    pub fn encode_statistics_sketch_meta(
+        &self,
+        table_name: &str,
+        index_id: IndexId,
+        sketch_meta: &CountMinSketchMeta,
+    ) -> Result<(BumpBytes<'_>, BumpBytes<'_>), DatabaseError> {
+        let key = self.encode_statistics_sketch_meta_key(table_name, index_id);
+        let mut value = BumpBytes::new_in(&self.arena);
+
+        sketch_meta.encode(&mut value, true, &mut ReferenceTables::new())?;
+
+        Ok((key, value))
+    }
+
+    pub fn encode_statistics_sketch_meta_key(
+        &self,
+        table_name: &str,
+        index_id: IndexId,
+    ) -> BumpBytes<'_> {
+        self.encode_statistics_key_prefix(table_name, index_id, StatisticsCodecType::SketchMeta)
+    }
+
+    pub fn decode_statistics_sketch_meta<T: Transaction>(
+        bytes: &[u8],
+    ) -> Result<CountMinSketchMeta, DatabaseError> {
+        CountMinSketchMeta::decode::<T, _>(&mut Cursor::new(bytes), None, &ReferenceTables::new())
+    }
+
+    /// Key: {TableName}{STATISTICS_TAG}{BOUND_MIN_TAG}{INDEX_ID}{SKETCH_PAGE_TAG}{BOUND_MIN_TAG}{ROW_ID}{BOUND_MIN_TAG}{PAGE_ID}
+    /// Value: CountMinSketchPage
+    pub fn encode_statistics_sketch_page(
+        &self,
+        table_name: &str,
+        index_id: IndexId,
+        sketch_page: &CountMinSketchPage,
+    ) -> Result<(BumpBytes<'_>, BumpBytes<'_>), DatabaseError> {
+        let key = self.encode_statistics_sketch_page_key(table_name, index_id, sketch_page)?;
+        let mut value = BumpBytes::new_in(&self.arena);
+
+        sketch_page.encode(&mut value, true, &mut ReferenceTables::new())?;
+
+        Ok((key, value))
+    }
+
+    pub fn encode_statistics_sketch_page_key(
+        &self,
+        table_name: &str,
+        index_id: IndexId,
+        sketch_page: &CountMinSketchPage,
+    ) -> Result<BumpBytes<'_>, DatabaseError> {
+        let mut key = self.encode_statistics_key_prefix(
+            table_name,
+            index_id,
+            StatisticsCodecType::SketchPage,
+        );
+
+        key.write_all(&[BOUND_MIN_TAG])?;
+        key.write_all(&(sketch_page.row_idx() as u32).to_be_bytes())?;
+        key.write_all(&[BOUND_MIN_TAG])?;
+        key.write_all(&(sketch_page.page_idx() as u32).to_be_bytes())?;
+
+        Ok(key)
+    }
+
+    pub fn decode_statistics_sketch_page<T: Transaction>(
+        bytes: &[u8],
+    ) -> Result<CountMinSketchPage, DatabaseError> {
+        CountMinSketchPage::decode::<T, _>(&mut Cursor::new(bytes), None, &ReferenceTables::new())
     }
 
     pub fn encode_statistics_bucket(
@@ -518,11 +637,30 @@ impl TableCodec {
         index_id: IndexId,
         ordinal: u32,
     ) -> BumpBytes<'_> {
-        let mut key = self.encode_statistics_meta_key(table_name, index_id);
+        let mut key =
+            self.encode_statistics_key_prefix(table_name, index_id, StatisticsCodecType::Bucket);
 
         key.push(BOUND_MIN_TAG);
         key.extend_from_slice(&ordinal.to_be_bytes());
         key
+    }
+
+    pub(crate) fn decode_statistics_codec_type(
+        &self,
+        table_name: &str,
+        index_id: IndexId,
+        key: &[u8],
+    ) -> Result<StatisticsCodecType, DatabaseError> {
+        let prefix_len = self
+            .encode_statistics_index_prefix(table_name, index_id)
+            .len();
+        let Some(tag) = key.get(prefix_len).copied() else {
+            return Err(DatabaseError::InvalidValue(
+                "statistics key is too short".to_string(),
+            ));
+        };
+
+        StatisticsCodecType::from_tag(tag)
     }
 
     pub fn decode_statistics_bucket<T: Transaction>(bytes: &[u8]) -> Result<Bucket, DatabaseError> {
@@ -545,7 +683,7 @@ impl TableCodec {
         table_name: &str,
         index_id: IndexId,
     ) -> (BumpBytes<'_>, BumpBytes<'_>) {
-        let min = self.encode_statistics_meta_key(table_name, index_id);
+        let min = self.encode_statistics_index_prefix(table_name, index_id);
         let mut max = min.clone();
         max.push(BOUND_MAX_TAG);
 
@@ -743,7 +881,7 @@ mod tests {
             builder.append(&DataValue::Int32(value))?;
         }
         let (histogram, sketch) = builder.build(2)?;
-        let (root, buckets) = StatisticsMeta::new(histogram, sketch).into_parts();
+        let (root, buckets) = StatisticsMeta::new(histogram).into_parts();
 
         let (_, root_bytes) = table_codec.encode_statistics_meta("t1", &root)?;
         let decoded_root = TableCodec::decode_statistics_meta::<RocksTransaction>(&root_bytes)?;
@@ -756,10 +894,21 @@ mod tests {
             decoded_root.histogram_meta().buckets_len(),
             root.histogram_meta().buckets_len()
         );
-        assert_eq!(
-            decoded_root.cm_sketch().estimate(&DataValue::Null),
-            root.cm_sketch().estimate(&DataValue::Null)
-        );
+
+        let (sketch_meta, mut sketch_pages) = sketch.clone().into_storage_parts(1);
+        let (_, sketch_meta_bytes) =
+            table_codec.encode_statistics_sketch_meta("t1", 0, &sketch_meta)?;
+        let decoded_sketch_meta =
+            TableCodec::decode_statistics_sketch_meta::<RocksTransaction>(&sketch_meta_bytes)?;
+        assert_eq!(decoded_sketch_meta.width(), sketch_meta.width());
+        assert_eq!(decoded_sketch_meta.k_num(), sketch_meta.k_num());
+
+        let first_sketch_page = sketch_pages.next().unwrap();
+        let (_, sketch_page_bytes) =
+            table_codec.encode_statistics_sketch_page("t1", 0, &first_sketch_page)?;
+        let decoded_sketch_page =
+            TableCodec::decode_statistics_sketch_page::<RocksTransaction>(&sketch_page_bytes)?;
+        assert_eq!(decoded_sketch_page.counters(), first_sketch_page.counters());
 
         let bucket0_key = table_codec.encode_statistics_bucket_key("t1", 0, 0);
         let bucket1_key = table_codec.encode_statistics_bucket_key("t1", 0, 1);


### PR DESCRIPTION
### What problem does this PR solve?

- The previous statistics layout stored the Count-Min Sketch too close to hot table/index data, which made RocksDB locality worse and showed up as a large TPCC regression.
- Statistics cache misses were also repeatedly falling back to storage, including negative lookup cases, which made the regression harder to reason about.
- We also lacked phase-level RocksDB diagnostics, so it was difficult to tell whether cache misses came from load, analyze, or the measured TPCC workload.

Issue link:

### What is changed and how it works?

- Split Count-Min Sketch persistence out of the statistics root and store it as sketch meta + sketch pages.
- Keep histogram metadata and buckets as the eager statistics payload, and load sketch data lazily only when `collect_count` actually needs it.
- Change `StatisticsMetaCache` to cache both positive entries and negative lookup results via `Option`, so repeated misses do not keep hitting storage.
- Update `ANALYZE`, storage codecs, and transaction APIs to read/write the new statistics layout.
- Add richer RocksDB metrics, including data/index/filter cache hit/miss counters and TPCC phase snapshots, so locality regressions are easier to diagnose.
- Bump crate version to `0.1.8` for the next publish.

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test steps:

- `cargo test test_analyze --lib`
- `cargo check -p tpcc -p kite_sql`
- `cargo run -p tpcc --release -- --backend kite --measure-time 60 --num-ware 1 --rocksdb-stats --path /tmp/kitesql_tpcc_phase_metrics`
  - Observed TPCC stayed in the restored ~24k TpmC range and phase metrics showed misses were dominated by data blocks during the measured phase.

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer

- The core of this PR is the sketch-storage split and the cache/load path changes around statistics.
- The RocksDB TPCC diagnostics are included to validate the locality impact of the refactor and to make future regressions easier to spot.
