### PR TITLE
chore: bump KiteSQL versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "kite_sql"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bumpalo",
  "chrono",
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "kite_sql_serde_macros"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name          = "kite_sql"
-version       = "0.3.1"
+version       = "0.3.2"
 edition       = "2021"
 build         = "build.rs"
 authors       = ["Kould <kould2333@gmail.com>", "Xwg <loloxwg@gmail.com>"]
@@ -53,7 +53,7 @@ required-features = ["pprof"]
 bumpalo               = { version = "3", default-features = false, features = ["collections"] }
 ordered-float         = { version = "4" }
 paste                 = { version = "1" }
-kite_sql_serde_macros = { version = "0.2.1", path = "kite_sql_serde_macros" }
+kite_sql_serde_macros = { version = "0.2.2", path = "kite_sql_serde_macros" }
 
 # Optional dependencies for features
 comfy-table           = { version = "7", default-features = false, optional = true }

--- a/kite_sql_serde_macros/Cargo.toml
+++ b/kite_sql_serde_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "kite_sql_serde_macros"
-version     = "0.2.1"
+version     = "0.2.2"
 edition     = "2021"
 description = "Derive macros for KiteSQL"
 documentation = "https://docs.rs/kite_sql_serde_macros/latest/kite_sql_serde_macros/"


### PR DESCRIPTION
## Summary
- Bump `kite_sql` to `0.3.2`
- Bump `kite_sql_serde_macros` to `0.2.2`
- Update `Cargo.lock` package versions

## Tests
- `make cargo-check`