### PR TITLE
fix: enable wasm feature for wasm-pack targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,11 @@ build:
 
 ## Build the WebAssembly package (artifact goes to ./pkg).
 wasm-build:
-	$(WASM_PACK) build --release --target nodejs
+	$(WASM_PACK) build --release --target nodejs -- --features wasm
 
 ## Execute wasm-bindgen tests under Node.js (wasm32 target).
 test-wasm:
-	$(WASM_PACK) test --node -- --package kite_sql --lib
+	$(WASM_PACK) test --node -- --features wasm --package kite_sql --lib
 
 ## Run the sqllogictest harness against the configured .slt suite.
 test-slt:


### PR DESCRIPTION
## Summary
- pass the new `wasm` feature to `wasm-pack build` so Node examples export `WasmDatabase`
- pass the same feature to `wasm-pack test` so wasm tests compile the intended wasm API

## Verification
- `make wasm-build && make wasm-examples`
- `make test-wasm`

Fixes the CI failure in PR #351 where `examples/wasm_hello_world.test.mjs` errored with `TypeError: WasmDatabase is not a constructor`.