### PR TITLE
docs: update TPCC benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,10 +201,10 @@ Recent 720-second local comparison on the machine above:
 
 | Backend | TpmC | New-Order p90 | Payment p90 | Order-Status p90 | Delivery p90 | Stock-Level p90 |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| KiteSQL LMDB | 61723 | 0.001s | 0.001s | 0.001s | 0.002s | 0.001s |
-| KiteSQL RocksDB | 30446 | 0.001s | 0.001s | 0.001s | 0.016s | 0.002s |
-| SQLite balanced | 42989 | 0.001s | 0.001s | 0.001s | 0.001s | 0.001s |
-| SQLite practical | 42276 | 0.001s | 0.001s | 0.001s | 0.001s | 0.001s |
+| KiteSQL LMDB | 73638 | 0.001s | 0.001s | 0.001s | 0.002s | 0.001s |
+| KiteSQL RocksDB | 39051 | 0.001s | 0.001s | 0.002s | 0.009s | 0.001s |
+| SQLite balanced | 39835 | 0.001s | 0.001s | 0.001s | 0.001s | 0.001s |
+| SQLite practical | 37911 | 0.001s | 0.001s | 0.001s | 0.001s | 0.001s |
 
 The detailed raw outputs are recorded in [tpcc/README.md](tpcc/README.md).
 #### 👉[check more](tpcc/README.md)

--- a/tpcc/README.md
+++ b/tpcc/README.md
@@ -29,14 +29,14 @@ Local 720-second comparison on the machine above:
 
 | Backend | TpmC | New-Order p90 | Payment p90 | Order-Status p90 | Delivery p90 | Stock-Level p90 |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| KiteSQL LMDB | 61723 | 0.001s | 0.001s | 0.001s | 0.002s | 0.001s |
-| KiteSQL RocksDB | 30446 | 0.001s | 0.001s | 0.001s | 0.016s | 0.002s |
-| SQLite balanced | 42989 | 0.001s | 0.001s | 0.001s | 0.001s | 0.001s |
-| SQLite practical | 42276 | 0.001s | 0.001s | 0.001s | 0.001s | 0.001s |
+| KiteSQL LMDB | 73638 | 0.001s | 0.001s | 0.001s | 0.002s | 0.001s |
+| KiteSQL RocksDB | 39051 | 0.001s | 0.001s | 0.002s | 0.009s | 0.001s |
+| SQLite balanced | 39835 | 0.001s | 0.001s | 0.001s | 0.001s | 0.001s |
+| SQLite practical | 37911 | 0.001s | 0.001s | 0.001s | 0.001s | 0.001s |
 
 - All rows are from fresh 720-second reruns with `--num-ware 1` and the default `--max-retry 5`.
 - SQLite rows use the `balanced` and `practical` profiles respectively.
-- Raw logs for this run were generated under `tpcc/results/2026-06-14_720-full-current/`.
+- Raw logs for this run were generated under `tpcc/results/2026-06-20_12-16-15/`.
 
 ### KiteSQL LMDB
 ```shell
@@ -44,11 +44,11 @@ Transaction Summary (elapsed 720.0s)
 +--------------+---------+------+---------+-------+
 | Transaction  | Success | Late | Failure | Total |
 +--------------+---------+------+---------+-------+
-| New-Order    |  740676 |    0 |    7570 | 748246 |
-| Payment      |  740652 |    0 |       0 | 740652 |
-| Order-Status |   74066 |    0 |       0 | 74066 |
-| Delivery     |   74065 |    0 |       0 | 74065 |
-| Stock-Level  |   74066 |    0 |       0 | 74066 |
+| New-Order    |  883651 |    0 |    8950 | 892601 |
+| Payment      |  883630 |    0 |       0 | 883630 |
+| Order-Status |   88363 |    0 |       0 | 88363 |
+| Delivery     |   88363 |    0 |       0 | 88363 |
+| Stock-Level  |   88363 |    0 |       0 | 88363 |
 +--------------+---------+------+---------+-------+
 <Constraint Check> (all must be [OK])
 [transaction percentage]
@@ -68,40 +68,41 @@ Transaction Summary (elapsed 720.0s)
 
 1.New-Order
 
-0.001, 740407
-0.002,    269
+0.001, 883629
+0.002,     19
+0.003,      3
 
 2.Payment
 
-0.001, 740652
+0.001, 883628
+0.002,      2
 
 3.Order-Status
 
-0.001,  72021
-0.002,   1961
-0.003,     81
-0.004,      3
+0.001,  85670
+0.002,   2219
+0.003,    474
 
 4.Delivery
 
-0.002,  73846
-0.003,    179
-0.004,     40
+0.002,  88351
+0.003,      8
+0.004,      2
+0.005,      1
+0.006,      1
 
 5.Stock-Level
 
-0.001,  73870
-0.002,    192
-0.003,      4
+0.001,  88363
 
 <90th Percentile RT (MaxRT)>
-   New-Order : 0.001  (0.002)
+   New-Order : 0.001  (0.003)
      Payment : 0.001  (0.001)
-Order-Status : 0.001  (0.004)
-    Delivery : 0.002  (0.003)
- Stock-Level : 0.001  (0.002)
+Order-Status : 0.001  (0.003)
+    Delivery : 0.002  (0.006)
+ Stock-Level : 0.001  (0.001)
 <TpmC>
-61723 Tpmc
+73638 Tpmc
 ```
 
 ### KiteSQL RocksDB
@@ -110,11 +111,11 @@ Transaction Summary (elapsed 720.0s)
 +--------------+---------+------+---------+-------+
 | Transaction  | Success | Late | Failure | Total |
 +--------------+---------+------+---------+-------+
-| New-Order    |  365348 |    0 |    3642 | 368990 |
-| Payment      |  365329 |    0 |       0 | 365329 |
-| Order-Status |   36532 |    0 |       0 | 36532 |
-| Delivery     |   36533 |    0 |       0 | 36533 |
-| Stock-Level  |   36532 |    0 |       0 | 36532 |
+| New-Order    |  468621 |    0 |    4749 | 473370 |
+| Payment      |  468598 |    0 |       0 | 468598 |
+| Order-Status |   46859 |    0 |       0 | 46859 |
+| Delivery     |   46860 |    0 |       0 | 46860 |
+| Stock-Level  |   46860 |    0 |       0 | 46860 |
 +--------------+---------+------+---------+-------+
 <Constraint Check> (all must be [OK])
 [transaction percentage]
@@ -134,68 +135,52 @@ Transaction Summary (elapsed 720.0s)
 
 1.New-Order
 
-0.001, 365260
-0.002,     85
-0.003,      3
+0.001, 468582
+0.002,     35
+0.003,      1
 
 2.Payment
 
-0.001, 365325
-0.002,      1
-0.003,      1
+0.001, 468590
+0.002,      4
 
 3.Order-Status
 
-0.001,  33395
-0.002,   2506
-0.003,    491
-0.004,    133
-0.005,      7
+0.001,  41541
+0.002,   4161
+0.003,    702
+0.004,    332
+0.005,    116
+0.006,      6
 
 4.Delivery
 
-0.002,    670
-0.003,   3081
-0.004,   3292
-0.005,   1845
-0.006,   2227
-0.007,   2495
-0.008,   2465
-0.009,   2434
-0.010,   2546
-0.011,   2394
-0.012,   2231
-0.013,   2333
-0.014,   2207
-0.015,   2564
-0.016,   2219
-0.017,   1165
-0.018,    345
-0.019,     12
-0.020,      3
-0.021,      1
-0.022,      1
-0.023,      1
-0.024,      1
-0.026,      1
+0.002,   2614
+0.003,   7226
+0.004,   6196
+0.005,   3654
+0.006,   5167
+0.007,   6457
+0.008,   6343
+0.009,   5644
+0.010,   3185
+0.011,    363
+0.012,      7
+0.013,      2
+0.015,      2
 
 5.Stock-Level
 
-0.001,  19405
-0.002,  13755
-0.003,   3316
-0.004,     53
-0.005,      1
-0.007,      1
+0.001,  46860
 
 <90th Percentile RT (MaxRT)>
-   New-Order : 0.001  (0.003)
-     Payment : 0.001  (0.007)
-Order-Status : 0.001  (0.005)
-    Delivery : 0.016  (0.025)
- Stock-Level : 0.002  (0.011)
+   New-Order : 0.001  (0.008)
+     Payment : 0.001  (0.008)
+Order-Status : 0.002  (0.010)
+    Delivery : 0.009  (0.014)
+ Stock-Level : 0.001  (0.000)
 <TpmC>
-30446 Tpmc
+39051 Tpmc
 ```
 
 ### SQLite balanced
@@ -204,11 +189,11 @@ Transaction Summary (elapsed 720.0s)
 +--------------+---------+------+---------+-------+
 | Transaction  | Success | Late | Failure | Total |
 +--------------+---------+------+---------+-------+
-| New-Order    |  515898 |    0 |    5323 | 521221 |
-| Payment      |  515873 |    0 |       0 | 515873 |
-| Order-Status |   51587 |    0 |       0 | 51587 |
-| Delivery     |   51587 |    0 |       0 | 51587 |
-| Stock-Level  |   51588 |    0 |       0 | 51588 |
+| New-Order    |  478016 |    0 |    4738 | 482754 |
+| Payment      |  477993 |    0 |       0 | 477993 |
+| Order-Status |   47800 |    0 |       0 | 47800 |
+| Delivery     |   47799 |    0 |       0 | 47799 |
+| Stock-Level  |   47799 |    0 |       0 | 47799 |
 +--------------+---------+------+---------+-------+
 <Constraint Check> (all must be [OK])
 [transaction percentage]
@@ -228,27 +213,28 @@ Transaction Summary (elapsed 720.0s)
 
 1.New-Order
 
-0.001, 514986
-0.002,    886
-0.003,     26
+0.001, 472255
+0.002,   5697
+0.003,     64
 
 2.Payment
 
-0.001, 515873
+0.001, 477992
+0.002,      1
 
 3.Order-Status
 
-0.001,  51587
+0.001,  47800
 
 4.Delivery
 
-0.001,  51420
-0.002,    165
-0.003,      2
+0.001,  46716
+0.002,   1070
+0.003,     13
 
 5.Stock-Level
 
-0.001,  51588
+0.001,  47799
 
 <90th Percentile RT (MaxRT)>
    New-Order : 0.001  (0.003)
@@ -257,7 +243,7 @@ Order-Status : 0.001  (0.001)
     Delivery : 0.001  (0.003)
  Stock-Level : 0.001  (0.000)
 <TpmC>
-42989 Tpmc
+39835 Tpmc
 ```
 
 ### SQLite practical
@@ -266,11 +252,11 @@ Transaction Summary (elapsed 720.0s)
 +--------------+---------+------+---------+-------+
 | Transaction  | Success | Late | Failure | Total |
 +--------------+---------+------+---------+-------+
-| New-Order    |  507311 |    0 |    5123 | 512434 |
-| Payment      |  507288 |    0 |       0 | 507288 |
-| Order-Status |   50728 |    0 |       0 | 50728 |
-| Delivery     |   50729 |    0 |       0 | 50729 |
-| Stock-Level  |   50729 |    0 |       0 | 50729 |
+| New-Order    |  454941 |    0 |    4578 | 459519 |
+| Payment      |  454917 |    0 |       0 | 454917 |
+| Order-Status |   45491 |    0 |       0 | 45491 |
+| Delivery     |   45492 |    0 |       0 | 45492 |
+| Stock-Level  |   45491 |    0 |       0 | 45491 |
 +--------------+---------+------+---------+-------+
 <Constraint Check> (all must be [OK])
 [transaction percentage]
@@ -290,28 +276,27 @@ Transaction Summary (elapsed 720.0s)
 
 1.New-Order
 
-0.001, 506391
-0.002,    898
-0.003,     22
+0.001, 452749
+0.002,   2175
+0.003,     17
 
 2.Payment
 
-0.001, 507287
-0.002,      1
+0.001, 454917
 
 3.Order-Status
 
-0.001,  50728
+0.001,  45491
 
 4.Delivery
 
-0.001,  50566
-0.002,    160
-0.003,      3
+0.001,  45045
+0.002,    442
+0.003,      5
 
 5.Stock-Level
 
-0.001,  50729
+0.001,  45491
 
 <90th Percentile RT (MaxRT)>
    New-Order : 0.001  (0.002)
@@ -320,7 +305,7 @@ Order-Status : 0.001  (0.001)
     Delivery : 0.001  (0.003)
  Stock-Level : 0.001  (0.000)
 <TpmC>
-42276 Tpmc
+37911 Tpmc
 ```
 
 ## Refer to


### PR DESCRIPTION
## Summary
- Update the root README TPCC comparison table with the latest full 720s matrix run.
- Update `tpcc/README.md` with the same 720s summary plus refreshed raw outputs for KiteSQL LMDB, KiteSQL RocksDB, SQLite balanced, and SQLite practical.

## TPCC Results
Run: `./scripts/run_tpcc_matrix.sh` with default TPCC duration, `--num-ware 1`, default `--max-retry 5`.

| Backend | TpmC | New-Order p90 | Payment p90 | Order-Status p90 | Delivery p90 | Stock-Level p90 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| KiteSQL LMDB | 73638 | 0.001s | 0.001s | 0.001s | 0.002s | 0.001s |
| KiteSQL RocksDB | 39051 | 0.001s | 0.001s | 0.002s | 0.009s | 0.001s |
| SQLite balanced | 39835 | 0.001s | 0.001s | 0.001s | 0.001s | 0.001s |
| SQLite practical | 37911 | 0.001s | 0.001s | 0.001s | 0.001s | 0.001s |

All variants completed successfully and passed TPCC constraint checks.

## Test
- `git diff --check origin/main...HEAD`
