### PR TITLE
Support COPY query source to file

### DIFF
--- a/src/binder/copy.rs
+++ b/src/binder/copy.rs
@@ -86,30 +86,34 @@ impl<T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'_, '_, T, A>
         target: CopyTarget,
         options: &[CopyOption],
     ) -> Result<LogicalPlan, DatabaseError> {
+        let ext_source = copy_ext_source(target, options)?;
+
         let (table_name, ..) = match source {
             CopySource::Table {
                 table_name,
                 columns,
             } => (table_name, columns),
-            CopySource::Query(_) => {
-                return Err(DatabaseError::UnsupportedStmt("'COPY SOURCE'".to_string()));
+            CopySource::Query(query) => {
+                if !to {
+                    return Err(DatabaseError::UnsupportedStmt(
+                        "'COPY FROM query'".to_string(),
+                    ));
+                }
+                let mut input_plan = self.bind_query(&query)?;
+                let schema_ref = input_plan.output_schema().clone();
+                return Ok(LogicalPlan::new(
+                    Operator::CopyToFile(CopyToFileOperator {
+                        target: ext_source,
+                        schema_ref,
+                    }),
+                    Childrens::Only(Box::new(input_plan)),
+                ));
             }
         };
         let table_name: Arc<str> = lower_case_name(&table_name)?.into();
 
         if let Some(table) = self.context.table(table_name.clone())? {
             let schema_ref = table.schema_ref().clone();
-            let ext_source = ExtSource {
-                path: match target {
-                    CopyTarget::File { filename } => filename.into(),
-                    t => {
-                        return Err(DatabaseError::UnsupportedStmt(format!(
-                            "copy target: {t:?}"
-                        )))
-                    }
-                },
-                format: FileFormat::from_options(options),
-            };
 
             if to {
                 // COPY <source_table> TO <dest_file>
@@ -137,6 +141,20 @@ impl<T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'_, '_, T, A>
             Err(DatabaseError::TableNotFound)
         }
     }
+}
+
+fn copy_ext_source(target: CopyTarget, options: &[CopyOption]) -> Result<ExtSource, DatabaseError> {
+    Ok(ExtSource {
+        path: match target {
+            CopyTarget::File { filename } => filename.into(),
+            t => {
+                return Err(DatabaseError::UnsupportedStmt(format!(
+                    "copy target: {t:?}"
+                )))
+            }
+        },
+        format: FileFormat::from_options(options),
+    })
 }
 
 impl FileFormat {

--- a/tests/slt/copy.slt
+++ b/tests/slt/copy.slt
@@ -17,3 +17,21 @@ query I
 COPY test_copy TO './copy.csv' ( DELIMITER ',' );
 ----
 Copy To ./copy.csv [a, b, c]
+
+query I
+COPY (SELECT a, c FROM test_copy WHERE a = 1) TO './copy_query.csv' ( DELIMITER ',', HEADER true );
+----
+Copy To ./copy_query.csv [a, c]
+
+statement ok
+create table test_copy_query (a int primary key, c varchar(10))
+
+query I
+COPY test_copy_query FROM './copy_query.csv' ( DELIMITER ',', HEADER true );
+----
+1
+
+query I
+SELECT * FROM test_copy_query
+----
+1 two


### PR DESCRIPTION
## Summary
- bind `COPY (query) TO file` by using the query plan as the `CopyToFile` input
- share COPY target parsing between table and query sources
- add SLT coverage that exports a query result and imports it back

Closes #332

## Tests
- cargo run -p sqllogictest-test -- --path tests/slt/copy.slt
- cargo test -p kite_sql copy_to_file -- --nocapture