### PR TITLE
ci: use self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
+      - name: Use preinstalled Rust
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Run cargo check
         run: make cargo-check
@@ -34,6 +34,9 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
+      - name: Use preinstalled Rust
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
       - name: Run cargo fmt
         run: make fmt
   # 3
@@ -42,8 +45,8 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
+      - name: Use preinstalled Rust
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Run sqllogictest suite
         run: make test-slt
@@ -53,6 +56,9 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
+
+      - name: Use preinstalled Rust
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -72,6 +78,9 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
+
+      - name: Use preinstalled Rust
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -95,6 +104,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Use preinstalled Rust
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
       - name: Run native examples
         run: make native-examples
   # 7
@@ -103,6 +115,9 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
+
+      - name: Use preinstalled Rust
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   # 1
   check:
     name: Rust project check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
       - name: Install latest nightly
@@ -41,7 +41,7 @@ jobs:
   # 2
   fmt:
     name: Rust fmt
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
       - name: Install latest nightly
@@ -59,7 +59,7 @@ jobs:
   # 3
   e2e:
     name: Rust e2e sqllogictest
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
       - name: Install latest nightly
@@ -80,7 +80,7 @@ jobs:
   # 4
   wasm-tests:
     name: Wasm cargo tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
 
@@ -106,7 +106,7 @@ jobs:
   # 5
   wasm-examples:
     name: Wasm examples (nodejs)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
 
@@ -135,7 +135,7 @@ jobs:
   # 6
   native-examples:
     name: Native examples
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
 
@@ -150,7 +150,7 @@ jobs:
   # 7
   python-tests:
     name: Python bindings tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,26 +17,14 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
-      - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
-
-      # `cargo check` command here will use installed `nightly`
-      # as it is set as an "override" for current directory
 
       - name: Run cargo check
         run: make cargo-check
 
-
       - name: Run cargo build
         run: make build
-
 
       - name: Run cargo test
         run: make test
@@ -46,16 +34,6 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
-      - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-
-      # `cargo check` command here will use installed `nightly`
-      # as it is set as an "override" for current directory
-
       - name: Run cargo fmt
         run: make fmt
   # 3
@@ -64,18 +42,8 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
-      - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
-
-      # `cargo check` command here will use installed `nightly`
-      # as it is set as an "override" for current directory
 
       - name: Run sqllogictest suite
         run: make test-slt
@@ -85,13 +53,6 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
-
-      - name: Install stable with wasm target
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -111,13 +72,6 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
-
-      - name: Install stable with wasm target
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          override: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -141,12 +95,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
       - name: Run native examples
         run: make native-examples
   # 7
@@ -155,12 +103,6 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,10 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
-      - name: Use preinstalled Rust
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - name: Use preinstalled tools
+        run: |
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          echo "$HOME/actions-runner/externals/node20/bin" >> "$GITHUB_PATH"
 
       - name: Run cargo check
         run: make cargo-check
@@ -34,8 +36,10 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
-      - name: Use preinstalled Rust
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - name: Use preinstalled tools
+        run: |
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          echo "$HOME/actions-runner/externals/node20/bin" >> "$GITHUB_PATH"
 
       - name: Run cargo fmt
         run: make fmt
@@ -45,8 +49,10 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v2
-      - name: Use preinstalled Rust
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - name: Use preinstalled tools
+        run: |
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          echo "$HOME/actions-runner/externals/node20/bin" >> "$GITHUB_PATH"
 
       - name: Run sqllogictest suite
         run: make test-slt
@@ -57,18 +63,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use preinstalled Rust
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: latest
+      - name: Use preinstalled tools
+        run: |
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          echo "$HOME/actions-runner/externals/node20/bin" >> "$GITHUB_PATH"
 
       - name: Run wasm-bindgen tests (wasm32 target)
         run: make test-wasm
@@ -79,18 +77,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use preinstalled Rust
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
-        with:
-          version: latest
+      - name: Use preinstalled tools
+        run: |
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          echo "$HOME/actions-runner/externals/node20/bin" >> "$GITHUB_PATH"
 
       - name: Build wasm package
         run: make wasm-build
@@ -104,8 +94,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use preinstalled Rust
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - name: Use preinstalled tools
+        run: |
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          echo "$HOME/actions-runner/externals/node20/bin" >> "$GITHUB_PATH"
 
       - name: Run native examples
         run: make native-examples
@@ -116,13 +108,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use preinstalled Rust
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
+      - name: Use preinstalled tools
+        run: |
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          echo "$HOME/actions-runner/externals/node20/bin" >> "$GITHUB_PATH"
 
       - name: Run python binding tests
         run: make test-python


### PR DESCRIPTION
## Summary
- run CI jobs on the organization self-hosted Linux runner
- replace ubuntu-latest with self-hosted/Linux/X64 labels

## Testing
- git diff --check