### PR TITLE
feat: improve statistics cardinality estimates

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -791,11 +791,14 @@ impl<S: Storage> Database<S> {
                     )?
                     .ok_or(DatabaseError::TableNotFound)?;
                 for index in table.indexes() {
-                    let index = self.state.table_arena.borrow().index(*index);
-                    if let Some(meta) =
-                        transaction.statistics_meta(&mut table_codec, name.as_ref(), index.id)?
-                    {
-                        self.state.meta_cache.insert((name.clone(), index.id), meta);
+                    let index_id = self.state.table_arena.borrow().index(*index).id;
+                    if let Some(meta) = transaction.statistics_meta(
+                        &mut table_codec,
+                        name.as_ref(),
+                        index_id,
+                        self.state.table_arena.borrow_mut(),
+                    )? {
+                        self.state.meta_cache.insert((name.clone(), index_id), meta);
                     }
                 }
                 self.state.table_cache.insert(name, table);

--- a/src/execution/ddl/drop_table.rs
+++ b/src/execution/ddl/drop_table.rs
@@ -49,7 +49,7 @@ impl<'a, T: Transaction + 'a> ExecutorNode<'a, T> for DropTable {
     fn next_tuple(
         &mut self,
         arena: &mut ExecArena<'a, T>,
-        _: &mut crate::planner::PlanArena<'a>,
+        plan_arena: &mut crate::planner::PlanArena<'a>,
     ) -> Result<(), DatabaseError> {
         let Some(DropTableOperator {
             table_name,
@@ -61,7 +61,7 @@ impl<'a, T: Transaction + 'a> ExecutorNode<'a, T> for DropTable {
         };
 
         let (transaction, table_codec) = arena.transaction_codec_mut();
-        if transaction.drop_table(table_codec, table_name.clone(), if_exists)? {
+        if transaction.drop_table(table_codec, plan_arena, table_name.clone(), if_exists)? {
             arena.push_ddl_apply(DDLApply::DropTable {
                 name: table_name.clone(),
             });

--- a/src/execution/dml/analyze.rs
+++ b/src/execution/dml/analyze.rs
@@ -125,6 +125,7 @@ impl<'a, T: Transaction + 'a> ExecutorNode<'a, T> for Analyze {
             ddl_apply,
             transaction,
             table_codec,
+            plan_arena,
         )?;
 
         let output = arena.result_tuple_mut();
@@ -149,6 +150,7 @@ impl Analyze {
         applies: &mut Vec<DDLApply>,
         transaction: &mut U,
         table_codec: &mut TableCodec,
+        plan_arena: &crate::planner::PlanArena<'_>,
     ) -> Result<Vec<DataValue>, DatabaseError> {
         let mut values = Vec::with_capacity(builders.len());
 
@@ -159,11 +161,11 @@ impl Analyze {
             ..
         } in builders
         {
-            let (histogram, sketch) =
+            let (histogram, sketch, top_n) =
                 builder.build(histogram_buckets.unwrap_or(DEFAULT_NUM_OF_BUCKETS))?;
-            let meta = StatisticsMeta::new(histogram, sketch);
+            let meta = StatisticsMeta::new(histogram, sketch, top_n);
 
-            transaction.save_statistics_meta(table_codec, table_name, meta.clone())?;
+            transaction.save_statistics_meta(table_codec, table_name, meta.clone(), plan_arena)?;
             applies.push(DDLApply::UpsertStatisticsMeta {
                 table_name: table_name.clone(),
                 index_id,
@@ -377,6 +379,7 @@ mod test {
             + statistics_meta
                 .sketch()
                 .storage_page_count(COUNT_MIN_SKETCH_STORAGE_PAGE_LEN)
+            + 1
             + statistics_meta.histogram().buckets_len();
         assert_eq!(keys, expected_keys);
 

--- a/src/execution/dql/show_table.rs
+++ b/src/execution/dql/show_table.rs
@@ -52,7 +52,7 @@ impl<'a, T: Transaction + 'a> ExecutorNode<'a, T> for ShowTables<'a, T> {
             .metas
             .as_mut()
             .expect("show tables iterator initialized")
-            .try_next()?
+            .try_next(plan_arena)?
         else {
             arena.finish();
             return Ok(());

--- a/src/optimizer/core/cm_sketch.rs
+++ b/src/optimizer/core/cm_sketch.rs
@@ -83,6 +83,11 @@ pub struct CountMinSketch<K> {
 }
 
 impl<K> CountMinSketch<K> {
+    pub fn error_bound(&self, total_count: usize) -> usize {
+        let width = self.mask + 1;
+        total_count.saturating_mul(2).div_ceil(width)
+    }
+
     pub fn storage_page_count(&self, page_len: usize) -> usize {
         self.counters
             .iter()
@@ -418,6 +423,15 @@ mod tests {
         for key in 0..100 {
             assert!(cms.estimate(&key) >= 9_000);
         }
+    }
+
+    #[test]
+    fn test_error_bound() {
+        let cms = CountMinSketch::<u64>::with_relative_error(0.95, 0.01).unwrap();
+
+        assert_eq!(cms.error_bound(0), 0);
+        assert_eq!(cms.error_bound(1), 1);
+        assert_eq!(cms.error_bound(10_000), 79);
     }
 
     #[test]

--- a/src/optimizer/core/histogram.rs
+++ b/src/optimizer/core/histogram.rs
@@ -16,7 +16,9 @@ use crate::errors::DatabaseError;
 use crate::expression::range_detacher::Range;
 use crate::expression::BinaryOperator;
 use crate::optimizer::core::cm_sketch::CountMinSketch;
+use crate::optimizer::core::hll::HyperLogLog;
 use crate::optimizer::core::kll_sketch::KllSketchBuilder;
+use crate::optimizer::core::top_n::{ColumnTopN, ANALYZE_STATISTICS_TOP_N_SIZE};
 use crate::types::evaluator::{binary_create, BinaryEvaluatorRef};
 use crate::types::index::{IndexId, IndexMeta};
 use crate::types::value::DataValue;
@@ -38,6 +40,8 @@ pub struct HistogramBuilder {
     values_len: usize,
     quantile: KllSketchBuilder,
     sketch: CountMinSketch<DataValue>,
+    hll: HyperLogLog<DataValue>,
+    top_n: ColumnTopN,
 }
 
 #[derive(Debug)]
@@ -104,6 +108,8 @@ impl HistogramBuilder {
                 ANALYZE_STATISTICS_CONFIDENCE,
                 relative_error,
             )?,
+            hll: HyperLogLog::with_relative_error(relative_error)?,
+            top_n: ColumnTopN::default(),
         })
     }
 
@@ -112,6 +118,9 @@ impl HistogramBuilder {
             self.null_count += 1;
         } else {
             self.sketch.increment(&value);
+            self.hll.add(&value);
+            self.top_n
+                .add_with_size(ANALYZE_STATISTICS_TOP_N_SIZE, value.clone(), 1);
             self.quantile.insert(value)?;
             self.values_len += 1;
         }
@@ -122,7 +131,7 @@ impl HistogramBuilder {
     pub fn build(
         self,
         number_of_buckets: usize,
-    ) -> Result<(Histogram, CountMinSketch<DataValue>), DatabaseError> {
+    ) -> Result<(Histogram, CountMinSketch<DataValue>, ColumnTopN), DatabaseError> {
         if number_of_buckets == 0 {
             return Err(DatabaseError::InvalidValue(
                 "histogram bucket count must be greater than zero".to_string(),
@@ -139,6 +148,8 @@ impl HistogramBuilder {
             null_count,
             quantile,
             mut sketch,
+            hll,
+            top_n,
             ..
         } = self;
         let mut buckets = Vec::with_capacity(number_of_buckets);
@@ -168,12 +179,14 @@ impl HistogramBuilder {
             });
         }
         sketch.add(&DataValue::Null, self.null_count);
+        let number_of_distinct_value = hll.estimate().clamp(1, values_len);
+        let top_n = top_n.finish_with_size(ANALYZE_STATISTICS_TOP_N_SIZE);
 
         Ok((
             Histogram {
                 meta: HistogramMeta {
                     index_id,
-                    number_of_distinct_value: values_len,
+                    number_of_distinct_value,
                     null_count,
                     values_len,
                     buckets_len: buckets.len(),
@@ -183,6 +196,7 @@ impl HistogramBuilder {
                 comparator: OnceLock::new(),
             },
             sketch,
+            top_n,
         ))
     }
 }
@@ -324,14 +338,40 @@ impl Histogram {
         self.meta.values_len
     }
 
+    pub fn distinct_values_len(&self) -> usize {
+        self.meta.number_of_distinct_value
+    }
+
     pub fn buckets_len(&self) -> usize {
         self.meta.buckets_len
+    }
+
+    fn average_count(&self) -> usize {
+        let distinct_values = self.meta.number_of_distinct_value;
+        if distinct_values == 0 || self.meta.values_len == 0 {
+            return 0;
+        }
+
+        cmp::max(
+            1,
+            (self.meta.values_len as f64 / distinct_values as f64).ceil() as usize,
+        )
+    }
+
+    fn equal_count(&self, value: &DataValue, sketch: &CountMinSketch<DataValue>) -> usize {
+        let average_count = self.average_count();
+        if sketch.error_bound(self.meta.values_len) >= average_count {
+            average_count
+        } else {
+            sketch.estimate(value)
+        }
     }
 
     pub fn collect_count(
         &self,
         ranges: &[Range],
         sketch: &CountMinSketch<DataValue>,
+        top_n: &ColumnTopN,
     ) -> Result<usize, DatabaseError> {
         if self.buckets.is_empty() || ranges.is_empty() {
             return Ok(0);
@@ -351,6 +391,7 @@ impl Histogram {
                 &mut bucket_idxs,
                 &mut count,
                 sketch,
+                top_n,
                 comparator,
             )?;
             if is_dummy {
@@ -374,6 +415,7 @@ impl Histogram {
         bucket_idxs: &mut Vec<usize>,
         count: &mut usize,
         sketch: &CountMinSketch<DataValue>,
+        top_n: &ColumnTopN,
         comparator: &BoundComparator,
     ) -> Result<bool, DatabaseError> {
         let float_value = |value: &DataValue, prefix_len: usize| {
@@ -562,8 +604,10 @@ impl Histogram {
             Range::Eq(value) => {
                 *count += if value.is_null() {
                     self.meta.null_count
+                } else if let Some(count) = top_n.get(value) {
+                    count
                 } else {
-                    sketch.estimate(value)
+                    self.equal_count(value, sketch)
                 };
                 *binary_i += 1
             }
@@ -622,6 +666,10 @@ impl HistogramMeta {
         self.values_len
     }
 
+    pub fn distinct_values_len(&self) -> usize {
+        self.number_of_distinct_value
+    }
+
     pub fn buckets_len(&self) -> usize {
         self.buckets_len
     }
@@ -635,6 +683,7 @@ mod tests {
     use crate::optimizer::core::histogram::{
         Bucket, HistogramBuilder, ANALYZE_STATISTICS_RELATIVE_ERROR,
     };
+    use crate::optimizer::core::top_n::ColumnTopN;
     use crate::types::index::{IndexMeta, IndexType};
     use crate::types::value::DataValue;
     use crate::types::LogicalType;
@@ -679,7 +728,7 @@ mod tests {
 
         // assert!(matches!(builder.build(10), Err(DataBaseError::TooManyBuckets)));
 
-        let (histogram, _) = builder.build(5)?;
+        let (histogram, _, _) = builder.build(5)?;
 
         assert_eq!(histogram.correlation(), 1.0);
         assert_eq!(histogram.null_count(), 2);
@@ -743,7 +792,7 @@ mod tests {
         builder.append(DataValue::Null)?;
         builder.append(DataValue::Null)?;
 
-        let (histogram, _) = builder.build(5)?;
+        let (histogram, _, _) = builder.build(5)?;
 
         assert_eq!(histogram.correlation(), -1.0);
         assert_eq!(histogram.null_count(), 2);
@@ -807,7 +856,7 @@ mod tests {
         builder.append(DataValue::Null)?;
         builder.append(DataValue::Null)?;
 
-        let (histogram, _) = builder.build(4)?;
+        let (histogram, _, _) = builder.build(4)?;
 
         assert!(histogram.correlation() < 0.0);
         assert_eq!(histogram.null_count(), 2);
@@ -865,7 +914,8 @@ mod tests {
 
         builder.append(DataValue::Null)?;
 
-        let (histogram, sketch) = builder.build(4)?;
+        let (histogram, sketch, _) = builder.build(4)?;
+        let top_n = ColumnTopN::default();
 
         let count_1 = histogram.collect_count(
             &[
@@ -876,6 +926,7 @@ mod tests {
                 },
             ],
             &sketch,
+            &top_n,
         )?;
 
         assert_eq!(count_1, 9);
@@ -886,6 +937,7 @@ mod tests {
                 max: Bound::Unbounded,
             }],
             &sketch,
+            &top_n,
         )?;
 
         assert_eq!(count_2, 11);
@@ -896,6 +948,7 @@ mod tests {
                 max: Bound::Unbounded,
             }],
             &sketch,
+            &top_n,
         )?;
 
         assert_eq!(count_3, 7);
@@ -906,6 +959,7 @@ mod tests {
                 max: Bound::Included(DataValue::Int32(11)),
             }],
             &sketch,
+            &top_n,
         )?;
 
         assert_eq!(count_4, 12);
@@ -916,6 +970,7 @@ mod tests {
                 max: Bound::Excluded(DataValue::Int32(8)),
             }],
             &sketch,
+            &top_n,
         )?;
 
         assert_eq!(count_5, 8);
@@ -926,6 +981,7 @@ mod tests {
                 max: Bound::Unbounded,
             }],
             &sketch,
+            &top_n,
         )?;
 
         assert_eq!(count_6, 12);
@@ -936,6 +992,7 @@ mod tests {
                 max: Bound::Unbounded,
             }],
             &sketch,
+            &top_n,
         )?;
 
         assert_eq!(count_7, 13);
@@ -946,6 +1003,7 @@ mod tests {
                 max: Bound::Included(DataValue::Int32(12)),
             }],
             &sketch,
+            &top_n,
         )?;
 
         assert_eq!(count_8, 13);
@@ -956,6 +1014,7 @@ mod tests {
                 max: Bound::Excluded(DataValue::Int32(13)),
             }],
             &sketch,
+            &top_n,
         )?;
 
         assert_eq!(count_9, 13);
@@ -966,6 +1025,7 @@ mod tests {
                 max: Bound::Excluded(DataValue::Int32(3)),
             }],
             &sketch,
+            &top_n,
         )?;
 
         assert_eq!(count_10, 2);
@@ -976,9 +1036,96 @@ mod tests {
                 max: Bound::Included(DataValue::Int32(2)),
             }],
             &sketch,
+            &top_n,
         )?;
 
         assert_eq!(count_11, 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_builder_uses_hll_for_distinct_values() -> Result<(), DatabaseError> {
+        let mut builder = HistogramBuilder::new(&index_meta(), ANALYZE_STATISTICS_RELATIVE_ERROR)?;
+
+        for _ in 0..50 {
+            builder.append(DataValue::Int32(1))?;
+            builder.append(DataValue::Int32(2))?;
+        }
+
+        let (histogram, _, top_n) = builder.build(10)?;
+
+        assert_eq!(histogram.values_len(), 100);
+        assert_eq!(histogram.distinct_values_len(), 2);
+        assert_eq!(top_n.get(&DataValue::Int32(1)), Some(50));
+        assert_eq!(top_n.get(&DataValue::Int32(2)), Some(50));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_eq_count_uses_cm_sketch_when_error_is_small() -> Result<(), DatabaseError> {
+        let mut builder = HistogramBuilder::new(&index_meta(), ANALYZE_STATISTICS_RELATIVE_ERROR)?;
+
+        for _ in 0..70 {
+            builder.append(DataValue::Int32(1))?;
+        }
+        for _ in 0..30 {
+            builder.append(DataValue::Int32(2))?;
+        }
+
+        let (histogram, sketch, _) = builder.build(10)?;
+        let top_n = ColumnTopN::default();
+
+        assert_eq!(
+            histogram.collect_count(&[Range::Eq(DataValue::Int32(1))], &sketch, &top_n)?,
+            70
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_eq_count_uses_top_n_when_value_is_cached() -> Result<(), DatabaseError> {
+        let mut builder = HistogramBuilder::new(&index_meta(), ANALYZE_STATISTICS_RELATIVE_ERROR)?;
+
+        for _ in 0..70 {
+            builder.append(DataValue::Int32(1))?;
+        }
+        for _ in 0..30 {
+            builder.append(DataValue::Int32(2))?;
+        }
+
+        let (histogram, mut sketch, top_n) = builder.build(10)?;
+        sketch.add(&DataValue::Int32(1), 1000);
+
+        assert_eq!(
+            histogram.collect_count(&[Range::Eq(DataValue::Int32(1))], &sketch, &top_n)?,
+            70
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_eq_count_falls_back_to_hll_when_cm_error_is_large() -> Result<(), DatabaseError> {
+        let mut builder = HistogramBuilder::new(&index_meta(), ANALYZE_STATISTICS_RELATIVE_ERROR)?;
+
+        for value in 0..10_000 {
+            builder.append(DataValue::Int32(value))?;
+        }
+
+        let (histogram, mut sketch, _) = builder.build(100)?;
+        let top_n = ColumnTopN::default();
+        let average_count = histogram.average_count();
+        assert!(sketch.error_bound(histogram.values_len()) >= average_count);
+
+        sketch.add(&DataValue::Int32(7), 1000);
+
+        assert_eq!(
+            histogram.collect_count(&[Range::Eq(DataValue::Int32(7))], &sketch, &top_n)?,
+            average_count
+        );
 
         Ok(())
     }
@@ -994,17 +1141,20 @@ mod tests {
             ))?;
         }
 
-        let (histogram, mut sketch) = builder.build(5)?;
+        let (histogram, mut sketch, top_n) = builder.build(5)?;
         let ranges = [Range::Scope {
             min: Bound::Excluded(DataValue::Tuple(vec![DataValue::Int32(0)], false)),
             max: Bound::Excluded(DataValue::Tuple(vec![DataValue::Int32(8)], true)),
         }];
-        let clean_count = histogram.collect_count(&ranges, &sketch)?;
+        let clean_count = histogram.collect_count(&ranges, &sketch, &top_n)?;
 
         sketch.increment(&DataValue::Tuple(vec![DataValue::Int32(0)], false));
         sketch.increment(&DataValue::Tuple(vec![DataValue::Int32(8)], true));
 
-        assert_eq!(histogram.collect_count(&ranges, &sketch)?, clean_count);
+        assert_eq!(
+            histogram.collect_count(&ranges, &sketch, &top_n)?,
+            clean_count
+        );
 
         Ok(())
     }

--- a/src/optimizer/core/hll.rs
+++ b/src/optimizer/core/hll.rs
@@ -1,0 +1,151 @@
+// Copyright 2024 KipData/KiteSQL
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::errors::DatabaseError;
+use crate::serdes::stable_hash::{StableHasher, HLL_HASH_KEYS};
+use std::cmp;
+use std::hash::{Hash, Hasher};
+use std::marker::PhantomData;
+
+const MIN_PRECISION: u8 = 4;
+const MAX_PRECISION: u8 = 26;
+
+#[derive(Debug, Clone)]
+pub struct HyperLogLog<K> {
+    registers: Vec<u8>,
+    precision: u8,
+    phantom_k: PhantomData<K>,
+}
+
+impl<K: Hash> HyperLogLog<K> {
+    pub fn with_relative_error(relative_error: f64) -> Result<Self, DatabaseError> {
+        if relative_error <= 0.0 || relative_error.is_nan() {
+            return Err(DatabaseError::InvalidValue(format!(
+                "hyperloglog relative error must be greater than zero, got {relative_error}"
+            )));
+        }
+
+        let register_count = Self::optimal_register_count(relative_error)?;
+        let precision = register_count.trailing_zeros() as u8;
+        Ok(Self {
+            registers: vec![0; register_count],
+            precision,
+            phantom_k: PhantomData,
+        })
+    }
+
+    pub fn add<Q: ?Sized + Hash>(&mut self, value: &Q) {
+        let hash = Self::hash(value);
+        let idx = (hash >> (64 - self.precision)) as usize;
+        let remaining = hash << self.precision;
+        let rank = if remaining == 0 {
+            64 - self.precision + 1
+        } else {
+            remaining.leading_zeros() as u8 + 1
+        };
+        self.registers[idx] = cmp::max(self.registers[idx], rank);
+    }
+
+    pub fn estimate(&self) -> usize {
+        let register_count = self.registers.len() as f64;
+        let zero_registers = self
+            .registers
+            .iter()
+            .filter(|register| **register == 0)
+            .count();
+        let raw_estimate = self.alpha() * register_count * register_count
+            / self
+                .registers
+                .iter()
+                .map(|register| 2f64.powi(-i32::from(*register)))
+                .sum::<f64>();
+
+        let estimate = if raw_estimate <= 2.5 * register_count && zero_registers > 0 {
+            register_count * (register_count / zero_registers as f64).ln()
+        } else {
+            raw_estimate
+        };
+
+        estimate.round() as usize
+    }
+
+    fn optimal_register_count(relative_error: f64) -> Result<usize, DatabaseError> {
+        let count = (1.04 / relative_error).powi(2).ceil();
+        if !count.is_finite() || count > usize::MAX as f64 {
+            return Err(DatabaseError::InvalidValue(format!(
+                "hyperloglog relative error is too small: {relative_error}"
+            )));
+        }
+
+        let min_count = 1usize << MIN_PRECISION;
+        let count = cmp::max(min_count, count as usize)
+            .checked_next_power_of_two()
+            .ok_or_else(|| {
+                DatabaseError::InvalidValue(format!(
+                    "hyperloglog register count overflow for relative error: {relative_error}"
+                ))
+            })?;
+        let precision = count.trailing_zeros() as u8;
+        if precision > MAX_PRECISION {
+            return Err(DatabaseError::InvalidValue(format!(
+                "hyperloglog relative error is too small: {relative_error}"
+            )));
+        }
+
+        Ok(count)
+    }
+
+    fn hash<Q: ?Sized + Hash>(value: &Q) -> u64 {
+        let (key0, key1) = HLL_HASH_KEYS;
+        let mut hasher = StableHasher::new_with_keys(key0, key1);
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn alpha(&self) -> f64 {
+        match self.registers.len() {
+            16 => 0.673,
+            32 => 0.697,
+            64 => 0.709,
+            count => 0.7213 / (1.0 + 1.079 / count as f64),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HyperLogLog;
+
+    #[test]
+    fn estimate_ignores_duplicates() {
+        let mut hll = HyperLogLog::<u64>::with_relative_error(0.01).unwrap();
+        for _ in 0..1000 {
+            hll.add(&7);
+        }
+
+        assert_eq!(hll.estimate(), 1);
+    }
+
+    #[test]
+    fn estimate_distinct_values_within_error_budget() {
+        let mut hll = HyperLogLog::<u64>::with_relative_error(0.02).unwrap();
+        for value in 0..10_000 {
+            hll.add(&value);
+        }
+
+        let estimate = hll.estimate() as f64;
+        let error = (estimate - 10_000.0).abs() / 10_000.0;
+        assert!(error < 0.03, "estimate={estimate}, error={error}");
+    }
+}

--- a/src/optimizer/core/mod.rs
+++ b/src/optimizer/core/mod.rs
@@ -14,7 +14,9 @@
 
 pub(crate) mod cm_sketch;
 pub(crate) mod histogram;
+pub(crate) mod hll;
 pub(crate) mod kll_sketch;
 pub(crate) mod pattern;
 pub(crate) mod rule;
 pub(crate) mod statistics_meta;
+pub(crate) mod top_n;

--- a/src/optimizer/core/statistics_meta.rs
+++ b/src/optimizer/core/statistics_meta.rs
@@ -17,6 +17,7 @@ use crate::errors::DatabaseError;
 use crate::expression::range_detacher::Range;
 use crate::optimizer::core::cm_sketch::CountMinSketch;
 use crate::optimizer::core::histogram::{Bucket, Histogram, HistogramMeta};
+use crate::optimizer::core::top_n::ColumnTopN;
 use crate::storage::StatisticsMetaCache;
 use crate::types::index::IndexId;
 use crate::types::value::DataValue;
@@ -58,7 +59,7 @@ impl<'a> StatisticMetaLoader<'a> {
 
         entry
             .histogram()
-            .collect_count(ranges, entry.sketch())
+            .collect_count(ranges, entry.sketch(), entry.top_n())
             .map(Some)
     }
 }
@@ -95,14 +96,16 @@ pub struct StatisticsMeta {
     index_id: IndexId,
     histogram: Histogram,
     sketch: CountMinSketch<DataValue>,
+    top_n: ColumnTopN,
 }
 
 impl StatisticsMeta {
-    pub fn new(histogram: Histogram, sketch: CountMinSketch<DataValue>) -> Self {
+    pub fn new(histogram: Histogram, sketch: CountMinSketch<DataValue>, top_n: ColumnTopN) -> Self {
         StatisticsMeta {
             index_id: histogram.index_id(),
             histogram,
             sketch,
+            top_n,
         }
     }
 
@@ -110,18 +113,27 @@ impl StatisticsMeta {
         root: StatisticsMetaRoot,
         buckets: Vec<Bucket>,
         sketch: CountMinSketch<DataValue>,
+        top_n: Option<ColumnTopN>,
     ) -> Result<Self, DatabaseError> {
         let histogram = Histogram::from_parts(root.into_histogram_meta(), buckets)?;
 
-        Ok(Self::new(histogram, sketch))
+        Ok(Self::new(histogram, sketch, top_n.unwrap_or_default()))
     }
 
-    pub fn into_parts(self) -> (StatisticsMetaRoot, Vec<Bucket>, CountMinSketch<DataValue>) {
+    pub fn into_parts(
+        self,
+    ) -> (
+        StatisticsMetaRoot,
+        Vec<Bucket>,
+        CountMinSketch<DataValue>,
+        ColumnTopN,
+    ) {
         let (histogram_meta, buckets) = self.histogram.into_parts();
         (
             StatisticsMetaRoot::new(histogram_meta),
             buckets,
             self.sketch,
+            self.top_n,
         )
     }
 
@@ -135,6 +147,10 @@ impl StatisticsMeta {
 
     pub fn sketch(&self) -> &CountMinSketch<DataValue> {
         &self.sketch
+    }
+
+    pub fn top_n(&self) -> &ColumnTopN {
+        &self.top_n
     }
 }
 
@@ -179,16 +195,21 @@ mod tests {
         builder.append(DataValue::Null)?;
         builder.append(DataValue::Null)?;
 
-        let (histogram, sketch) = builder.build(4)?;
+        let (histogram, sketch, top_n) = builder.build(4)?;
         let expected_estimate = sketch.estimate(&DataValue::Int32(7));
-        let meta = StatisticsMeta::new(histogram.clone(), sketch);
-        let (root, buckets, sketch) = meta.into_parts();
-        let statistics_meta = StatisticsMeta::from_parts(root, buckets, sketch)?;
+        let expected_top_n_count = top_n.get(&DataValue::Int32(7));
+        let meta = StatisticsMeta::new(histogram.clone(), sketch, top_n);
+        let (root, buckets, sketch, top_n) = meta.into_parts();
+        let statistics_meta = StatisticsMeta::from_parts(root, buckets, sketch, Some(top_n))?;
 
         assert_eq!(histogram, statistics_meta.histogram);
         assert_eq!(
             expected_estimate,
             statistics_meta.sketch().estimate(&DataValue::Int32(7))
+        );
+        assert_eq!(
+            expected_top_n_count,
+            statistics_meta.top_n().get(&DataValue::Int32(7))
         );
 
         Ok(())

--- a/src/optimizer/core/top_n.rs
+++ b/src/optimizer/core/top_n.rs
@@ -1,0 +1,292 @@
+// Copyright 2024 KipData/KiteSQL
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::types::value::DataValue;
+use kite_sql_serde_macros::ReferenceSerialization;
+use std::cmp::Ordering;
+
+pub(crate) const ANALYZE_STATISTICS_TOP_N_SIZE: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq, ReferenceSerialization)]
+pub struct ColumnTopNEntry {
+    value: DataValue,
+    count: usize,
+    error: usize,
+}
+
+impl ColumnTopNEntry {
+    pub fn value(&self) -> &DataValue {
+        &self.value
+    }
+
+    pub fn count(&self) -> usize {
+        self.count
+    }
+
+    pub fn error(&self) -> usize {
+        self.error
+    }
+}
+
+#[derive(Debug, Clone, Default, ReferenceSerialization)]
+pub struct ColumnTopN {
+    values: Vec<ColumnTopNEntry>,
+    min_index: Option<usize>,
+}
+
+impl PartialEq for ColumnTopN {
+    fn eq(&self, other: &Self) -> bool {
+        self.values == other.values
+    }
+}
+
+impl Eq for ColumnTopN {}
+
+impl ColumnTopN {
+    pub fn get(&self, value: &DataValue) -> Option<usize> {
+        self.get_entry(value).map(ColumnTopNEntry::count)
+    }
+
+    pub fn get_entry(&self, value: &DataValue) -> Option<&ColumnTopNEntry> {
+        if value.is_null() {
+            return None;
+        }
+
+        self.find(value).ok().and_then(|idx| self.values.get(idx))
+    }
+
+    pub fn add_with_size(&mut self, top_n_size: usize, value: DataValue, count: usize) {
+        self.add_with_options(top_n_size, value, count, 0);
+    }
+
+    pub fn merge_with_size(&mut self, other: ColumnTopN, top_n_size: usize) {
+        for entry in other.values {
+            if self.should_insert(&entry.value, entry.count, entry.error) {
+                self.insert_new_with_options(top_n_size, entry);
+            }
+        }
+    }
+
+    pub fn finish_with_size(mut self, top_n_size: usize) -> Self {
+        self.prune_to_capacity(top_n_size);
+        self
+    }
+
+    pub fn values(&self) -> &[ColumnTopNEntry] {
+        &self.values
+    }
+
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.values.is_empty()
+    }
+
+    fn add_with_options(&mut self, capacity: usize, value: DataValue, count: usize, error: usize) {
+        if self.should_insert(&value, count, error) {
+            self.insert_new_with_options(
+                capacity,
+                ColumnTopNEntry {
+                    value,
+                    count,
+                    error,
+                },
+            );
+        }
+    }
+
+    fn find(&self, value: &DataValue) -> Result<usize, usize> {
+        self.values
+            .binary_search_by(|entry| entry.value.partial_cmp(value).unwrap_or(Ordering::Equal))
+    }
+
+    fn should_insert(&mut self, value: &DataValue, count: usize, error: usize) -> bool {
+        if count == 0 || value.is_null() {
+            return false;
+        }
+        if let Ok(index) = self.find(value) {
+            self.update_existing(index, count, error);
+            return false;
+        }
+        true
+    }
+
+    fn update_existing(&mut self, index: usize, count: usize, error: usize) {
+        let was_min = self.min_index == Some(index);
+        let entry = &mut self.values[index];
+        entry.count = entry.count.saturating_add(count);
+        entry.error = entry.error.saturating_add(error);
+        if was_min {
+            self.min_index = None;
+        }
+    }
+
+    fn insert_new_with_options(&mut self, capacity: usize, entry: ColumnTopNEntry) {
+        if capacity == 0 {
+            return;
+        }
+
+        let index = self.find(&entry.value).unwrap_or_else(|index| index);
+        self.values.insert(index, entry);
+        self.on_insert(index);
+        if self.values.len() > capacity {
+            self.prune_to_capacity(capacity);
+        }
+    }
+
+    fn prune_to_capacity(&mut self, capacity: usize) {
+        if self.values.len() <= capacity {
+            return;
+        }
+
+        while self.values.len() > capacity {
+            if self.prune_min().is_none() {
+                break;
+            }
+        }
+    }
+
+    fn prune_min(&mut self) -> Option<()> {
+        let (min_index, next_min_index) = match self.min_index.take() {
+            Some(index) if index < self.values.len() => (index, None),
+            _ => self.find_min_and_next_index()?,
+        };
+        self.values.remove(min_index);
+        self.min_index =
+            next_min_index.map(|index| if index > min_index { index - 1 } else { index });
+        Some(())
+    }
+
+    fn on_insert(&mut self, index: usize) {
+        if let Some(min_index) = &mut self.min_index {
+            if *min_index >= index {
+                *min_index += 1;
+            }
+        }
+        match self.min_index {
+            None => self.min_index = Some(index),
+            Some(min_index) => {
+                let count = self.values[index].count;
+                let min_count = self.values[min_index].count;
+                if count < min_count || (count == min_count && index > min_index) {
+                    self.min_index = Some(index);
+                }
+            }
+        }
+    }
+
+    fn find_min_and_next_index(&self) -> Option<(usize, Option<usize>)> {
+        let first = self.values.first()?;
+        let mut min_index = 0;
+        let mut min_count = first.count;
+        let mut previous_min_index = None;
+        let mut second_min: Option<(usize, usize)> = None;
+
+        for (index, entry) in self.values.iter().enumerate().skip(1) {
+            let count = entry.count;
+            if count < min_count {
+                second_min = Some((min_index, min_count));
+                min_index = index;
+                min_count = count;
+                previous_min_index = None;
+            } else if count == min_count {
+                previous_min_index = Some(min_index);
+                min_index = index;
+            } else {
+                match second_min {
+                    None => second_min = Some((index, count)),
+                    Some((second_index, second_count))
+                        if count < second_count
+                            || (count == second_count && index > second_index) =>
+                    {
+                        second_min = Some((index, count));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        Some((
+            min_index,
+            previous_min_index.or(second_min.map(|(index, _)| index)),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ColumnTopN;
+    use crate::types::value::DataValue;
+
+    #[test]
+    fn top_n_prunes_to_capacity() {
+        let mut top_n = ColumnTopN::default();
+        top_n.add_with_size(2, DataValue::Int32(1), 5);
+        top_n.add_with_size(2, DataValue::Int32(2), 3);
+        top_n.add_with_size(2, DataValue::Int32(3), 1);
+
+        assert_eq!(top_n.len(), 2);
+
+        top_n.add_with_size(2, DataValue::Int32(4), 1);
+
+        assert_eq!(top_n.len(), 2);
+        assert_eq!(top_n.get(&DataValue::Int32(1)), Some(5));
+        assert_eq!(top_n.get(&DataValue::Int32(2)), Some(3));
+    }
+
+    #[test]
+    fn top_n_adds_existing_value() {
+        let mut top_n = ColumnTopN::default();
+        top_n.add_with_size(2, DataValue::Int32(2), 1);
+        top_n.add_with_size(2, DataValue::Int32(1), 1);
+        top_n.add_with_size(2, DataValue::Int32(1), 4);
+        top_n.add_with_size(2, DataValue::Int32(3), 1);
+
+        assert_eq!(top_n.len(), 2);
+        assert!(top_n
+            .values()
+            .windows(2)
+            .all(|pair| pair[0].value() < pair[1].value()));
+        assert_eq!(top_n.get(&DataValue::Int32(1)), Some(5));
+        assert_eq!(top_n.get(&DataValue::Int32(2)), Some(1));
+    }
+
+    #[test]
+    fn top_n_merge_accumulates_entries() {
+        let mut left = ColumnTopN::default();
+        left.add_with_size(2, DataValue::Int32(1), 3);
+        left.add_with_size(2, DataValue::Int32(2), 2);
+
+        let mut right = ColumnTopN::default();
+        right.add_with_size(2, DataValue::Int32(1), 4);
+        right.add_with_size(2, DataValue::Int32(3), 1);
+
+        left.merge_with_size(right, 2);
+
+        assert_eq!(left.get(&DataValue::Int32(1)), Some(7));
+        assert_eq!(left.len(), 2);
+    }
+
+    #[test]
+    fn top_n_skips_null() {
+        let mut top_n = ColumnTopN::default();
+        top_n.add_with_size(2, DataValue::Null, 1);
+        top_n.add_with_size(2, DataValue::Int32(1), 1);
+
+        assert_eq!(top_n.len(), 1);
+        assert_eq!(top_n.get(&DataValue::Null), None);
+    }
+}

--- a/src/serdes/stable_hash.rs
+++ b/src/serdes/stable_hash.rs
@@ -22,6 +22,7 @@ pub(crate) const CM_SKETCH_HASH_KEYS: [(u64, u64); 2] = [
     (0x94d0_49bb_1331_11eb, 0xd6e8_feb8_6659_fd93),
     (0xa076_1d64_78bd_642f, 0xe703_7ed1_a0b4_28db),
 ];
+pub(crate) const HLL_HASH_KEYS: (u64, u64) = (0xd1b5_4a32_d192_ed03, 0xabc9_83a9_351f_3c2d);
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct StableHasher {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -331,9 +331,13 @@ pub trait Transaction: Sized {
         let index_meta = table.add_index_meta(index_name, column_ids, ty, plan_arena)?;
         let index_meta = plan_arena.index(index_meta);
         let index_id = index_meta.id;
-        table_codec.with_index_meta(table_name, index_id, Some(index_meta), |key, value| {
-            self.set(key, value)
-        })?;
+        table_codec.with_index_meta(
+            table_name,
+            index_id,
+            Some(index_meta),
+            plan_arena,
+            |key, value| self.set(key, value),
+        )?;
 
         Ok((table, index_id))
     }
@@ -431,7 +435,7 @@ pub trait Transaction: Sized {
         })?;
 
         for column in table.columns().map(|column| arena.column(*column)) {
-            table_codec.with_column(column, true, |key, value| self.set(key, value))?;
+            table_codec.with_column(column, true, arena, |key, value| self.set(key, value))?;
         }
         for index_meta in table.indexes() {
             let index_meta = arena.index(*index_meta);
@@ -439,6 +443,7 @@ pub trait Transaction: Sized {
                 table_name.as_ref(),
                 index_meta.id,
                 Some(index_meta),
+                arena,
                 |key, value| self.set(key, value),
             )?;
         }
@@ -576,13 +581,17 @@ pub trait Transaction: Sized {
                 plan_arena,
             )?;
             let meta = plan_arena.index(meta_ref);
-            table_codec.with_index_meta(table_name, meta.id, Some(meta), |key, value| {
-                self.set(key, value)
-            })?;
+            table_codec.with_index_meta(
+                table_name,
+                meta.id,
+                Some(meta),
+                plan_arena,
+                |key, value| self.set(key, value),
+            )?;
         }
 
         let column = plan_arena.column(table.get_column_by_id(&col_id).unwrap());
-        table_codec.with_column(column, true, |key, value| self.set(key, value))?;
+        table_codec.with_column(column, true, plan_arena, |key, value| self.set(key, value))?;
 
         Ok((table, col_id))
     }
@@ -600,7 +609,7 @@ pub trait Transaction: Sized {
         let column_id = {
             let column = plan_arena.column(table_catalog.get_column_by_name(column_name).unwrap());
             let column_id = column.id().unwrap();
-            table_codec.with_column(column, false, |key, _| self.remove(key))?;
+            table_codec.with_column(column, false, plan_arena, |key, _| self.remove(key))?;
             column_id
         };
 
@@ -609,8 +618,13 @@ pub trait Transaction: Sized {
             if !index_meta.column_ids.contains(&column_id) {
                 continue;
             }
-            table_codec
-                .with_index_meta(table_name, index_meta.id, None, |key, _| self.remove(key))?;
+            table_codec.with_index_meta(
+                table_name,
+                index_meta.id,
+                None,
+                plan_arena,
+                |key, _| self.remove(key),
+            )?;
 
             table_codec.with_index_bound(table_name, index_meta.id, |min, max| {
                 self.remove_range(Bound::Included(min), Bound::Included(max))
@@ -656,7 +670,9 @@ pub trait Transaction: Sized {
         }
 
         let exists =
-            table_codec.with_root_table(table_name.as_ref(), None, |key, _| self.exists(key))?;
+            table_codec.with_root_table(table_name.as_ref(), None, plan_arena, |key, _| {
+                self.exists(key)
+            })?;
         if exists {
             if if_not_exists {
                 return Ok(None);
@@ -666,15 +682,18 @@ pub trait Transaction: Sized {
         self.check_name_hash(table_codec, &table_name)?;
         self.create_index_meta_from_column(table_codec, plan_arena, &mut table_catalog)?;
         let table_meta = TableMeta::empty(table_name.clone());
-        table_codec.with_root_table(table_name.as_ref(), Some(&table_meta), |key, value| {
-            self.set(key, value)
-        })?;
+        table_codec.with_root_table(
+            table_name.as_ref(),
+            Some(&table_meta),
+            plan_arena,
+            |key, value| self.set(key, value),
+        )?;
 
         for column in table_catalog
             .columns()
             .map(|column| plan_arena.column(*column))
         {
-            table_codec.with_column(column, true, |key, value| self.set(key, value))?;
+            table_codec.with_column(column, true, plan_arena, |key, value| self.set(key, value))?;
         }
 
         Ok(Some(table_catalog))
@@ -750,9 +769,13 @@ pub trait Transaction: Sized {
         }
 
         let index_id = index_meta.id;
-        table_codec.with_index_meta(table_name.as_ref(), index_id, None, |key, _| {
-            self.remove(key)
-        })?;
+        table_codec.with_index_meta(
+            table_name.as_ref(),
+            index_id,
+            None,
+            plan_arena,
+            |key, _| self.remove(key),
+        )?;
 
         table_codec.with_index_bound(table_name.as_ref(), index_id, |min, max| {
             self.remove_range(Bound::Included(min), Bound::Included(max))
@@ -769,11 +792,14 @@ pub trait Transaction: Sized {
     fn drop_table(
         &mut self,
         table_codec: &mut TableCodec,
+        plan_arena: &mut PlanArena,
         table_name: TableName,
         if_exists: bool,
     ) -> Result<bool, DatabaseError> {
         let exists =
-            table_codec.with_root_table(table_name.as_ref(), None, |key, _| self.exists(key))?;
+            table_codec.with_root_table(table_name.as_ref(), None, plan_arena, |key, _| {
+                self.exists(key)
+            })?;
         if !exists {
             if if_exists {
                 return Ok(false);
@@ -792,7 +818,9 @@ pub trait Transaction: Sized {
             self.remove_range(Bound::Included(min), Bound::Included(max))
         })?;
 
-        table_codec.with_root_table(table_name.as_ref(), None, |key, _| self.remove(key))?;
+        table_codec.with_root_table(table_name.as_ref(), None, plan_arena, |key, _| {
+            self.remove(key)
+        })?;
 
         Ok(true)
     }
@@ -885,7 +913,7 @@ pub trait Transaction: Sized {
         arena: &mut impl MetaArena,
         table_name: TableName,
     ) -> Result<Option<TableCatalog>, DatabaseError> {
-        self.table_collect(table_codec, &table_name)?
+        self.table_collect(table_codec, &table_name, arena)?
             .map(|(columns, indexes)| {
                 TableCatalog::reload(table_name, columns.into_iter(), indexes.into_iter(), arena)
             })
@@ -908,13 +936,15 @@ pub trait Transaction: Sized {
         table_codec: &mut TableCodec,
         table_name: &TableName,
         statistics_meta: StatisticsMeta,
+        arena: &impl MetaArena,
     ) -> Result<(), DatabaseError> {
         let index_id = statistics_meta.index_id();
-        let (root, buckets, cm_sketch) = statistics_meta.into_parts();
+        let (root, buckets, cm_sketch, top_n) = statistics_meta.into_parts();
         table_codec.with_statistics_meta(
             table_name.as_ref(),
             index_id,
             Some(&root),
+            arena,
             |key, value| self.set(key, value),
         )?;
         let (sketch_meta, sketch_pages) =
@@ -923,6 +953,7 @@ pub trait Transaction: Sized {
             table_name.as_ref(),
             index_id,
             Some(&sketch_meta),
+            arena,
             |key, value| self.set(key, value),
         )?;
         for sketch_page in sketch_pages {
@@ -931,6 +962,7 @@ pub trait Transaction: Sized {
                 index_id,
                 &sketch_page,
                 true,
+                arena,
                 |key, value| self.set(key, value),
             )?;
         }
@@ -941,9 +973,17 @@ pub trait Transaction: Sized {
                 index_id,
                 ordinal as u32,
                 Some(bucket),
+                arena,
                 |key, value| self.set(key, value),
             )?;
         }
+        table_codec.with_statistics_top_n(
+            table_name.as_ref(),
+            index_id,
+            Some(&top_n),
+            arena,
+            |key, value| self.set(key, value),
+        )?;
 
         Ok(())
     }
@@ -953,6 +993,7 @@ pub trait Transaction: Sized {
         table_codec: &mut TableCodec,
         table_name: &str,
         index_id: IndexId,
+        arena: &mut impl MetaArena,
     ) -> Result<Option<StatisticsMeta>, DatabaseError> {
         table_codec.with_statistics_index_bound(table_name, index_id, |min, max| {
             let mut iter = self.range(Bound::Included(min), Bound::Included(max))?;
@@ -960,22 +1001,28 @@ pub trait Transaction: Sized {
             let mut buckets = Vec::new();
             let mut sketch_meta = None;
             let mut sketch_pages = Vec::<CountMinSketchPage>::new();
+            let mut top_n = None;
 
             while let Some((key, value)) = iter.try_next()? {
                 match TableCodec::decode_statistics_codec_type(key)? {
                     StatisticsCodecType::Root => {
-                        root = Some(TableCodec::decode_statistics_meta::<Self>(value)?);
+                        root = Some(TableCodec::decode_statistics_meta::<Self>(value, arena)?);
                     }
                     StatisticsCodecType::SketchMeta => {
-                        sketch_meta =
-                            Some(TableCodec::decode_statistics_sketch_meta::<Self>(value)?);
+                        sketch_meta = Some(TableCodec::decode_statistics_sketch_meta::<Self>(
+                            value, arena,
+                        )?);
                     }
                     StatisticsCodecType::SketchPage => {
-                        sketch_pages
-                            .push(TableCodec::decode_statistics_sketch_page::<Self>(value)?);
+                        sketch_pages.push(TableCodec::decode_statistics_sketch_page::<Self>(
+                            value, arena,
+                        )?);
                     }
                     StatisticsCodecType::Bucket => {
-                        buckets.push(TableCodec::decode_statistics_bucket::<Self>(value)?);
+                        buckets.push(TableCodec::decode_statistics_bucket::<Self>(value, arena)?);
+                    }
+                    StatisticsCodecType::TopN => {
+                        top_n = Some(TableCodec::decode_statistics_top_n::<Self>(value, arena)?);
                     }
                 }
             }
@@ -983,9 +1030,13 @@ pub trait Transaction: Sized {
             match (root, sketch_meta) {
                 (Some(root), Some(sketch_meta)) => {
                     let sketch = CountMinSketch::from_storage_parts(sketch_meta, sketch_pages)?;
-                    StatisticsMeta::from_parts(root, buckets, sketch).map(Some)
+                    StatisticsMeta::from_parts(root, buckets, sketch, top_n).map(Some)
                 }
-                (None, None) if buckets.is_empty() && sketch_pages.is_empty() => Ok(None),
+                (None, None)
+                    if buckets.is_empty() && sketch_pages.is_empty() && top_n.is_none() =>
+                {
+                    Ok(None)
+                }
                 _ => Err(DatabaseError::InvalidValue(
                     "statistics meta is incomplete".to_string(),
                 )),
@@ -1011,6 +1062,7 @@ pub trait Transaction: Sized {
         &self,
         table_codec: &mut TableCodec,
         table_name: &TableName,
+        arena: &mut impl MetaArena,
     ) -> Result<Option<(Vec<ColumnCatalog>, Vec<IndexMeta>)>, DatabaseError> {
         table_codec.with_table_bound(table_name, |table_min, table_max| {
             let mut column_iter =
@@ -1028,9 +1080,10 @@ pub trait Transaction: Sized {
                     columns.push(TableCodec::decode_column::<Self, _>(
                         &mut cursor,
                         &reference_tables,
+                        arena,
                     )?);
                 } else {
-                    index_metas.push(TableCodec::decode_index_meta::<Self>(value)?);
+                    index_metas.push(TableCodec::decode_index_meta::<Self>(value, arena)?);
                 }
             }
 
@@ -1064,9 +1117,13 @@ pub trait Transaction: Sized {
             let index_name = format!("uk_{}_index", col.name());
             let meta_ref = table.add_index_meta(index_name, vec![col_id], index_ty, arena)?;
             let meta = arena.index(meta_ref);
-            table_codec.with_index_meta(&table_name, meta.id, Some(meta), |key, value| {
-                self.set(key, value)
-            })?;
+            table_codec.with_index_meta(
+                &table_name,
+                meta.id,
+                Some(meta),
+                arena,
+                |key, value| self.set(key, value),
+            )?;
         }
         let primary_keys = table
             .primary_keys()
@@ -1079,7 +1136,7 @@ pub trait Transaction: Sized {
         let meta_ref =
             table.add_index_meta("pk_index".to_string(), primary_keys, pk_index_ty, arena)?;
         let meta = arena.index(meta_ref);
-        table_codec.with_index_meta(&table_name, meta.id, Some(meta), |key, value| {
+        table_codec.with_index_meta(&table_name, meta.id, Some(meta), arena, |key, value| {
             self.set(key, value)
         })?;
 
@@ -2005,12 +2062,15 @@ pub struct TableIter<'a, T: Transaction + 'a> {
 }
 
 impl<T: Transaction> TableIter<'_, T> {
-    pub fn try_next(&mut self) -> Result<Option<TableMeta>, DatabaseError> {
+    pub fn try_next(
+        &mut self,
+        arena: &mut impl MetaArena,
+    ) -> Result<Option<TableMeta>, DatabaseError> {
         let Some((_, value)) = self.iter.try_next()? else {
             return Ok(None);
         };
 
-        Ok(Some(TableCodec::decode_root_table::<T>(value)?))
+        Ok(Some(TableCodec::decode_root_table::<T>(value, arena)?))
     }
 }
 

--- a/src/storage/table_codec.rs
+++ b/src/storage/table_codec.rs
@@ -19,7 +19,8 @@ use crate::errors::DatabaseError;
 use crate::optimizer::core::cm_sketch::{CountMinSketchMeta, CountMinSketchPage};
 use crate::optimizer::core::histogram::Bucket;
 use crate::optimizer::core::statistics_meta::StatisticsMetaRoot;
-use crate::planner::{MetaArena, TableArena};
+use crate::optimizer::core::top_n::ColumnTopN;
+use crate::planner::MetaArena;
 use crate::serdes::stable_hash::{StableHasher, TABLE_NAME_HASH_KEYS};
 use crate::serdes::{ReferenceDecodeContext, ReferenceSerialization, ReferenceTables};
 use crate::storage::{TableCache, Transaction};
@@ -47,6 +48,7 @@ const STATISTICS_BUCKET_ORD_LEN: usize = 4;
 static ROOT_BYTES: LazyLock<Vec<u8>> = LazyLock::new(|| b"Root".to_vec());
 static VIEW_BYTES: LazyLock<Vec<u8>> = LazyLock::new(|| b"View".to_vec());
 static HASH_BYTES: LazyLock<Vec<u8>> = LazyLock::new(|| b"Hash".to_vec());
+static EMPTY_REFERENCE_TABLES: LazyLock<ReferenceTables> = LazyLock::new(ReferenceTables::new);
 
 pub type Bytes = Vec<u8>;
 pub type BumpBytes<'bump> = bumpalo::collections::Vec<'bump, u8>;
@@ -92,6 +94,7 @@ pub(crate) enum StatisticsCodecType {
     SketchMeta,
     SketchPage,
     Bucket,
+    TopN,
 }
 
 impl StatisticsCodecType {
@@ -101,6 +104,7 @@ impl StatisticsCodecType {
             StatisticsCodecType::SketchMeta => b'1',
             StatisticsCodecType::SketchPage => b'2',
             StatisticsCodecType::Bucket => b'3',
+            StatisticsCodecType::TopN => b'4',
         }
     }
 
@@ -110,6 +114,7 @@ impl StatisticsCodecType {
             b'1' => Ok(StatisticsCodecType::SketchMeta),
             b'2' => Ok(StatisticsCodecType::SketchPage),
             b'3' => Ok(StatisticsCodecType::Bucket),
+            b'4' => Ok(StatisticsCodecType::TopN),
             _ => Err(DatabaseError::InvalidValue(format!(
                 "invalid statistics codec tag: {tag}"
             ))),
@@ -302,6 +307,7 @@ impl TableCodec {
         table_name: &str,
         index_id: IndexId,
         index_meta: Option<&IndexMeta>,
+        arena: &impl MetaArena,
         f: impl FnOnce(&[u8], &[u8]) -> Result<R, DatabaseError>,
     ) -> Result<R, DatabaseError> {
         self.clear_buffers();
@@ -311,7 +317,7 @@ impl TableCodec {
             lower.extend_from_slice(&index_id.to_le_bytes());
 
             if let Some(index_meta) = index_meta {
-                Self::encode_index_meta_value_into(index_meta, refs, value)?;
+                Self::encode_index_meta_value_into(index_meta, refs, value, arena)?;
             }
 
             f(lower.as_slice(), value.as_slice())
@@ -416,6 +422,7 @@ impl TableCodec {
         &mut self,
         col: &ColumnCatalog,
         encode_value: bool,
+        arena: &impl MetaArena,
         f: impl FnOnce(&[u8], &[u8]) -> Result<R, DatabaseError>,
     ) -> Result<R, DatabaseError> {
         if let ColumnRelation::Table {
@@ -432,7 +439,7 @@ impl TableCodec {
 
                 if encode_value {
                     let _ = refs.push_or_replace(table_name);
-                    Self::encode_column_value_into(col, refs, value)?;
+                    Self::encode_column_value_into(col, refs, value, arena)?;
                 }
 
                 f(lower.as_slice(), value.as_slice())
@@ -525,6 +532,7 @@ impl TableCodec {
         table_name: &str,
         index_id: IndexId,
         statistics_meta: Option<&StatisticsMetaRoot>,
+        arena: &impl MetaArena,
         f: impl FnOnce(&[u8], &[u8]) -> Result<R, DatabaseError>,
     ) -> Result<R, DatabaseError> {
         self.clear_buffers();
@@ -535,7 +543,7 @@ impl TableCodec {
             lower.push(StatisticsCodecType::Root.tag());
 
             if let Some(statistics_meta) = statistics_meta {
-                Self::encode_statistics_meta_value_into(statistics_meta, refs, value)?;
+                Self::encode_statistics_meta_value_into(statistics_meta, refs, value, arena)?;
             }
 
             f(lower.as_slice(), value.as_slice())
@@ -548,6 +556,7 @@ impl TableCodec {
         table_name: &str,
         index_id: IndexId,
         sketch_meta: Option<&CountMinSketchMeta>,
+        arena: &impl MetaArena,
         f: impl FnOnce(&[u8], &[u8]) -> Result<R, DatabaseError>,
     ) -> Result<R, DatabaseError> {
         self.clear_buffers();
@@ -558,7 +567,7 @@ impl TableCodec {
             lower.push(StatisticsCodecType::SketchMeta.tag());
 
             if let Some(sketch_meta) = sketch_meta {
-                Self::encode_statistics_sketch_meta_value_into(sketch_meta, refs, value)?;
+                Self::encode_statistics_sketch_meta_value_into(sketch_meta, refs, value, arena)?;
             }
 
             f(lower.as_slice(), value.as_slice())
@@ -572,6 +581,7 @@ impl TableCodec {
         index_id: IndexId,
         sketch_page: &CountMinSketchPage,
         encode_value: bool,
+        arena: &impl MetaArena,
         f: impl FnOnce(&[u8], &[u8]) -> Result<R, DatabaseError>,
     ) -> Result<R, DatabaseError> {
         self.clear_buffers();
@@ -586,7 +596,7 @@ impl TableCodec {
             lower.extend_from_slice(&(sketch_page.page_idx() as u32).to_be_bytes());
 
             if encode_value {
-                Self::encode_statistics_sketch_page_value_into(sketch_page, refs, value)?;
+                Self::encode_statistics_sketch_page_value_into(sketch_page, refs, value, arena)?;
             }
 
             f(lower.as_slice(), value.as_slice())
@@ -600,6 +610,7 @@ impl TableCodec {
         index_id: IndexId,
         ordinal: u32,
         bucket: Option<&Bucket>,
+        arena: &impl MetaArena,
         f: impl FnOnce(&[u8], &[u8]) -> Result<R, DatabaseError>,
     ) -> Result<R, DatabaseError> {
         self.clear_buffers();
@@ -612,7 +623,31 @@ impl TableCodec {
             lower.extend_from_slice(&ordinal.to_be_bytes());
 
             if let Some(bucket) = bucket {
-                Self::encode_statistics_bucket_value_into(bucket, refs, value)?;
+                Self::encode_statistics_bucket_value_into(bucket, refs, value, arena)?;
+            }
+
+            f(lower.as_slice(), value.as_slice())
+        })
+    }
+
+    /// Key: `{TableName}{STATISTICS_TAG}{BOUND_MIN_TAG}{INDEX_ID}{TOP_N_TAG}`.
+    pub fn with_statistics_top_n<R>(
+        &mut self,
+        table_name: &str,
+        index_id: IndexId,
+        top_n: Option<&ColumnTopN>,
+        arena: &impl MetaArena,
+        f: impl FnOnce(&[u8], &[u8]) -> Result<R, DatabaseError>,
+    ) -> Result<R, DatabaseError> {
+        self.clear_buffers();
+        self.with_table_hash_buffers(table_name, |lower, table_hash, value, refs| {
+            Self::write_key_prefix(lower, CodecType::Statistics, table_hash);
+            lower.push(BOUND_MIN_TAG);
+            lower.extend_from_slice(&index_id.to_le_bytes());
+            lower.push(StatisticsCodecType::TopN.tag());
+
+            if let Some(top_n) = top_n {
+                Self::encode_statistics_top_n_value_into(top_n, refs, value, arena)?;
             }
 
             f(lower.as_slice(), value.as_slice())
@@ -666,6 +701,7 @@ impl TableCodec {
         &mut self,
         table_name: &str,
         meta: Option<&TableMeta>,
+        arena: &impl MetaArena,
         f: impl FnOnce(&[u8], &[u8]) -> Result<R, DatabaseError>,
     ) -> Result<R, DatabaseError> {
         self.clear_buffers();
@@ -673,7 +709,7 @@ impl TableCodec {
             Self::write_key_prefix(lower, CodecType::Root, table_hash);
 
             if let Some(meta) = meta {
-                Self::encode_root_table_value_into(meta, refs, value)?;
+                Self::encode_root_table_value_into(meta, refs, value, arena)?;
             }
 
             f(lower.as_slice(), value.as_slice())
@@ -730,26 +766,20 @@ impl TableCodec {
         index_meta: &IndexMeta,
         reference_tables: &mut ReferenceTables,
         value: &mut Bytes,
+        arena: &impl MetaArena,
     ) -> Result<(), DatabaseError> {
-        index_meta.encode(value, true, reference_tables, &TableArena::default())
+        index_meta.encode(value, true, reference_tables, arena)
     }
 
-    pub fn encode_index_meta_value(
-        &mut self,
-        index_meta: &IndexMeta,
-    ) -> Result<Bytes, DatabaseError> {
-        self.clear_buffers();
-        let (_, value, reference_tables) = self.slots_mut();
-        Self::encode_index_meta_value_into(index_meta, reference_tables, value)?;
-        Ok(value.clone())
-    }
-
-    pub fn decode_index_meta<T: Transaction>(bytes: &[u8]) -> Result<IndexMeta, DatabaseError> {
+    pub fn decode_index_meta<T: Transaction>(
+        bytes: &[u8],
+        arena: &mut impl MetaArena,
+    ) -> Result<IndexMeta, DatabaseError> {
         IndexMeta::decode::<T, _, _>(
             &mut Cursor::new(bytes),
             None,
-            &ReferenceTables::new(),
-            &mut TableArena::default(),
+            &EMPTY_REFERENCE_TABLES,
+            arena,
         )
     }
 
@@ -771,51 +801,38 @@ impl TableCodec {
         col: &ColumnCatalog,
         reference_tables: &mut ReferenceTables,
         value: &mut Bytes,
+        arena: &impl MetaArena,
     ) -> Result<(), DatabaseError> {
-        col.encode(value, true, reference_tables, &TableArena::default())
-    }
-
-    pub fn encode_column_value(&mut self, col: &ColumnCatalog) -> Result<Bytes, DatabaseError> {
-        self.clear_buffers();
-        let (_, value, reference_tables) = self.slots_mut();
-        Self::encode_column_value_into(col, reference_tables, value)?;
-        Ok(value.clone())
+        col.encode(value, true, reference_tables, arena)
     }
 
     pub fn decode_column<T: Transaction, R: Read>(
         reader: &mut R,
         reference_tables: &ReferenceTables,
+        arena: &mut impl MetaArena,
     ) -> Result<ColumnCatalog, DatabaseError> {
         // `TableCache` is not theoretically used in `table_collect` because `ColumnCatalog` should not depend on other Column
-        ColumnCatalog::decode::<T, R, _>(reader, None, reference_tables, &mut TableArena::default())
+        ColumnCatalog::decode::<T, R, _>(reader, None, reference_tables, arena)
     }
 
     fn encode_statistics_meta_value_into(
         statistics_meta: &StatisticsMetaRoot,
         reference_tables: &mut ReferenceTables,
         value: &mut Bytes,
+        arena: &impl MetaArena,
     ) -> Result<(), DatabaseError> {
-        statistics_meta.encode(value, true, reference_tables, &TableArena::default())
-    }
-
-    pub fn encode_statistics_meta_value(
-        &mut self,
-        statistics_meta: &StatisticsMetaRoot,
-    ) -> Result<Bytes, DatabaseError> {
-        self.clear_buffers();
-        let (_, value, reference_tables) = self.slots_mut();
-        Self::encode_statistics_meta_value_into(statistics_meta, reference_tables, value)?;
-        Ok(value.clone())
+        statistics_meta.encode(value, true, reference_tables, arena)
     }
 
     pub fn decode_statistics_meta<T: Transaction>(
         bytes: &[u8],
+        arena: &mut impl MetaArena,
     ) -> Result<StatisticsMetaRoot, DatabaseError> {
         StatisticsMetaRoot::decode::<T, _, _>(
             &mut Cursor::new(bytes),
             None,
-            &ReferenceTables::new(),
-            &mut TableArena::default(),
+            &EMPTY_REFERENCE_TABLES,
+            arena,
         )
     }
 
@@ -823,28 +840,20 @@ impl TableCodec {
         sketch_meta: &CountMinSketchMeta,
         reference_tables: &mut ReferenceTables,
         value: &mut Bytes,
+        arena: &impl MetaArena,
     ) -> Result<(), DatabaseError> {
-        sketch_meta.encode(value, true, reference_tables, &TableArena::default())
-    }
-
-    pub fn encode_statistics_sketch_meta_value(
-        &mut self,
-        sketch_meta: &CountMinSketchMeta,
-    ) -> Result<Bytes, DatabaseError> {
-        self.clear_buffers();
-        let (_, value, reference_tables) = self.slots_mut();
-        Self::encode_statistics_sketch_meta_value_into(sketch_meta, reference_tables, value)?;
-        Ok(value.clone())
+        sketch_meta.encode(value, true, reference_tables, arena)
     }
 
     pub fn decode_statistics_sketch_meta<T: Transaction>(
         bytes: &[u8],
+        arena: &mut impl MetaArena,
     ) -> Result<CountMinSketchMeta, DatabaseError> {
         CountMinSketchMeta::decode::<T, _, _>(
             &mut Cursor::new(bytes),
             None,
-            &ReferenceTables::new(),
-            &mut TableArena::default(),
+            &EMPTY_REFERENCE_TABLES,
+            arena,
         )
     }
 
@@ -852,28 +861,20 @@ impl TableCodec {
         sketch_page: &CountMinSketchPage,
         reference_tables: &mut ReferenceTables,
         value: &mut Bytes,
+        arena: &impl MetaArena,
     ) -> Result<(), DatabaseError> {
-        sketch_page.encode(value, true, reference_tables, &TableArena::default())
-    }
-
-    pub fn encode_statistics_sketch_page_value(
-        &mut self,
-        sketch_page: &CountMinSketchPage,
-    ) -> Result<Bytes, DatabaseError> {
-        self.clear_buffers();
-        let (_, value, reference_tables) = self.slots_mut();
-        Self::encode_statistics_sketch_page_value_into(sketch_page, reference_tables, value)?;
-        Ok(value.clone())
+        sketch_page.encode(value, true, reference_tables, arena)
     }
 
     pub fn decode_statistics_sketch_page<T: Transaction>(
         bytes: &[u8],
+        arena: &mut impl MetaArena,
     ) -> Result<CountMinSketchPage, DatabaseError> {
         CountMinSketchPage::decode::<T, _, _>(
             &mut Cursor::new(bytes),
             None,
-            &ReferenceTables::new(),
-            &mut TableArena::default(),
+            &EMPTY_REFERENCE_TABLES,
+            arena,
         )
     }
 
@@ -881,18 +882,9 @@ impl TableCodec {
         bucket: &Bucket,
         reference_tables: &mut ReferenceTables,
         value: &mut Bytes,
+        arena: &impl MetaArena,
     ) -> Result<(), DatabaseError> {
-        bucket.encode(value, true, reference_tables, &TableArena::default())
-    }
-
-    pub fn encode_statistics_bucket_value(
-        &mut self,
-        bucket: &Bucket,
-    ) -> Result<Bytes, DatabaseError> {
-        self.clear_buffers();
-        let (_, value, reference_tables) = self.slots_mut();
-        Self::encode_statistics_bucket_value_into(bucket, reference_tables, value)?;
-        Ok(value.clone())
+        bucket.encode(value, true, reference_tables, arena)
     }
 
     pub(crate) fn decode_statistics_codec_type(
@@ -908,12 +900,36 @@ impl TableCodec {
         StatisticsCodecType::from_tag(tag)
     }
 
-    pub fn decode_statistics_bucket<T: Transaction>(bytes: &[u8]) -> Result<Bucket, DatabaseError> {
+    pub fn decode_statistics_bucket<T: Transaction>(
+        bytes: &[u8],
+        arena: &mut impl MetaArena,
+    ) -> Result<Bucket, DatabaseError> {
         Bucket::decode::<T, _, _>(
             &mut Cursor::new(bytes),
             None,
-            &ReferenceTables::new(),
-            &mut TableArena::default(),
+            &EMPTY_REFERENCE_TABLES,
+            arena,
+        )
+    }
+
+    fn encode_statistics_top_n_value_into(
+        top_n: &ColumnTopN,
+        reference_tables: &mut ReferenceTables,
+        value: &mut Bytes,
+        arena: &impl MetaArena,
+    ) -> Result<(), DatabaseError> {
+        top_n.encode(value, true, reference_tables, arena)
+    }
+
+    pub fn decode_statistics_top_n<T: Transaction>(
+        bytes: &[u8],
+        arena: &mut impl MetaArena,
+    ) -> Result<ColumnTopN, DatabaseError> {
+        ColumnTopN::decode::<T, _, _>(
+            &mut Cursor::new(bytes),
+            None,
+            &EMPTY_REFERENCE_TABLES,
+            arena,
         )
     }
 
@@ -974,26 +990,18 @@ impl TableCodec {
         meta: &TableMeta,
         reference_tables: &mut ReferenceTables,
         value: &mut Bytes,
+        arena: &impl MetaArena,
     ) -> Result<(), DatabaseError> {
-        meta.encode(value, true, reference_tables, &TableArena::default())
+        meta.encode(value, true, reference_tables, arena)
     }
 
-    pub fn encode_root_table_value(&mut self, meta: &TableMeta) -> Result<Bytes, DatabaseError> {
-        self.clear_buffers();
-        let (_, value, reference_tables) = self.slots_mut();
-        Self::encode_root_table_value_into(meta, reference_tables, value)?;
-        Ok(value.clone())
-    }
-
-    pub fn decode_root_table<T: Transaction>(bytes: &[u8]) -> Result<TableMeta, DatabaseError> {
+    pub fn decode_root_table<T: Transaction>(
+        bytes: &[u8],
+        arena: &mut impl MetaArena,
+    ) -> Result<TableMeta, DatabaseError> {
         let mut bytes = Cursor::new(bytes);
 
-        TableMeta::decode::<T, _, _>(
-            &mut bytes,
-            None,
-            &ReferenceTables::new(),
-            &mut TableArena::default(),
-        )
+        TableMeta::decode::<T, _, _>(&mut bytes, None, &EMPTY_REFERENCE_TABLES, arena)
     }
 }
 
@@ -1079,13 +1087,21 @@ mod tests {
         let mut table_codec = TableCodec::default();
         let table_arena = TableArenaCell::default();
         let table_catalog = build_table_codec(&table_arena);
+        let meta = TableMeta {
+            table_name: table_catalog.name.clone(),
+        };
         let bytes = table_codec
-            .encode_root_table_value(&TableMeta {
-                table_name: table_catalog.name.clone(),
-            })
+            .with_root_table(
+                table_catalog.name.as_ref(),
+                Some(&meta),
+                table_arena.borrow(),
+                |_, value| Ok::<_, DatabaseError>(value.to_vec()),
+            )
             .unwrap();
 
-        let table_meta = TableCodec::decode_root_table::<RocksTransaction>(&bytes).unwrap();
+        let table_meta =
+            TableCodec::decode_root_table::<RocksTransaction>(&bytes, table_arena.borrow_mut())
+                .unwrap();
 
         assert_eq!(table_meta.table_name.as_ref(), table_catalog.name.as_ref());
     }
@@ -1093,6 +1109,8 @@ mod tests {
     #[test]
     fn test_table_codec_statistics_meta() -> Result<(), DatabaseError> {
         let mut table_codec = TableCodec::default();
+        let table_arena = TableArenaCell::default();
+        let mut plan_arena = PlanArena::new(&table_arena);
         let index_meta = IndexMeta {
             id: 0,
             column_ids: vec![1],
@@ -1107,11 +1125,16 @@ mod tests {
         for value in 0..4 {
             builder.append(DataValue::Int32(value))?;
         }
-        let (histogram, sketch) = builder.build(2)?;
-        let (root, buckets, _) = StatisticsMeta::new(histogram, sketch.clone()).into_parts();
+        let (histogram, sketch, top_n) = builder.build(2)?;
+        let (root, buckets, _, top_n) =
+            StatisticsMeta::new(histogram, sketch.clone(), top_n).into_parts();
 
-        let root_bytes = table_codec.encode_statistics_meta_value(&root)?;
-        let decoded_root = TableCodec::decode_statistics_meta::<RocksTransaction>(&root_bytes)?;
+        let root_bytes =
+            table_codec.with_statistics_meta("t1", 0, Some(&root), &plan_arena, |_, value| {
+                Ok::<_, DatabaseError>(value.to_vec())
+            })?;
+        let decoded_root =
+            TableCodec::decode_statistics_meta::<RocksTransaction>(&root_bytes, &mut plan_arena)?;
         assert_eq!(decoded_root.index_id(), root.index_id());
         assert_eq!(
             decoded_root.histogram_meta().values_len(),
@@ -1123,25 +1146,43 @@ mod tests {
         );
 
         let (sketch_meta, mut sketch_pages) = sketch.clone().into_storage_parts(1);
-        let sketch_meta_bytes = table_codec.encode_statistics_sketch_meta_value(&sketch_meta)?;
-        let decoded_sketch_meta =
-            TableCodec::decode_statistics_sketch_meta::<RocksTransaction>(&sketch_meta_bytes)?;
+        let sketch_meta_bytes = table_codec.with_statistics_sketch_meta(
+            "t1",
+            0,
+            Some(&sketch_meta),
+            &plan_arena,
+            |_, value| Ok::<_, DatabaseError>(value.to_vec()),
+        )?;
+        let decoded_sketch_meta = TableCodec::decode_statistics_sketch_meta::<RocksTransaction>(
+            &sketch_meta_bytes,
+            &mut plan_arena,
+        )?;
         assert_eq!(decoded_sketch_meta.width(), sketch_meta.width());
         assert_eq!(decoded_sketch_meta.k_num(), sketch_meta.k_num());
 
         let first_sketch_page = sketch_pages.next().unwrap();
-        let sketch_page_bytes =
-            table_codec.encode_statistics_sketch_page_value(&first_sketch_page)?;
-        let decoded_sketch_page =
-            TableCodec::decode_statistics_sketch_page::<RocksTransaction>(&sketch_page_bytes)?;
+        let sketch_page_bytes = table_codec.with_statistics_sketch_page(
+            "t1",
+            0,
+            &first_sketch_page,
+            true,
+            &plan_arena,
+            |_, value| Ok::<_, DatabaseError>(value.to_vec()),
+        )?;
+        let decoded_sketch_page = TableCodec::decode_statistics_sketch_page::<RocksTransaction>(
+            &sketch_page_bytes,
+            &mut plan_arena,
+        )?;
         assert_eq!(decoded_sketch_page.counters(), first_sketch_page.counters());
 
-        let bucket0_key = table_codec.with_statistics_bucket("t1", 0, 0, None, |key, _| {
-            Ok::<_, DatabaseError>(key.to_vec())
-        })?;
-        let bucket1_key = table_codec.with_statistics_bucket("t1", 0, 1, None, |key, _| {
-            Ok::<_, DatabaseError>(key.to_vec())
-        })?;
+        let bucket0_key =
+            table_codec.with_statistics_bucket("t1", 0, 0, None, &plan_arena, |key, _| {
+                Ok::<_, DatabaseError>(key.to_vec())
+            })?;
+        let bucket1_key =
+            table_codec.with_statistics_bucket("t1", 0, 1, None, &plan_arena, |key, _| {
+                Ok::<_, DatabaseError>(key.to_vec())
+            })?;
         assert!(bucket0_key < bucket1_key);
 
         let (bucket0_min, bucket0_max) =
@@ -1151,9 +1192,18 @@ mod tests {
         assert!(bucket0_key.as_slice() >= bucket0_min.as_slice());
         assert!(bucket1_key.as_slice() <= bucket0_max.as_slice());
 
-        let bucket_bytes = table_codec.encode_statistics_bucket_value(&buckets[0])?;
-        let decoded_bucket =
-            TableCodec::decode_statistics_bucket::<RocksTransaction>(&bucket_bytes)?;
+        let bucket_bytes = table_codec.with_statistics_bucket(
+            "t1",
+            0,
+            0,
+            Some(&buckets[0]),
+            &plan_arena,
+            |_, value| Ok::<_, DatabaseError>(value.to_vec()),
+        )?;
+        let decoded_bucket = TableCodec::decode_statistics_bucket::<RocksTransaction>(
+            &bucket_bytes,
+            &mut plan_arena,
+        )?;
         assert_eq!(decoded_bucket, buckets[0]);
         assert_eq!(
             TableCodec::decode_statistics_bucket_ordinal(&bucket0_key)?,
@@ -1164,12 +1214,29 @@ mod tests {
             1
         );
 
+        let top_n_key =
+            table_codec.with_statistics_top_n("t1", 0, None, &plan_arena, |key, _| {
+                Ok::<_, DatabaseError>(key.to_vec())
+            })?;
+        assert!(top_n_key.as_slice() >= bucket0_min.as_slice());
+        assert!(top_n_key.as_slice() <= bucket0_max.as_slice());
+
+        let top_n_bytes =
+            table_codec.with_statistics_top_n("t1", 0, Some(&top_n), &plan_arena, |_, value| {
+                Ok::<_, DatabaseError>(value.to_vec())
+            })?;
+        let decoded_top_n =
+            TableCodec::decode_statistics_top_n::<RocksTransaction>(&top_n_bytes, &mut plan_arena)?;
+        assert_eq!(decoded_top_n, top_n);
+
         Ok(())
     }
 
     #[test]
     fn test_table_codec_index_meta() -> Result<(), DatabaseError> {
         let mut table_codec = TableCodec::default();
+        let table_arena = TableArenaCell::default();
+        let mut plan_arena = PlanArena::new(&table_arena);
         let index_meta = IndexMeta {
             id: 0,
             column_ids: vec![1],
@@ -1179,10 +1246,13 @@ mod tests {
             name: "index_1".to_string(),
             ty: IndexType::PrimaryKey { is_multiple: false },
         };
-        let bytes = table_codec.encode_index_meta_value(&index_meta)?;
+        let bytes =
+            table_codec.with_index_meta("t1", 0, Some(&index_meta), &plan_arena, |_, value| {
+                Ok::<_, DatabaseError>(value.to_vec())
+            })?;
 
         assert_eq!(
-            TableCodec::decode_index_meta::<RocksTransaction>(&bytes)?,
+            TableCodec::decode_index_meta::<RocksTransaction>(&bytes, &mut plan_arena)?,
             index_meta
         );
 
@@ -1218,10 +1288,19 @@ mod tests {
         reference_tables.push_or_replace(&"t1".to_string().into());
 
         let mut table_codec = TableCodec::default();
-        let bytes = table_codec.encode_column_value(&col).unwrap();
+        let table_arena = TableArenaCell::default();
+        let mut plan_arena = PlanArena::new(&table_arena);
+        let bytes = table_codec
+            .with_column(&col, true, &plan_arena, |_, value| {
+                Ok::<_, DatabaseError>(value.to_vec())
+            })
+            .unwrap();
         let mut cursor = Cursor::new(bytes);
-        let decode_col =
-            TableCodec::decode_column::<RocksTransaction, _>(&mut cursor, &reference_tables)?;
+        let decode_col = TableCodec::decode_column::<RocksTransaction, _>(
+            &mut cursor,
+            &reference_tables,
+            &mut plan_arena,
+        )?;
 
         assert_eq!(decode_col, expected_col);
 
@@ -1382,8 +1461,12 @@ mod tests {
                 is_temp: false,
             };
 
+            let table_arena = TableArenaCell::default();
+            let plan_arena = PlanArena::new(&table_arena);
             table_codec
-                .with_column(&col, false, |key, _| Ok::<_, DatabaseError>(key.to_vec()))
+                .with_column(&col, false, &plan_arena, |key, _| {
+                    Ok::<_, DatabaseError>(key.to_vec())
+                })
                 .unwrap()
         };
 
@@ -1436,8 +1519,10 @@ mod tests {
                 ty: IndexType::PrimaryKey { is_multiple: false },
             };
 
+            let table_arena = TableArenaCell::default();
+            let plan_arena = PlanArena::new(&table_arena);
             table_codec
-                .with_index_meta(table_name, index_meta.id, None, |key, _| {
+                .with_index_meta(table_name, index_meta.id, None, &plan_arena, |key, _| {
                     Ok::<_, DatabaseError>(key.to_vec())
                 })
                 .unwrap()
@@ -1647,8 +1732,10 @@ mod tests {
         let mut set: BTreeSet<Bytes> = BTreeSet::new();
         let op = |table_name: &str| {
             let mut table_codec = TableCodec::default();
+            let table_arena = TableArenaCell::default();
+            let plan_arena = PlanArena::new(&table_arena);
             table_codec
-                .with_root_table(table_name, None, |key, _| {
+                .with_root_table(table_name, None, &plan_arena, |key, _| {
                     Ok::<_, DatabaseError>(key.to_vec())
                 })
                 .unwrap()


### PR DESCRIPTION
## Summary
- Add HyperLogLog NDV tracking during ANALYZE and persist TopN statistics beside histogram and CM sketch metadata.
- Estimate equality predicates with NULL count first, TopN exact counts for hot values, CM sketch when its error bound is below the HLL-derived average count, and HLL average-count fallback otherwise.
- Store and load ColumnTopN statistics, keeping older statistics metadata compatible when TopN is absent.
- Thread MetaArena through TableCodec metadata/statistics serialization instead of constructing ad-hoc TableArena defaults, and remove value-cloning encode helper APIs.

## Tests
- cargo fmt --check
- cargo check --features decimal
- cargo test --features decimal --lib
