### PR TITLE
ci: reduce self-hosted rebuilds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_REGISTRIES_MY_REGISTRY_INDEX: https://github.com/rust-lang/crates.io-index
+  CARGO_TARGET_DIR: ${{ github.workspace }}/../target
 
 jobs:
   # 1
@@ -21,12 +22,6 @@ jobs:
         run: |
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           echo "$HOME/actions-runner/externals/node20/bin" >> "$GITHUB_PATH"
-
-      - name: Run cargo check
-        run: make cargo-check
-
-      - name: Run cargo build
-        run: make build
 
       - name: Run cargo test
         run: make test


### PR DESCRIPTION
## Summary
- keep Cargo target artifacts outside the checked-out repository so self-hosted runs can reuse them
- avoid running cargo check, cargo build, and cargo test back-to-back in the same job
- keep the Rust project check focused on make test

## Why
The previous Rust project check spent about 19m40s total, with cargo check, cargo build, and cargo test each rebuilding large portions of the project. The checkout clean step also removed target artifacts when they lived inside the repository.

## Testing
- git diff --check