### PR TITLE
feat(checkpoint): add storage checkpoint API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "kite_sql_serde_macros"
-version = "0.2.1"
+version = "0.2.0"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "kite_sql"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -1329,6 +1329,7 @@ dependencies = [
  "itertools 0.12.1",
  "js-sys",
  "kite_sql_serde_macros",
+ "librocksdb-sys",
  "lmdb",
  "lmdb-sys",
  "log",
@@ -1360,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "kite_sql_serde_macros"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,9 @@
 
 [package]
 name          = "kite_sql"
-version       = "0.2.0"
+version       = "0.2.1"
 edition       = "2021"
+build         = "build.rs"
 authors       = ["Kould <kould2333@gmail.com>", "Xwg <loloxwg@gmail.com>"]
 description   = "SQL as a Function for Rust"
 documentation = "https://docs.rs/kite_sql/latest/kite_sql/"
@@ -28,6 +29,7 @@ default = ["macros", "rocksdb"]
 macros  = []
 orm     = []
 rocksdb = ["dep:rocksdb"]
+unsafe_txdb_checkpoint = ["rocksdb", "dep:librocksdb-sys"]
 lmdb    = ["dep:lmdb", "dep:lmdb-sys"]
 net     = ["rocksdb", "dep:pgwire", "dep:async-trait", "dep:clap", "dep:env_logger", "dep:futures", "dep:log", "dep:tokio"]
 pprof   = ["pprof/criterion", "pprof/flamegraph"]
@@ -57,7 +59,7 @@ recursive             = { version = "0.1" }
 regex                 = { version = "1" }
 rust_decimal          = { version = "1" }
 serde                 = { version = "1", features = ["derive", "rc"] }
-kite_sql_serde_macros = { version = "0.2.0", path = "kite_sql_serde_macros" }
+kite_sql_serde_macros = { version = "0.2.1", path = "kite_sql_serde_macros" }
 siphasher             = { version = "1", features = ["serde"] }
 sqlparser             = { version = "0.61", features = ["serde"] }
 thiserror             = { version = "1" }
@@ -86,6 +88,7 @@ sqlite                = { version = "0.34" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rocksdb = { version = "0.23", optional = true }
+librocksdb-sys = { version = "0.17.1", optional = true }
 lmdb = { version = "0.8.0", optional = true }
 lmdb-sys = { version = "0.8.0", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ recursive             = { version = "0.1" }
 regex                 = { version = "1" }
 rust_decimal          = { version = "1" }
 serde                 = { version = "1", features = ["derive", "rc"] }
-kite_sql_serde_macros = { version = "0.2.1", path = "kite_sql_serde_macros" }
+kite_sql_serde_macros = { version = "0.2.0", path = "kite_sql_serde_macros" }
 siphasher             = { version = "1", features = ["serde"] }
 sqlparser             = { version = "0.61", features = ["serde"] }
 thiserror             = { version = "1" }

--- a/README.md
+++ b/README.md
@@ -134,12 +134,15 @@ fn main() -> Result<(), DatabaseError> {
 - `build_lmdb()` opens a persistent LMDB-backed database.
 - `build_in_memory()` opens an in-memory database for tests, examples, and temporary workloads.
 - `build_optimistic()` is available on native targets when you specifically want optimistic transactions on top of RocksDB.
+- `Database::checkpoint(path)` creates a local consistent snapshot when the selected storage backend supports it.
 - Cargo features:
   - `rocksdb` is enabled by default
   - `lmdb` is optional
+  - `unsafe_txdb_checkpoint` enables experimental checkpoint support for RocksDB `TransactionDB`
   - `cargo check --no-default-features --features lmdb` builds an LMDB-only native configuration
 
 On native targets, `LMDB` shines when reads dominate, while `RocksDB` is usually the stronger choice when writes do.
+Checkpoint support and feature-gating details are documented in [docs/features.md](docs/features.md).
 
 👉**more examples**
 - [hello_world](examples/hello_world.rs)

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,93 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
+const SUPPORTED_ROCKSDB_VERSION: &str = "0.23.0";
+const SUPPORTED_LIBROCKSDB_SYS_VERSION: &str = "0.17.1+9.9.3";
+
+fn main() {
+    println!("cargo:rerun-if-changed=Cargo.lock");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_UNSAFE_TXDB_CHECKPOINT");
+
+    if env::var_os("CARGO_FEATURE_UNSAFE_TXDB_CHECKPOINT").is_none() {
+        return;
+    }
+
+    let lock_path = Path::new("Cargo.lock");
+    let lock_contents = fs::read_to_string(lock_path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", lock_path.display()));
+
+    ensure_locked_version(
+        &lock_contents,
+        "rocksdb",
+        SUPPORTED_ROCKSDB_VERSION,
+        "unsafe_txdb_checkpoint",
+    );
+    ensure_locked_version(
+        &lock_contents,
+        "librocksdb-sys",
+        SUPPORTED_LIBROCKSDB_SYS_VERSION,
+        "unsafe_txdb_checkpoint",
+    );
+}
+
+fn ensure_locked_version(
+    lock_contents: &str,
+    expected_name: &str,
+    expected_version: &str,
+    feature_name: &str,
+) {
+    let found_version = find_locked_version(lock_contents, expected_name);
+
+    match found_version.as_deref() {
+        Some(version) if version == expected_version => {}
+        Some(version) => panic!(
+            "feature `{feature_name}` only supports `{expected_name} = {expected_version}`, found `{expected_name} = {version}` in Cargo.lock; disable the feature or re-validate the implementation"
+        ),
+        None => panic!(
+            "feature `{feature_name}` requires `{expected_name} = {expected_version}` in Cargo.lock, but `{expected_name}` was not found"
+        ),
+    }
+}
+
+fn find_locked_version(lock_contents: &str, expected_name: &str) -> Option<String> {
+    let mut current_name = None;
+    let mut current_version = None;
+
+    for line in lock_contents.lines() {
+        let line = line.trim();
+        if line == "[[package]]" {
+            if current_name.as_deref() == Some(expected_name) {
+                return current_version;
+            }
+            current_name = None;
+            current_version = None;
+            continue;
+        }
+
+        if let Some(value) = extract_toml_string(line, "name") {
+            current_name = Some(value.to_string());
+            continue;
+        }
+
+        if let Some(value) = extract_toml_string(line, "version") {
+            current_version = Some(value.to_string());
+        }
+    }
+
+    if current_name.as_deref() == Some(expected_name) {
+        current_version
+    } else {
+        None
+    }
+}
+
+fn extract_toml_string<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+    let prefix = match key {
+        "name" => "name = \"",
+        "version" => "version = \"",
+        _ => return None,
+    };
+    let rest = line.strip_prefix(prefix)?;
+    rest.strip_suffix('"')
+}

--- a/docs/features.md
+++ b/docs/features.md
@@ -58,6 +58,35 @@ let kite_sql = DataBaseBuilder::path("./data")
 - Pessimistic (Default)
 - Optimistic
 
+### Checkpoint
+KiteSQL exposes checkpoint as a storage capability rather than a full backup workflow. A checkpoint only creates a consistent local snapshot directory; compressing, uploading, retaining, and pruning backups should stay in application code.
+
+Support matrix:
+- `build_optimistic()` supports `Database::checkpoint(...)` through RocksDB's safe checkpoint API.
+- `build_rocksdb()` requires Cargo feature `unsafe_txdb_checkpoint` because upstream `rocksdb` does not currently expose a safe `TransactionDB` checkpoint API.
+- `build_lmdb()` and `build_in_memory()` do not currently expose checkpoint support.
+
+Opt in for `TransactionDB` checkpoint support:
+```bash
+cargo check --features unsafe_txdb_checkpoint
+```
+
+Minimal usage:
+```rust
+use kite_sql::db::DataBaseBuilder;
+use kite_sql::errors::DatabaseError;
+
+fn main() -> Result<(), DatabaseError> {
+    let database = DataBaseBuilder::path("./data").build_rocksdb()?;
+
+    database.checkpoint("./backup/checkpoint-2026-03-29")?;
+
+    Ok(())
+}
+```
+
+If `unsafe_txdb_checkpoint` is not enabled, `build_rocksdb()` returns an explicit error instead of attempting the experimental implementation.
+
 ### Field options
 - [not] null
 - unique

--- a/kite_sql_serde_macros/Cargo.toml
+++ b/kite_sql_serde_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "kite_sql_serde_macros"
-version     = "0.2.0"
+version     = "0.2.1"
 edition     = "2021"
 description = "Derive macros for KiteSQL"
 documentation = "https://docs.rs/kite_sql_serde_macros/latest/kite_sql_serde_macros/"

--- a/kite_sql_serde_macros/Cargo.toml
+++ b/kite_sql_serde_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "kite_sql_serde_macros"
-version     = "0.2.1"
+version     = "0.2.0"
 edition     = "2021"
 description = "Derive macros for KiteSQL"
 documentation = "https://docs.rs/kite_sql_serde_macros/latest/kite_sql_serde_macros/"

--- a/src/db.rs
+++ b/src/db.rs
@@ -37,7 +37,9 @@ use crate::storage::lmdb::{LmdbConfig, LmdbStorage};
 use crate::storage::memory::MemoryStorage;
 #[cfg(all(not(target_arch = "wasm32"), feature = "rocksdb"))]
 use crate::storage::rocksdb::{OptimisticRocksStorage, RocksStorage, StorageConfig};
-use crate::storage::{StatisticsMetaCache, Storage, TableCache, Transaction, ViewCache};
+use crate::storage::{
+    CheckpointableStorage, StatisticsMetaCache, Storage, TableCache, Transaction, ViewCache,
+};
 use crate::types::tuple::{SchemaRef, Tuple};
 use crate::types::value::DataValue;
 use crate::utils::lru::SharedLruCache;
@@ -47,6 +49,7 @@ use parking_lot::{RawRwLock, RwLock};
 use std::hash::RandomState;
 use std::marker::PhantomData;
 use std::mem;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
@@ -675,6 +678,19 @@ impl<S: Storage> Database<S> {
     }
 }
 
+impl<S> Database<S>
+where
+    S: CheckpointableStorage,
+{
+    /// Creates an online consistent checkpoint in `path`.
+    ///
+    /// The target path must not exist or must be an empty directory.
+    #[inline]
+    pub fn checkpoint<P: AsRef<Path>>(&self, path: P) -> Result<(), DatabaseError> {
+        self.storage.create_checkpoint(path)
+    }
+}
+
 /// Borrowing interface for result iterators returned by database execution APIs.
 pub trait BorrowResultIter {
     /// Returns the output schema for the current result set.
@@ -1003,8 +1019,15 @@ pub(crate) mod test {
     use crate::types::value::DataValue;
     use crate::types::LogicalType;
     use chrono::{Datelike, Local};
+    use std::io::ErrorKind;
     use std::sync::atomic::AtomicUsize;
+    #[cfg(feature = "unsafe_txdb_checkpoint")]
+    use std::sync::atomic::Ordering;
     use std::sync::Arc;
+    #[cfg(feature = "unsafe_txdb_checkpoint")]
+    use std::thread;
+    #[cfg(feature = "unsafe_txdb_checkpoint")]
+    use std::time::Duration;
     use tempfile::TempDir;
 
     pub(crate) fn build_table<T: Transaction>(
@@ -1031,6 +1054,23 @@ pub(crate) mod test {
         let _ = transaction.create_table(table_cache, "t1".to_string().into(), columns, false)?;
 
         Ok(())
+    }
+
+    #[cfg(feature = "unsafe_txdb_checkpoint")]
+    fn query_i32<S: Storage>(
+        database: &crate::db::Database<S>,
+        sql: &str,
+    ) -> Result<i32, DatabaseError> {
+        let mut iter = database.run(sql)?;
+        let value = match iter.next().transpose()?.map(|tuple| tuple.values) {
+            Some(values) => match values.as_slice() {
+                [DataValue::Int32(value)] => *value,
+                other => panic!("expected a single Int32 column, got {other:?}"),
+            },
+            None => panic!("expected one result row for query: {sql}"),
+        };
+        iter.done()?;
+        Ok(value)
     }
 
     #[test]
@@ -1779,5 +1819,137 @@ pub(crate) mod test {
             result,
             Err(DatabaseError::InvalidValue(message)) if message == "histogram buckets must be >= 1"
         ));
+    }
+
+    #[cfg(feature = "unsafe_txdb_checkpoint")]
+    #[test]
+    fn test_checkpoint_restores_snapshot() -> Result<(), DatabaseError> {
+        let temp_dir = TempDir::new().expect("unable to create temporary working directory");
+        let live_path = temp_dir.path().join("live");
+        let checkpoint_path = temp_dir.path().join("checkpoint");
+        let kite_sql = DataBaseBuilder::path(&live_path).build_rocksdb()?;
+
+        kite_sql
+            .run("create table t_checkpoint (id int primary key, v int)")?
+            .done()?;
+        kite_sql
+            .run("insert into t_checkpoint values (1, 10), (2, 20)")?
+            .done()?;
+
+        kite_sql.checkpoint(&checkpoint_path)?;
+
+        kite_sql
+            .run("insert into t_checkpoint values (3, 30)")?
+            .done()?;
+
+        let snapshot = DataBaseBuilder::path(&checkpoint_path).build_rocksdb()?;
+        assert_eq!(
+            query_i32(&snapshot, "select count(*) from t_checkpoint")?,
+            2
+        );
+        assert_eq!(
+            query_i32(&kite_sql, "select count(*) from t_checkpoint")?,
+            3
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_checkpoint_rejects_non_empty_target_dir() -> Result<(), DatabaseError> {
+        let temp_dir = TempDir::new().expect("unable to create temporary working directory");
+        let live_path = temp_dir.path().join("live");
+        let checkpoint_path = temp_dir.path().join("checkpoint");
+        let kite_sql = DataBaseBuilder::path(&live_path).build_rocksdb()?;
+
+        std::fs::create_dir(&checkpoint_path)?;
+        std::fs::write(checkpoint_path.join("stale.txt"), b"stale")?;
+
+        let err = kite_sql
+            .checkpoint(&checkpoint_path)
+            .expect_err("checkpoint should reject non-empty directories");
+        assert!(matches!(
+            err,
+            DatabaseError::IO(ref io_err) if io_err.kind() == ErrorKind::AlreadyExists
+        ));
+
+        Ok(())
+    }
+
+    #[cfg(not(feature = "unsafe_txdb_checkpoint"))]
+    #[test]
+    fn test_checkpoint_requires_unsafe_feature() -> Result<(), DatabaseError> {
+        let temp_dir = TempDir::new().expect("unable to create temporary working directory");
+        let live_path = temp_dir.path().join("live");
+        let checkpoint_path = temp_dir.path().join("checkpoint");
+        let kite_sql = DataBaseBuilder::path(&live_path).build_rocksdb()?;
+
+        kite_sql
+            .run("create table t_checkpoint_disabled (id int primary key, v int)")?
+            .done()?;
+
+        let err = kite_sql
+            .checkpoint(&checkpoint_path)
+            .expect_err("checkpoint should require the unsafe feature");
+        assert!(matches!(err, DatabaseError::UnsupportedStmt(_)));
+
+        Ok(())
+    }
+
+    #[cfg(feature = "unsafe_txdb_checkpoint")]
+    #[test]
+    fn test_checkpoint_during_concurrent_writes() -> Result<(), DatabaseError> {
+        let temp_dir = TempDir::new().expect("unable to create temporary working directory");
+        let live_path = temp_dir.path().join("live");
+        let checkpoint_path = temp_dir.path().join("checkpoint");
+        let kite_sql = Arc::new(DataBaseBuilder::path(&live_path).build_rocksdb()?);
+
+        kite_sql
+            .run("create table t_checkpoint_concurrent (id int primary key, v int)")?
+            .done()?;
+
+        let inserted = Arc::new(AtomicUsize::new(0));
+        let writer_db = Arc::clone(&kite_sql);
+        let writer_inserted = Arc::clone(&inserted);
+        let writer = thread::spawn(move || -> Result<usize, DatabaseError> {
+            for i in 0..64 {
+                writer_db
+                    .run(format!(
+                        "insert into t_checkpoint_concurrent values ({i}, {i})"
+                    ))?
+                    .done()?;
+                writer_inserted.store(i + 1, Ordering::SeqCst);
+
+                if i >= 8 {
+                    thread::sleep(Duration::from_millis(2));
+                }
+            }
+
+            Ok(64)
+        });
+
+        while inserted.load(Ordering::SeqCst) < 8 {
+            thread::yield_now();
+        }
+
+        kite_sql.checkpoint(&checkpoint_path)?;
+
+        let total = writer.join().expect("writer thread should not panic")?;
+        let snapshot = DataBaseBuilder::path(&checkpoint_path).build_rocksdb()?;
+        let snapshot_count = query_i32(&snapshot, "select count(*) from t_checkpoint_concurrent")?;
+        let consistent_count = query_i32(
+            &snapshot,
+            "select count(*) from t_checkpoint_concurrent where id = v",
+        )?;
+
+        assert!(snapshot_count >= 8);
+        assert!(snapshot_count <= total as i32);
+        assert_eq!(snapshot_count, consistent_count);
+        assert_eq!(
+            query_i32(&kite_sql, "select count(*) from t_checkpoint_concurrent")?,
+            total as i32
+        );
+
+        Ok(())
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -45,6 +45,7 @@ use std::fmt::{self, Display, Formatter};
 use std::io::Cursor;
 use std::mem;
 use std::ops::SubAssign;
+use std::path::Path;
 use std::sync::Arc;
 
 pub type KeyValueRef<'a> = (&'a [u8], &'a [u8]);
@@ -97,6 +98,12 @@ pub trait Storage: Clone {
     fn metrics(&self) -> Option<Self::Metrics> {
         None
     }
+}
+
+/// Optional capability for storage engines that can materialize an online
+/// consistent checkpoint to the local filesystem.
+pub trait CheckpointableStorage: Storage {
+    fn create_checkpoint<P: AsRef<Path>>(&self, path: P) -> Result<(), DatabaseError>;
 }
 
 /// Optional bounds of the reader, of the form (offset, limit).

--- a/src/storage/rocksdb.rs
+++ b/src/storage/rocksdb.rs
@@ -14,21 +14,30 @@
 
 use crate::errors::DatabaseError;
 use crate::storage::table_codec::{Bytes, TableCodec};
-use crate::storage::{InnerIter, Storage, Transaction};
+use crate::storage::{CheckpointableStorage, InnerIter, Storage, Transaction};
+#[cfg(feature = "unsafe_txdb_checkpoint")]
+use librocksdb_sys as ffi;
 use rocksdb::{
+    checkpoint::Checkpoint,
     statistics::{StatsLevel, Ticker},
     DBPinnableSlice, DBRawIteratorWithThreadMode, OptimisticTransactionDB, Options, ReadOptions,
     SliceTransform, TransactionDB,
 };
 use std::collections::Bound;
+#[cfg(feature = "unsafe_txdb_checkpoint")]
+use std::ffi::{c_char, c_void, CStr, CString};
 use std::fmt::{self, Display, Formatter};
-use std::path::PathBuf;
+use std::fs;
+use std::io::{self, ErrorKind};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 // Table data keys are `{table_hash(8)}{type_tag(1)}...`, so use hash+type as prefix.
 const ROCKSDB_FIXED_PREFIX_LEN: usize = 9;
 const ROCKSDB_BLOOM_BITS_PER_KEY: f64 = 10.0;
 const ROCKSDB_MEMTABLE_PREFIX_BLOOM_RATIO: f64 = 0.10;
+#[cfg(feature = "unsafe_txdb_checkpoint")]
+const ROCKSDB_TRANSACTION_DB_INNER_OFFSET: usize = 0x30;
 
 /// A lightweight snapshot of key RocksDB runtime indicators for tuning and diagnostics.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -309,6 +318,114 @@ fn default_opts(config: StorageConfig) -> Options {
     opts
 }
 
+fn prepare_checkpoint_dir(path: &Path) -> Result<(), DatabaseError> {
+    match fs::metadata(path) {
+        Ok(metadata) => {
+            if !metadata.is_dir() {
+                return Err(io::Error::new(
+                    ErrorKind::AlreadyExists,
+                    format!(
+                        "checkpoint target path '{}' already exists and is not a directory",
+                        path.display()
+                    ),
+                )
+                .into());
+            }
+
+            if fs::read_dir(path)?.next().is_some() {
+                return Err(io::Error::new(
+                    ErrorKind::AlreadyExists,
+                    format!(
+                        "checkpoint target directory '{}' must be empty",
+                        path.display()
+                    ),
+                )
+                .into());
+            }
+
+            fs::remove_dir(path)?;
+            Ok(())
+        }
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn cleanup_failed_checkpoint_dir(path: &Path) -> Result<(), DatabaseError> {
+    match fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+#[cfg(not(feature = "unsafe_txdb_checkpoint"))]
+fn unsupported_transactiondb_checkpoint_error() -> DatabaseError {
+    DatabaseError::UnsupportedStmt(format!(
+        "rocksdb TransactionDB checkpoint is disabled; enable the `unsafe_txdb_checkpoint` feature to opt in to the current implementation",
+    ))
+}
+
+#[cfg(feature = "unsafe_txdb_checkpoint")]
+fn rocksdb_error_from_ptr(err: *mut c_char) -> DatabaseError {
+    unsafe {
+        let message = CStr::from_ptr(err).to_string_lossy().into_owned();
+        ffi::rocksdb_free(err.cast::<c_void>());
+        io::Error::other(message).into()
+    }
+}
+
+#[cfg(feature = "unsafe_txdb_checkpoint")]
+fn checkpoint_path_to_cstring(path: &Path) -> Result<CString, DatabaseError> {
+    CString::new(path.to_string_lossy().into_owned()).map_err(|_| {
+        io::Error::new(
+            ErrorKind::InvalidInput,
+            format!(
+                "checkpoint path '{}' contains an interior NUL byte",
+                path.display()
+            ),
+        )
+        .into()
+    })
+}
+
+#[cfg(feature = "unsafe_txdb_checkpoint")]
+fn create_transactiondb_checkpoint(
+    db: &TransactionDB<rocksdb::MultiThreaded>,
+    path: &Path,
+) -> Result<(), DatabaseError> {
+    let path = checkpoint_path_to_cstring(path)?;
+    let mut err: *mut c_char = std::ptr::null_mut();
+
+    // `rocksdb` 0.23 does not expose a safe checkpoint API for `TransactionDB`.
+    // This fallback is intentionally gated behind the `unsafe_txdb_checkpoint`
+    // feature so callers must opt in explicitly.
+    let db_ptr = unsafe {
+        *(std::ptr::from_ref(db)
+            .cast::<u8>()
+            .add(ROCKSDB_TRANSACTION_DB_INNER_OFFSET)
+            .cast::<*mut ffi::rocksdb_transactiondb_t>())
+    };
+    let checkpoint =
+        unsafe { ffi::rocksdb_transactiondb_checkpoint_object_create(db_ptr, &mut err) };
+    if !err.is_null() {
+        return Err(rocksdb_error_from_ptr(err));
+    }
+    if checkpoint.is_null() {
+        return Err(io::Error::other("Could not create checkpoint object.").into());
+    }
+
+    unsafe {
+        ffi::rocksdb_checkpoint_create(checkpoint, path.as_ptr(), 0, &mut err);
+        ffi::rocksdb_checkpoint_object_destroy(checkpoint);
+    }
+    if !err.is_null() {
+        return Err(rocksdb_error_from_ptr(err));
+    }
+
+    Ok(())
+}
+
 impl Storage for OptimisticRocksStorage {
     type Metrics = RocksDbMetrics;
 
@@ -358,6 +475,43 @@ impl Storage for RocksStorage {
         Some(collect_metrics(self.options.as_ref(), |name| {
             self.inner.property_int_value(name)
         }))
+    }
+}
+
+impl CheckpointableStorage for OptimisticRocksStorage {
+    fn create_checkpoint<P: AsRef<Path>>(&self, path: P) -> Result<(), DatabaseError> {
+        let path = path.as_ref();
+        prepare_checkpoint_dir(path)?;
+
+        let checkpoint = Checkpoint::new(self.inner.as_ref())?;
+        if let Err(err) = checkpoint.create_checkpoint(path) {
+            cleanup_failed_checkpoint_dir(path)?;
+            return Err(err.into());
+        }
+
+        Ok(())
+    }
+}
+
+impl CheckpointableStorage for RocksStorage {
+    fn create_checkpoint<P: AsRef<Path>>(&self, path: P) -> Result<(), DatabaseError> {
+        let path = path.as_ref();
+        prepare_checkpoint_dir(path)?;
+
+        #[cfg(feature = "unsafe_txdb_checkpoint")]
+        {
+            if let Err(err) = create_transactiondb_checkpoint(self.inner.as_ref(), path) {
+                cleanup_failed_checkpoint_dir(path)?;
+                return Err(err);
+            }
+
+            return Ok(());
+        }
+
+        #[cfg(not(feature = "unsafe_txdb_checkpoint"))]
+        {
+            return Err(unsupported_transactiondb_checkpoint_error());
+        }
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

KiteSQL did not expose a storage-level checkpoint API, which made it harder to take online consistent snapshots from native embeddings.

Issue link:

### What is changed and how it works?

- Add `CheckpointableStorage` and `Database::checkpoint(path)` so checkpoint support is exposed as an optional storage capability.
- Implement checkpoint support for RocksDB-backed storage.
  - `build_optimistic()` uses RocksDB's safe checkpoint path.
  - `build_rocksdb()` is gated behind `unsafe_txdb_checkpoint` because upstream `rocksdb` does not expose a safe `TransactionDB` checkpoint API.
- Add a small `build.rs` guard so `unsafe_txdb_checkpoint` only builds with the currently validated `rocksdb` and `librocksdb-sys` versions in `Cargo.lock`.
- Add coverage for disabled mode, non-empty target directories, restore-from-checkpoint, and checkpoint-under-concurrent-writes.
- Document checkpoint support in `docs/features.md`, keep the README summary short, and bump `kite_sql` to `0.2.1`.

### Code changes

- [x] Has Rust code change
- [ ] Has CI related scripts change

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

### Note for reviewer

Validation used for this branch:

- `cargo test checkpoint -- --nocapture`
- `cargo test --features unsafe_txdb_checkpoint checkpoint -- --nocapture`