### PR TITLE
test: improve types coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@grcov
 
       - name: Generate Codecov report
         run: make codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,28 @@ jobs:
       - name: Run sqllogictest suite
         run: make test-slt
   # 4
+  coverage:
+    name: Rust coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate Codecov report
+        run: make codecov
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          flags: rust
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+  # 5
   wasm-tests:
     name: Wasm cargo tests
     runs-on: ubuntu-latest
@@ -65,7 +87,7 @@ jobs:
 
       - name: Run wasm-bindgen tests (wasm32 target)
         run: make test-wasm
-  # 5
+  # 6
   wasm-examples:
     name: Wasm examples (nodejs)
     runs-on: ubuntu-latest
@@ -86,7 +108,7 @@ jobs:
 
       - name: Run wasm example scripts
         run: make wasm-examples
-  # 6
+  # 7
   native-examples:
     name: Native examples
     runs-on: ubuntu-latest
@@ -97,7 +119,7 @@ jobs:
 
       - name: Run native examples
         run: make native-examples
-  # 7
+  # 8
   python-tests:
     name: Python bindings tests
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ kite_sql_tpcc
 copy.csv
 copy_query.csv
 lcov.info
+*.profraw
 
 tests/data/row_20000.csv
 tests/data/distinct_rows.csv

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ kitesql_bench
 sqlite_bench
 kite_sql_tpcc
 copy.csv
+copy_query.csv
+lcov.info
 
 tests/data/row_20000.csv
 tests/data/distinct_rows.csv

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ codecov:
 		mkdir -p '$(COVERAGE_PROFILE_DIR)'; \
 		CARGO_INCREMENTAL=0 RUSTFLAGS=\"$${RUSTFLAGS:-} $(COVERAGE_RUSTFLAGS)\" LLVM_PROFILE_FILE='$(COVERAGE_PROFILE_DIR)/kitesql-%p-%m.profraw' $(CARGO) test --all --features decimal; \
 		CARGO_INCREMENTAL=0 RUSTFLAGS=\"$${RUSTFLAGS:-} $(COVERAGE_RUSTFLAGS)\" LLVM_PROFILE_FILE='$(COVERAGE_PROFILE_DIR)/kitesql-%p-%m.profraw' $(CARGO) run -p sqllogictest-test -- --path '$(SQLLOGIC_PATH)'; \
-		$(GRCOV) . --binary-path ./target/debug -s . -t lcov $(COVERAGE_REPORT_ARGS) -o '$(CODECOV_OUTPUT)'"
+		$(GRCOV) . --binary-path \"$${CARGO_TARGET_DIR:-target}/debug\" -s . -t lcov $(COVERAGE_REPORT_ARGS) -o '$(CODECOV_OUTPUT)'"
 
 ## Generate a local HTML coverage report.
 codecov-html:
@@ -67,7 +67,7 @@ codecov-html:
 		mkdir -p '$(COVERAGE_PROFILE_DIR)' '$(COVERAGE_HTML_DIR)'; \
 		CARGO_INCREMENTAL=0 RUSTFLAGS=\"$${RUSTFLAGS:-} $(COVERAGE_RUSTFLAGS)\" LLVM_PROFILE_FILE='$(COVERAGE_PROFILE_DIR)/kitesql-%p-%m.profraw' $(CARGO) test --all --features decimal; \
 		CARGO_INCREMENTAL=0 RUSTFLAGS=\"$${RUSTFLAGS:-} $(COVERAGE_RUSTFLAGS)\" LLVM_PROFILE_FILE='$(COVERAGE_PROFILE_DIR)/kitesql-%p-%m.profraw' $(CARGO) run -p sqllogictest-test -- --path '$(SQLLOGIC_PATH)'; \
-		$(GRCOV) . --binary-path ./target/debug -s . -t html $(COVERAGE_REPORT_ARGS) -o '$(COVERAGE_HTML_DIR)'"
+		$(GRCOV) . --binary-path \"$${CARGO_TARGET_DIR:-target}/debug\" -s . -t html $(COVERAGE_REPORT_ARGS) -o '$(COVERAGE_HTML_DIR)'"
 	@echo "Coverage report: $(COVERAGE_HTML_DIR)/index.html"
 
 ## Run formatting (check mode) across the workspace.

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,10 @@ TPCC_PPROF_OUTPUT ?= /tmp/tpcc_lmdb.svg
 TPCC_HEAPTRACK_MEASURE_TIME ?= 300
 TPCC_HEAPTRACK_OUTPUT ?= /tmp/tpcc_lmdb_heaptrack
 TPCC_SQLITE_PROFILE ?= balanced
+CODECOV_OUTPUT ?= lcov.info
+COVERAGE_REPORT_ARGS ?= --ignore-filename-regex '(^|/)(tests|tpcc)/'
 
-.PHONY: test test-python test-wasm test-slt test-all wasm-build check tpcc tpcc-kitesql-rocksdb tpcc-kitesql-lmdb tpcc-lmdb-flamegraph tpcc-lmdb-heaptrack tpcc-sqlite tpcc-sqlite-practical tpcc-sqlite-balanced tpcc-dual cargo-check build wasm-examples native-examples fmt clippy
+.PHONY: test test-python test-wasm test-slt test-all codecov codecov-html wasm-build check tpcc tpcc-kitesql-rocksdb tpcc-kitesql-lmdb tpcc-lmdb-flamegraph tpcc-lmdb-heaptrack tpcc-sqlite tpcc-sqlite-practical tpcc-sqlite-balanced tpcc-dual cargo-check build wasm-examples native-examples fmt clippy
 
 ## Run default Rust tests in the current environment (non-WASM).
 test:
@@ -42,6 +44,25 @@ test-slt:
 
 ## Convenience target to run every suite in sequence.
 test-all: test test-wasm test-slt test-python
+
+## Generate an lcov coverage report for Codecov upload.
+codecov:
+	bash -c "set -euo pipefail; \
+		source <($(CARGO) llvm-cov show-env --sh); \
+		$(CARGO) llvm-cov clean --workspace; \
+		$(CARGO) test --all; \
+		$(CARGO) run -p sqllogictest-test -- --path '$(SQLLOGIC_PATH)'; \
+		$(CARGO) llvm-cov report $(COVERAGE_REPORT_ARGS) --lcov --output-path \"$(CODECOV_OUTPUT)\""
+
+## Generate a local HTML coverage report.
+codecov-html:
+	bash -c "set -euo pipefail; \
+		source <($(CARGO) llvm-cov show-env --sh); \
+		$(CARGO) llvm-cov clean --workspace; \
+		$(CARGO) test --all; \
+		$(CARGO) run -p sqllogictest-test -- --path '$(SQLLOGIC_PATH)'; \
+		$(CARGO) llvm-cov report $(COVERAGE_REPORT_ARGS) --html"
+	@echo "Coverage report: $${CARGO_TARGET_DIR:-target}/llvm-cov/html/index.html"
 
 ## Run formatting (check mode) across the workspace.
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Helper variables (override on invocation if needed).
 CARGO ?= cargo
+GRCOV ?= grcov
 WASM_PACK ?= wasm-pack
 SQLLOGIC_PATH ?= tests/slt/**/*.slt
 PYO3_PYTHON ?= /usr/bin/python3.12
@@ -10,7 +11,10 @@ TPCC_HEAPTRACK_MEASURE_TIME ?= 300
 TPCC_HEAPTRACK_OUTPUT ?= /tmp/tpcc_lmdb_heaptrack
 TPCC_SQLITE_PROFILE ?= balanced
 CODECOV_OUTPUT ?= lcov.info
-COVERAGE_REPORT_ARGS ?= --ignore-filename-regex '(^|/)(tests|tpcc)/'
+COVERAGE_PROFILE_DIR ?= target/grcov/profraw
+COVERAGE_HTML_DIR ?= target/grcov/html
+COVERAGE_RUSTFLAGS ?= -Cinstrument-coverage
+COVERAGE_REPORT_ARGS ?= --llvm --ignore-not-existing --keep-only 'src/**' --ignore 'src/**/tests/**' --ignore 'tests/**' --ignore 'tpcc/**' --excl-start 'GRCOV_EXCL_START' --excl-stop 'GRCOV_EXCL_STOP'
 
 .PHONY: test test-python test-wasm test-slt test-all codecov codecov-html wasm-build check tpcc tpcc-kitesql-rocksdb tpcc-kitesql-lmdb tpcc-lmdb-flamegraph tpcc-lmdb-heaptrack tpcc-sqlite tpcc-sqlite-practical tpcc-sqlite-balanced tpcc-dual cargo-check build wasm-examples native-examples fmt clippy
 
@@ -48,21 +52,23 @@ test-all: test test-wasm test-slt test-python
 ## Generate an lcov coverage report for Codecov upload.
 codecov:
 	bash -c "set -euo pipefail; \
-		source <($(CARGO) llvm-cov show-env --sh); \
-		$(CARGO) llvm-cov clean --workspace; \
-		$(CARGO) test --all; \
-		$(CARGO) run -p sqllogictest-test -- --path '$(SQLLOGIC_PATH)'; \
-		$(CARGO) llvm-cov report $(COVERAGE_REPORT_ARGS) --lcov --output-path \"$(CODECOV_OUTPUT)\""
+		command -v $(GRCOV) >/dev/null || { echo 'grcov is not installed; run: cargo install grcov'; exit 1; }; \
+		rm -rf '$(COVERAGE_PROFILE_DIR)' '$(CODECOV_OUTPUT)'; \
+		mkdir -p '$(COVERAGE_PROFILE_DIR)'; \
+		CARGO_INCREMENTAL=0 RUSTFLAGS=\"$${RUSTFLAGS:-} $(COVERAGE_RUSTFLAGS)\" LLVM_PROFILE_FILE='$(COVERAGE_PROFILE_DIR)/kitesql-%p-%m.profraw' $(CARGO) test --all --features decimal; \
+		CARGO_INCREMENTAL=0 RUSTFLAGS=\"$${RUSTFLAGS:-} $(COVERAGE_RUSTFLAGS)\" LLVM_PROFILE_FILE='$(COVERAGE_PROFILE_DIR)/kitesql-%p-%m.profraw' $(CARGO) run -p sqllogictest-test -- --path '$(SQLLOGIC_PATH)'; \
+		$(GRCOV) . --binary-path ./target/debug -s . -t lcov $(COVERAGE_REPORT_ARGS) -o '$(CODECOV_OUTPUT)'"
 
 ## Generate a local HTML coverage report.
 codecov-html:
 	bash -c "set -euo pipefail; \
-		source <($(CARGO) llvm-cov show-env --sh); \
-		$(CARGO) llvm-cov clean --workspace; \
-		$(CARGO) test --all; \
-		$(CARGO) run -p sqllogictest-test -- --path '$(SQLLOGIC_PATH)'; \
-		$(CARGO) llvm-cov report $(COVERAGE_REPORT_ARGS) --html"
-	@echo "Coverage report: $${CARGO_TARGET_DIR:-target}/llvm-cov/html/index.html"
+		command -v $(GRCOV) >/dev/null || { echo 'grcov is not installed; run: cargo install grcov'; exit 1; }; \
+		rm -rf '$(COVERAGE_PROFILE_DIR)' '$(COVERAGE_HTML_DIR)'; \
+		mkdir -p '$(COVERAGE_PROFILE_DIR)' '$(COVERAGE_HTML_DIR)'; \
+		CARGO_INCREMENTAL=0 RUSTFLAGS=\"$${RUSTFLAGS:-} $(COVERAGE_RUSTFLAGS)\" LLVM_PROFILE_FILE='$(COVERAGE_PROFILE_DIR)/kitesql-%p-%m.profraw' $(CARGO) test --all --features decimal; \
+		CARGO_INCREMENTAL=0 RUSTFLAGS=\"$${RUSTFLAGS:-} $(COVERAGE_RUSTFLAGS)\" LLVM_PROFILE_FILE='$(COVERAGE_PROFILE_DIR)/kitesql-%p-%m.profraw' $(CARGO) run -p sqllogictest-test -- --path '$(SQLLOGIC_PATH)'; \
+		$(GRCOV) . --binary-path ./target/debug -s . -t html $(COVERAGE_REPORT_ARGS) -o '$(COVERAGE_HTML_DIR)'"
+	@echo "Coverage report: $(COVERAGE_HTML_DIR)/index.html"
 
 ## Run formatting (check mode) across the workspace.
 fmt:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 </p>
 <p align="center">
     <a href="https://github.com/KipData/KiteSQL/actions/workflows/ci.yml"><img src="https://github.com/KipData/KiteSQL/actions/workflows/ci.yml/badge.svg" alt="CI"></img></a>
+    <a href="https://codecov.io/github/KipData/KiteSQL"><img src="https://codecov.io/github/KipData/KiteSQL/branch/main/graph/badge.svg" alt="Codecov"></img></a>
     <a href="https://deepwiki.com/KipData/KiteSQL"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></img></a>
     <a href="https://discord.gg/dU8eVGpJ8h"><img src="https://img.shields.io/badge/Discord-Join_us-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
     <a href="https://crates.io/crates/kite_sql/"><img src="https://img.shields.io/crates/v/kite_sql.svg"></a>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+  hide_project_coverage: false
+  hide_comment_details: true

--- a/src/types/evaluator/binary.rs
+++ b/src/types/evaluator/binary.rs
@@ -656,6 +656,7 @@ macro_rules! numeric_binary_evaluator_definition {
     };
 }
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -664,12 +665,36 @@ mod test {
     use crate::serdes::{ReferenceSerialization, ReferenceTables};
     use crate::storage::rocksdb::RocksTransaction;
     use crate::types::evaluator::BinaryEvaluatorRef;
+    use crate::types::value::DataValue;
     use crate::types::LogicalType;
+    use ordered_float::OrderedFloat;
+    #[cfg(feature = "decimal")]
+    use rust_decimal::Decimal;
     use std::borrow::Cow;
     use std::io::{Cursor, Seek, SeekFrom};
 
     fn create(ty: LogicalType, op: BinaryOperator) -> Result<BinaryEvaluatorRef, DatabaseError> {
         binary_create(Cow::Owned(ty), op)
+    }
+
+    fn eval(
+        ty: LogicalType,
+        op: BinaryOperator,
+        left: &DataValue,
+        right: &DataValue,
+    ) -> Result<DataValue, DatabaseError> {
+        create(ty, op)?.binary_eval(left, right)
+    }
+
+    fn assert_panics(f: impl FnOnce() + std::panic::UnwindSafe) {
+        assert!(std::panic::catch_unwind(f).is_err());
+    }
+
+    fn assert_binary_ref_panics(pos: u16, params: BinaryEvaluatorParams, value: &DataValue) {
+        assert_panics(|| {
+            let evaluator = BinaryEvaluatorRef::new(pos, params);
+            let _ = evaluator.binary_eval(value, value).unwrap();
+        });
     }
 
     #[test]
@@ -716,4 +741,181 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn test_binary_create_dispatches_numeric_time_and_decimal_evaluators(
+    ) -> Result<(), DatabaseError> {
+        let numeric_cases = vec![
+            (
+                LogicalType::Tinyint,
+                DataValue::Int8(1),
+                DataValue::Int8(2),
+                DataValue::Int8(3),
+            ),
+            (
+                LogicalType::Smallint,
+                DataValue::Int16(1),
+                DataValue::Int16(2),
+                DataValue::Int16(3),
+            ),
+            (
+                LogicalType::Integer,
+                DataValue::Int32(1),
+                DataValue::Int32(2),
+                DataValue::Int32(3),
+            ),
+            (
+                LogicalType::Bigint,
+                DataValue::Int64(1),
+                DataValue::Int64(2),
+                DataValue::Int64(3),
+            ),
+            (
+                LogicalType::UTinyint,
+                DataValue::UInt8(1),
+                DataValue::UInt8(2),
+                DataValue::UInt8(3),
+            ),
+            (
+                LogicalType::USmallint,
+                DataValue::UInt16(1),
+                DataValue::UInt16(2),
+                DataValue::UInt16(3),
+            ),
+            (
+                LogicalType::UInteger,
+                DataValue::UInt32(1),
+                DataValue::UInt32(2),
+                DataValue::UInt32(3),
+            ),
+            (
+                LogicalType::UBigint,
+                DataValue::UInt64(1),
+                DataValue::UInt64(2),
+                DataValue::UInt64(3),
+            ),
+            (
+                LogicalType::Float,
+                DataValue::Float32(OrderedFloat(1.0)),
+                DataValue::Float32(2.0.into()),
+                DataValue::Float32(3.0.into()),
+            ),
+            (
+                LogicalType::Double,
+                DataValue::Float64(OrderedFloat(1.0)),
+                DataValue::Float64(2.0.into()),
+                DataValue::Float64(3.0.into()),
+            ),
+        ];
+
+        for (ty, left, right, expected) in numeric_cases {
+            assert_eq!(eval(ty, BinaryOperator::Plus, &left, &right)?, expected);
+        }
+
+        assert_eq!(
+            eval(
+                LogicalType::DateTime,
+                BinaryOperator::Eq,
+                &DataValue::Date64(1),
+                &DataValue::Date64(1),
+            )?,
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            eval(
+                LogicalType::Time(Some(0)),
+                BinaryOperator::Plus,
+                &DataValue::Time32(DataValue::pack_time(1, 0, 0), 0),
+                &DataValue::Time32(DataValue::pack_time(2, 0, 0), 0),
+            )?,
+            DataValue::Time32(DataValue::pack_time(3, 0, 0), 0)
+        );
+        assert_eq!(
+            eval(
+                LogicalType::Time(Some(0)),
+                BinaryOperator::Minus,
+                &DataValue::Time32(DataValue::pack_time(3, 0, 0), 0),
+                &DataValue::Time32(DataValue::pack_time(2, 0, 0), 0),
+            )?,
+            DataValue::Time32(DataValue::pack_time(1, 0, 0), 0)
+        );
+        assert_eq!(
+            eval(
+                LogicalType::TimeStamp(Some(0), false),
+                BinaryOperator::NotEq,
+                &DataValue::Time64(1, 0, false),
+                &DataValue::Time64(2, 0, false),
+            )?,
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            eval(
+                LogicalType::Boolean,
+                BinaryOperator::NotEq,
+                &DataValue::Boolean(true),
+                &DataValue::Boolean(false),
+            )?,
+            DataValue::Boolean(true)
+        );
+        #[cfg(feature = "decimal")]
+        assert_eq!(
+            eval(
+                LogicalType::Decimal(None, Some(1)),
+                BinaryOperator::Plus,
+                &DataValue::Decimal(Decimal::new(10, 1)),
+                &DataValue::Decimal(Decimal::new(20, 1)),
+            )?,
+            DataValue::Decimal(Decimal::new(30, 1))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_binary_create_rejects_unsupported_operators() {
+        let cases = vec![
+            (LogicalType::Integer, BinaryOperator::Like(None)),
+            (LogicalType::Time(Some(0)), BinaryOperator::Multiply),
+            (LogicalType::TimeStamp(Some(0), false), BinaryOperator::Plus),
+            (LogicalType::Boolean, BinaryOperator::Plus),
+            (
+                LogicalType::Varchar(None, crate::types::CharLengthUnits::Characters),
+                BinaryOperator::Plus,
+            ),
+            (
+                LogicalType::Tuple(vec![LogicalType::Integer]),
+                BinaryOperator::Plus,
+            ),
+        ];
+
+        for (ty, op) in cases {
+            assert!(matches!(
+                create(ty, op),
+                Err(DatabaseError::UnsupportedBinaryOperator(..))
+            ));
+        }
+    }
+
+    #[test]
+    fn test_binary_eval_rejects_invalid_positions_and_params() {
+        let value = DataValue::Utf8 {
+            value: "abc".to_string(),
+            ty: crate::types::value::Utf8Type::Variable(None),
+            unit: crate::types::CharLengthUnits::Characters,
+        };
+        for offset in [UTF8_LIKE_OFFSET, UTF8_NOT_LIKE_OFFSET] {
+            assert_binary_ref_panics(
+                binary_pos(BINARY_UTF8_BASE, offset),
+                BinaryEvaluatorParams::Unit,
+                &value,
+            );
+        }
+        assert_panics(|| {
+            let evaluator = BinaryEvaluatorRef::new(u16::MAX, BinaryEvaluatorParams::Unit);
+            let _ = evaluator
+                .binary_eval(&DataValue::Int32(1), &DataValue::Int32(1))
+                .unwrap();
+        });
+    }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/boolean.rs
+++ b/src/types/evaluator/boolean.rs
@@ -123,6 +123,7 @@ pub fn boolean_not_eq_binary_eval(
     })
 }
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -130,6 +131,11 @@ mod test {
 
     #[test]
     fn test_boolean_binary_evaluators() {
+        assert_eq!(
+            boolean_not_unary_eval(&DataValue::Boolean(true)),
+            DataValue::Boolean(false)
+        );
+        assert_eq!(boolean_not_unary_eval(&DataValue::Null), DataValue::Null);
         assert_eq!(
             boolean_and_binary_eval(&DataValue::Boolean(true), &DataValue::Boolean(true)).unwrap(),
             DataValue::Boolean(true)
@@ -139,8 +145,37 @@ mod test {
             DataValue::Boolean(false)
         );
         assert_eq!(
+            boolean_and_binary_eval(&DataValue::Boolean(true), &DataValue::Null).unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
             boolean_or_binary_eval(&DataValue::Boolean(false), &DataValue::Boolean(true)).unwrap(),
             DataValue::Boolean(true)
+        );
+        assert_eq!(
+            boolean_or_binary_eval(&DataValue::Boolean(true), &DataValue::Null).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            boolean_or_binary_eval(&DataValue::Boolean(false), &DataValue::Null).unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            boolean_eq_binary_eval(&DataValue::Boolean(true), &DataValue::Boolean(true)).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            boolean_eq_binary_eval(&DataValue::Boolean(true), &DataValue::Null).unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            boolean_not_eq_binary_eval(&DataValue::Boolean(true), &DataValue::Boolean(false))
+                .unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            boolean_not_eq_binary_eval(&DataValue::Boolean(true), &DataValue::Null).unwrap(),
+            DataValue::Null
         );
     }
 
@@ -223,3 +258,4 @@ mod test {
         );
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/cast.rs
+++ b/src/types/evaluator/cast.rs
@@ -1146,6 +1146,7 @@ impl CastEvaluatorRef {
     }
 }
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -1180,6 +1181,17 @@ mod test {
         value: &DataValue,
     ) -> Result<DataValue, DatabaseError> {
         create(from, to)?.eval(value)
+    }
+
+    fn assert_panics(f: impl FnOnce() + std::panic::UnwindSafe) {
+        assert!(std::panic::catch_unwind(f).is_err());
+    }
+
+    fn assert_cast_ref_panics(pos: u16, params: CastEvaluatorParams, value: DataValue) {
+        assert_panics(|| {
+            let evaluator = CastEvaluatorRef::new(pos, params);
+            let _ = evaluator.eval(&value).unwrap();
+        });
     }
 
     #[test]
@@ -1229,6 +1241,49 @@ mod test {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn test_cast_evaluators_reject_invalid_positions_and_params() {
+        let cases = vec![
+            (
+                CAST_BOOLEAN * CAST_TYPE_STRIDE + CAST_CHAR,
+                CastEvaluatorParams::Unit,
+                DataValue::Boolean(true),
+            ),
+            (
+                CAST_CHAR * CAST_TYPE_STRIDE + CAST_TIME,
+                CastEvaluatorParams::Unit,
+                utf8("03:04:05"),
+            ),
+            (
+                CAST_CHAR * CAST_TYPE_STRIDE + CAST_TIMESTAMP,
+                CastEvaluatorParams::Unit,
+                utf8("2024-01-02 03:04:05"),
+            ),
+            #[cfg(feature = "decimal")]
+            (
+                CAST_FLOAT * CAST_TYPE_STRIDE + CAST_DECIMAL,
+                CastEvaluatorParams::Unit,
+                DataValue::Float32(OrderedFloat(1.0)),
+            ),
+            #[cfg(feature = "decimal")]
+            (
+                CAST_DECIMAL * CAST_TYPE_STRIDE + CAST_TIME,
+                CastEvaluatorParams::Unit,
+                DataValue::Decimal(Decimal::new(1, 0)),
+            ),
+            (
+                CAST_TUPLE * CAST_TYPE_STRIDE + CAST_TUPLE,
+                CastEvaluatorParams::Unit,
+                DataValue::Tuple(vec![DataValue::Int32(1)], false),
+            ),
+            (u16::MAX, CastEvaluatorParams::Unit, DataValue::Int32(1)),
+        ];
+
+        for (pos, params, value) in cases {
+            assert_cast_ref_panics(pos, params, value);
+        }
     }
 
     #[test]
@@ -1350,6 +1405,92 @@ mod test {
     }
 
     #[test]
+    fn test_cast_create_dispatches_integer_casts() -> Result<(), DatabaseError> {
+        let cases = vec![
+            (
+                LogicalType::Tinyint,
+                DataValue::Int8(1),
+                DataValue::Float64(OrderedFloat(1.0)),
+            ),
+            (
+                LogicalType::Smallint,
+                DataValue::Int16(2),
+                DataValue::Float64(OrderedFloat(2.0)),
+            ),
+            (
+                LogicalType::Integer,
+                DataValue::Int32(3),
+                DataValue::Float64(OrderedFloat(3.0)),
+            ),
+            (
+                LogicalType::Bigint,
+                DataValue::Int64(4),
+                DataValue::Float64(OrderedFloat(4.0)),
+            ),
+            (
+                LogicalType::UTinyint,
+                DataValue::UInt8(5),
+                DataValue::Float64(OrderedFloat(5.0)),
+            ),
+            (
+                LogicalType::USmallint,
+                DataValue::UInt16(6),
+                DataValue::Float64(OrderedFloat(6.0)),
+            ),
+            (
+                LogicalType::UInteger,
+                DataValue::UInt32(7),
+                DataValue::Float64(OrderedFloat(7.0)),
+            ),
+            (
+                LogicalType::UBigint,
+                DataValue::UInt64(8),
+                DataValue::Float64(OrderedFloat(8.0)),
+            ),
+        ];
+
+        for (from, value, expected) in cases {
+            assert_eq!(cast_eval(from, LogicalType::Double, &value)?, expected);
+        }
+
+        assert_eq!(
+            cast_eval(
+                LogicalType::Integer,
+                LogicalType::Char(1, CharLengthUnits::Characters),
+                &DataValue::Int32(9),
+            )?,
+            DataValue::Utf8 {
+                value: "9".to_string(),
+                ty: Utf8Type::Fixed(1),
+                unit: CharLengthUnits::Characters,
+            }
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::UInteger,
+                LogicalType::Varchar(Some(2), CharLengthUnits::Characters),
+                &DataValue::UInt32(10),
+            )?,
+            DataValue::Utf8 {
+                value: "10".to_string(),
+                ty: Utf8Type::Variable(Some(2)),
+                unit: CharLengthUnits::Characters,
+            }
+        );
+        #[cfg(feature = "decimal")]
+        assert_eq!(
+            cast_eval(
+                LogicalType::Smallint,
+                LogicalType::Decimal(None, Some(1)),
+                &DataValue::Int16(12),
+            )?,
+            DataValue::Decimal(Decimal::new(120, 1))
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn test_cast_create_dispatches_utf8_casts() -> Result<(), DatabaseError> {
         assert_eq!(
             cast_eval(
@@ -1370,6 +1511,38 @@ mod test {
         assert_eq!(
             cast_eval(
                 LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::Tinyint,
+                &utf8("12")
+            )?,
+            DataValue::Int8(12)
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::UTinyint,
+                &utf8("12")
+            )?,
+            DataValue::UInt8(12)
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::Smallint,
+                &utf8("12")
+            )?,
+            DataValue::Int16(12)
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::USmallint,
+                &utf8("12")
+            )?,
+            DataValue::UInt16(12)
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
                 LogicalType::UInteger,
                 &utf8("12")
             )?,
@@ -1378,10 +1551,34 @@ mod test {
         assert_eq!(
             cast_eval(
                 LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::Bigint,
+                &utf8("12")
+            )?,
+            DataValue::Int64(12)
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::UBigint,
+                &utf8("12")
+            )?,
+            DataValue::UInt64(12)
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
                 LogicalType::Float,
                 &utf8("1.5")
             )?,
             DataValue::Float32(OrderedFloat(1.5))
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::Double,
+                &utf8("1.5")
+            )?,
+            DataValue::Float64(OrderedFloat(1.5))
         );
         assert_eq!(
             cast_eval(
@@ -1444,7 +1641,7 @@ mod test {
                 LogicalType::Time(Some(0)),
                 &utf8("03:04:05"),
             )?,
-            DataValue::Time32(DataValue::pack(3 * 3600 + 4 * 60 + 5, 0, 0), 0)
+            DataValue::Time32(DataValue::pack_time(3 * 3600 + 4 * 60 + 5, 0, 0), 0)
         );
         assert_eq!(
             cast_eval(
@@ -1525,6 +1722,30 @@ mod test {
             cast_eval(LogicalType::DateTime, LogicalType::Date, &datetime)?,
             date
         );
+        assert_eq!(
+            cast_eval(
+                LogicalType::DateTime,
+                LogicalType::Char(19, CharLengthUnits::Characters),
+                &datetime,
+            )?,
+            DataValue::Utf8 {
+                value: "2024-01-02 03:04:05".to_string(),
+                ty: Utf8Type::Fixed(19),
+                unit: CharLengthUnits::Characters,
+            }
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::DateTime,
+                LogicalType::Varchar(Some(19), CharLengthUnits::Characters),
+                &datetime,
+            )?,
+            DataValue::Utf8 {
+                value: "2024-01-02 03:04:05".to_string(),
+                ty: Utf8Type::Variable(Some(19)),
+                unit: CharLengthUnits::Characters,
+            }
+        );
         assert!(matches!(
             cast_eval(LogicalType::DateTime, LogicalType::Time(Some(0)), &datetime)?,
             DataValue::Time32(_, 0)
@@ -1575,6 +1796,54 @@ mod test {
             )?,
             DataValue::Time64(*timestamp_value, 3, true)
         );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Time(Some(0)),
+                LogicalType::Char(8, CharLengthUnits::Characters),
+                &DataValue::Time32(DataValue::pack_time(3 * 3600 + 4 * 60 + 5, 0, 0), 0),
+            )?,
+            DataValue::Utf8 {
+                value: "03:04:05".to_string(),
+                ty: Utf8Type::Fixed(8),
+                unit: CharLengthUnits::Characters,
+            }
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Time(Some(0)),
+                LogicalType::Varchar(Some(8), CharLengthUnits::Characters),
+                &DataValue::Time32(DataValue::pack_time(3 * 3600 + 4 * 60 + 5, 0, 0), 0),
+            )?,
+            DataValue::Utf8 {
+                value: "03:04:05".to_string(),
+                ty: Utf8Type::Variable(Some(8)),
+                unit: CharLengthUnits::Characters,
+            }
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::TimeStamp(Some(3), false),
+                LogicalType::Char(23, CharLengthUnits::Characters),
+                &timestamp,
+            )?,
+            DataValue::Utf8 {
+                value: "2024-01-02 03:04:05.123".to_string(),
+                ty: Utf8Type::Fixed(23),
+                unit: CharLengthUnits::Characters,
+            }
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::TimeStamp(Some(3), false),
+                LogicalType::Varchar(Some(23), CharLengthUnits::Characters),
+                &timestamp,
+            )?,
+            DataValue::Utf8 {
+                value: "2024-01-02 03:04:05.123".to_string(),
+                ty: Utf8Type::Variable(Some(23)),
+                unit: CharLengthUnits::Characters,
+            }
+        );
 
         Ok(())
     }
@@ -1606,8 +1875,33 @@ mod test {
             create(LogicalType::Date, LogicalType::Boolean),
             Err(DatabaseError::CastFail { .. })
         ));
+        assert_eq!(
+            create(LogicalType::Integer, LogicalType::Integer)?.eval(&DataValue::Int32(1))?,
+            DataValue::Int32(1)
+        );
 
         Ok(())
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_float_to_decimal_cast_rejects_nan() {
+        assert!(matches!(
+            cast_eval(
+                LogicalType::Float,
+                LogicalType::Decimal(Some(4), Some(2)),
+                &DataValue::Float32(OrderedFloat(f32::NAN)),
+            ),
+            Err(DatabaseError::CastFail { .. })
+        ));
+        assert!(matches!(
+            cast_eval(
+                LogicalType::Double,
+                LogicalType::Decimal(Some(4), Some(2)),
+                &DataValue::Float64(OrderedFloat(f64::NAN)),
+            ),
+            Err(DatabaseError::CastFail { .. })
+        ));
     }
 
     #[cfg(feature = "decimal")]
@@ -1662,3 +1956,4 @@ mod test {
         Ok(())
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/cast.rs
+++ b/src/types/evaluator/cast.rs
@@ -1153,12 +1153,33 @@ mod test {
     use crate::serdes::{ReferenceSerialization, ReferenceTables};
     use crate::storage::rocksdb::RocksTransaction;
     use crate::types::evaluator::CastEvaluatorRef;
-    use crate::types::LogicalType;
+    use crate::types::value::{DataValue, Utf8Type};
+    use crate::types::{CharLengthUnits, LogicalType};
+    use chrono::Datelike;
+    use ordered_float::OrderedFloat;
+    #[cfg(feature = "decimal")]
+    use rust_decimal::Decimal;
     use std::borrow::Cow;
     use std::io::{Cursor, Seek, SeekFrom};
 
     fn create(from: LogicalType, to: LogicalType) -> Result<CastEvaluatorRef, DatabaseError> {
         cast_create(Cow::Owned(from), Cow::Owned(to))
+    }
+
+    fn utf8(value: &str) -> DataValue {
+        DataValue::Utf8 {
+            value: value.to_string(),
+            ty: Utf8Type::Variable(None),
+            unit: CharLengthUnits::Characters,
+        }
+    }
+
+    fn cast_eval(
+        from: LogicalType,
+        to: LogicalType,
+        value: &DataValue,
+    ) -> Result<DataValue, DatabaseError> {
+        create(from, to)?.eval(value)
     }
 
     #[test]
@@ -1206,6 +1227,437 @@ mod test {
             )?,
             evaluator
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cast_create_dispatches_boolean_numeric_and_string_casts() -> Result<(), DatabaseError> {
+        let value = DataValue::Boolean(true);
+        let cases = vec![
+            (LogicalType::Tinyint, DataValue::Int8(1)),
+            (LogicalType::UTinyint, DataValue::UInt8(1)),
+            (LogicalType::Smallint, DataValue::Int16(1)),
+            (LogicalType::USmallint, DataValue::UInt16(1)),
+            (LogicalType::Integer, DataValue::Int32(1)),
+            (LogicalType::UInteger, DataValue::UInt32(1)),
+            (LogicalType::Bigint, DataValue::Int64(1)),
+            (LogicalType::UBigint, DataValue::UInt64(1)),
+            (LogicalType::Float, DataValue::Float32(OrderedFloat(1.0))),
+            (LogicalType::Double, DataValue::Float64(OrderedFloat(1.0))),
+            (
+                LogicalType::Char(4, CharLengthUnits::Characters),
+                DataValue::Utf8 {
+                    value: "true".to_string(),
+                    ty: Utf8Type::Fixed(4),
+                    unit: CharLengthUnits::Characters,
+                },
+            ),
+            (
+                LogicalType::Varchar(Some(4), CharLengthUnits::Characters),
+                DataValue::Utf8 {
+                    value: "true".to_string(),
+                    ty: Utf8Type::Variable(Some(4)),
+                    unit: CharLengthUnits::Characters,
+                },
+            ),
+        ];
+
+        for (to, expected) in cases {
+            assert_eq!(cast_eval(LogicalType::Boolean, to, &value)?, expected);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cast_create_dispatches_float_and_double_casts() -> Result<(), DatabaseError> {
+        let float = DataValue::Float32(OrderedFloat(1.5));
+        let float_cases = vec![
+            (LogicalType::Tinyint, DataValue::Int8(1)),
+            (LogicalType::UTinyint, DataValue::UInt8(1)),
+            (LogicalType::Smallint, DataValue::Int16(1)),
+            (LogicalType::USmallint, DataValue::UInt16(1)),
+            (LogicalType::Integer, DataValue::Int32(1)),
+            (LogicalType::UInteger, DataValue::UInt32(1)),
+            (LogicalType::Bigint, DataValue::Int64(1)),
+            (LogicalType::UBigint, DataValue::UInt64(1)),
+            (LogicalType::Double, DataValue::Float64(OrderedFloat(1.5))),
+            (
+                LogicalType::Char(3, CharLengthUnits::Characters),
+                DataValue::Utf8 {
+                    value: "1.5".to_string(),
+                    ty: Utf8Type::Fixed(3),
+                    unit: CharLengthUnits::Characters,
+                },
+            ),
+            (
+                LogicalType::Varchar(Some(3), CharLengthUnits::Characters),
+                DataValue::Utf8 {
+                    value: "1.5".to_string(),
+                    ty: Utf8Type::Variable(Some(3)),
+                    unit: CharLengthUnits::Characters,
+                },
+            ),
+            #[cfg(feature = "decimal")]
+            (
+                LogicalType::Decimal(None, Some(1)),
+                DataValue::Decimal(Decimal::new(15, 1)),
+            ),
+        ];
+        for (to, expected) in float_cases {
+            assert_eq!(cast_eval(LogicalType::Float, to, &float)?, expected);
+        }
+
+        let double = DataValue::Float64(OrderedFloat(1.5));
+        let double_cases = vec![
+            (LogicalType::Float, DataValue::Float32(OrderedFloat(1.5))),
+            (LogicalType::Tinyint, DataValue::Int8(1)),
+            (LogicalType::UTinyint, DataValue::UInt8(1)),
+            (LogicalType::Smallint, DataValue::Int16(1)),
+            (LogicalType::USmallint, DataValue::UInt16(1)),
+            (LogicalType::Integer, DataValue::Int32(1)),
+            (LogicalType::UInteger, DataValue::UInt32(1)),
+            (LogicalType::Bigint, DataValue::Int64(1)),
+            (LogicalType::UBigint, DataValue::UInt64(1)),
+            (
+                LogicalType::Char(3, CharLengthUnits::Characters),
+                DataValue::Utf8 {
+                    value: "1.5".to_string(),
+                    ty: Utf8Type::Fixed(3),
+                    unit: CharLengthUnits::Characters,
+                },
+            ),
+            (
+                LogicalType::Varchar(Some(3), CharLengthUnits::Characters),
+                DataValue::Utf8 {
+                    value: "1.5".to_string(),
+                    ty: Utf8Type::Variable(Some(3)),
+                    unit: CharLengthUnits::Characters,
+                },
+            ),
+            #[cfg(feature = "decimal")]
+            (
+                LogicalType::Decimal(None, Some(1)),
+                DataValue::Decimal(Decimal::new(15, 1)),
+            ),
+        ];
+        for (to, expected) in double_cases {
+            assert_eq!(cast_eval(LogicalType::Double, to, &double)?, expected);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cast_create_dispatches_utf8_casts() -> Result<(), DatabaseError> {
+        assert_eq!(
+            cast_eval(
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::Boolean,
+                &utf8("true")
+            )?,
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::Integer,
+                &utf8("12")
+            )?,
+            DataValue::Int32(12)
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::UInteger,
+                &utf8("12")
+            )?,
+            DataValue::UInt32(12)
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::Float,
+                &utf8("1.5")
+            )?,
+            DataValue::Float32(OrderedFloat(1.5))
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Char(2, CharLengthUnits::Characters),
+                LogicalType::Varchar(Some(2), CharLengthUnits::Characters),
+                &DataValue::Utf8 {
+                    value: "ab".to_string(),
+                    ty: Utf8Type::Fixed(2),
+                    unit: CharLengthUnits::Characters,
+                },
+            )?,
+            DataValue::Utf8 {
+                value: "ab".to_string(),
+                ty: Utf8Type::Variable(Some(2)),
+                unit: CharLengthUnits::Characters,
+            }
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::Char(2, CharLengthUnits::Characters),
+                &utf8("ab"),
+            )?,
+            DataValue::Utf8 {
+                value: "ab".to_string(),
+                ty: Utf8Type::Fixed(2),
+                unit: CharLengthUnits::Characters,
+            }
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::Date,
+                &utf8("2024-01-02")
+            )?,
+            DataValue::Date32(
+                chrono::NaiveDate::from_ymd_opt(2024, 1, 2)
+                    .unwrap()
+                    .num_days_from_ce()
+            )
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::DateTime,
+                &utf8("2024-01-02 03:04:05"),
+            )?,
+            DataValue::Date64(
+                chrono::NaiveDate::from_ymd_opt(2024, 1, 2)
+                    .unwrap()
+                    .and_hms_opt(3, 4, 5)
+                    .unwrap()
+                    .and_utc()
+                    .timestamp()
+            )
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::Time(Some(0)),
+                &utf8("03:04:05"),
+            )?,
+            DataValue::Time32(DataValue::pack(3 * 3600 + 4 * 60 + 5, 0, 0), 0)
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::TimeStamp(Some(0), true),
+                &utf8("2024-01-02 03:04:05+00:00"),
+            )?,
+            DataValue::Time64(
+                chrono::NaiveDate::from_ymd_opt(2024, 1, 2)
+                    .unwrap()
+                    .and_hms_opt(3, 4, 5)
+                    .unwrap()
+                    .and_utc()
+                    .timestamp(),
+                0,
+                true,
+            )
+        );
+
+        #[cfg(feature = "decimal")]
+        assert_eq!(
+            cast_eval(
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::Decimal(None, None),
+                &utf8("12.34"),
+            )?,
+            DataValue::Decimal(Decimal::new(1234, 2))
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cast_create_dispatches_chrono_casts() -> Result<(), DatabaseError> {
+        let date = DataValue::Date32(
+            chrono::NaiveDate::from_ymd_opt(2024, 1, 2)
+                .unwrap()
+                .num_days_from_ce(),
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Date,
+                LogicalType::Char(10, CharLengthUnits::Characters),
+                &date,
+            )?,
+            DataValue::Utf8 {
+                value: "2024-01-02".to_string(),
+                ty: Utf8Type::Fixed(10),
+                unit: CharLengthUnits::Characters,
+            }
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::Date,
+                LogicalType::Varchar(Some(10), CharLengthUnits::Characters),
+                &date,
+            )?,
+            DataValue::Utf8 {
+                value: "2024-01-02".to_string(),
+                ty: Utf8Type::Variable(Some(10)),
+                unit: CharLengthUnits::Characters,
+            }
+        );
+        assert!(matches!(
+            cast_eval(LogicalType::Date, LogicalType::DateTime, &date)?,
+            DataValue::Date64(_)
+        ));
+
+        let datetime = DataValue::Date64(
+            chrono::NaiveDate::from_ymd_opt(2024, 1, 2)
+                .unwrap()
+                .and_hms_opt(3, 4, 5)
+                .unwrap()
+                .and_utc()
+                .timestamp(),
+        );
+        assert_eq!(
+            cast_eval(LogicalType::DateTime, LogicalType::Date, &datetime)?,
+            date
+        );
+        assert!(matches!(
+            cast_eval(LogicalType::DateTime, LogicalType::Time(Some(0)), &datetime)?,
+            DataValue::Time32(_, 0)
+        ));
+        assert!(matches!(
+            cast_eval(
+                LogicalType::DateTime,
+                LogicalType::TimeStamp(Some(0), false),
+                &datetime,
+            )?,
+            DataValue::Time64(_, 0, false)
+        ));
+
+        let timestamp = DataValue::Time64(
+            chrono::NaiveDate::from_ymd_opt(2024, 1, 2)
+                .unwrap()
+                .and_hms_milli_opt(3, 4, 5, 123)
+                .unwrap()
+                .and_utc()
+                .timestamp_millis(),
+            3,
+            false,
+        );
+        assert_eq!(
+            cast_eval(
+                LogicalType::TimeStamp(Some(3), false),
+                LogicalType::Date,
+                &timestamp
+            )?,
+            date
+        );
+        assert!(matches!(
+            cast_eval(
+                LogicalType::TimeStamp(Some(3), false),
+                LogicalType::Time(Some(3)),
+                &timestamp,
+            )?,
+            DataValue::Time32(_, 3)
+        ));
+        let DataValue::Time64(timestamp_value, ..) = &timestamp else {
+            unreachable!("timestamp fixture must be Time64")
+        };
+        assert_eq!(
+            cast_eval(
+                LogicalType::TimeStamp(Some(3), false),
+                LogicalType::TimeStamp(Some(3), true),
+                &timestamp,
+            )?,
+            DataValue::Time64(*timestamp_value, 3, true)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cast_create_dispatches_tuple_and_rejects_unsupported_casts() -> Result<(), DatabaseError>
+    {
+        let tuple = DataValue::Tuple(vec![DataValue::Int32(1), utf8("2")], false);
+        assert_eq!(
+            cast_eval(
+                LogicalType::Tuple(vec![
+                    LogicalType::Integer,
+                    LogicalType::Varchar(None, CharLengthUnits::Characters),
+                ]),
+                LogicalType::Tuple(vec![LogicalType::Bigint, LogicalType::Integer]),
+                &tuple,
+            )?,
+            DataValue::Tuple(vec![DataValue::Int64(1), DataValue::Int32(2)], false)
+        );
+
+        assert!(matches!(
+            create(
+                LogicalType::Tuple(vec![LogicalType::Integer]),
+                LogicalType::Integer
+            ),
+            Err(DatabaseError::CastFail { .. })
+        ));
+        assert!(matches!(
+            create(LogicalType::Date, LogicalType::Boolean),
+            Err(DatabaseError::CastFail { .. })
+        ));
+
+        Ok(())
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_cast_create_dispatches_decimal_casts() -> Result<(), DatabaseError> {
+        let value = DataValue::Decimal(Decimal::new(125, 1));
+        let cases = vec![
+            (LogicalType::Float, DataValue::Float32(OrderedFloat(12.5))),
+            (LogicalType::Double, DataValue::Float64(OrderedFloat(12.5))),
+            (
+                LogicalType::Decimal(None, None),
+                DataValue::Decimal(Decimal::new(125, 1)),
+            ),
+            (LogicalType::Tinyint, DataValue::Int8(12)),
+            (LogicalType::UTinyint, DataValue::UInt8(12)),
+            (LogicalType::Smallint, DataValue::Int16(12)),
+            (LogicalType::USmallint, DataValue::UInt16(12)),
+            (LogicalType::Integer, DataValue::Int32(12)),
+            (LogicalType::UInteger, DataValue::UInt32(12)),
+            (LogicalType::Bigint, DataValue::Int64(12)),
+            (LogicalType::UBigint, DataValue::UInt64(12)),
+            (
+                LogicalType::Char(4, CharLengthUnits::Characters),
+                DataValue::Utf8 {
+                    value: "12.5".to_string(),
+                    ty: Utf8Type::Fixed(4),
+                    unit: CharLengthUnits::Characters,
+                },
+            ),
+            (
+                LogicalType::Varchar(Some(4), CharLengthUnits::Characters),
+                DataValue::Utf8 {
+                    value: "12.5".to_string(),
+                    ty: Utf8Type::Variable(Some(4)),
+                    unit: CharLengthUnits::Characters,
+                },
+            ),
+        ];
+
+        for (to, expected) in cases {
+            assert_eq!(
+                cast_eval(LogicalType::Decimal(None, None), to, &value)?,
+                expected
+            );
+        }
+
+        assert!(matches!(
+            create(LogicalType::Decimal(None, None), LogicalType::Date),
+            Err(DatabaseError::CastFail { .. })
+        ));
 
         Ok(())
     }

--- a/src/types/evaluator/date.rs
+++ b/src/types/evaluator/date.rs
@@ -62,9 +62,11 @@ crate::define_cast_evaluator!(date32_to_datetime_cast_eval, DataValue::Date32(va
     }
 );
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
+    use crate::errors::DatabaseError;
     use crate::types::value::Utf8Type;
     use chrono::Datelike;
 
@@ -102,5 +104,23 @@ mod test {
                     .timestamp()
             )
         );
+        assert_eq!(
+            date_plus_binary_eval(&DataValue::Date32(1), &DataValue::Date32(2)).unwrap(),
+            DataValue::Date32(3)
+        );
+        let invalid = DataValue::Date32(i32::MAX);
+        assert!(matches!(
+            date32_to_char_cast_eval(10, CharLengthUnits::Characters, &invalid),
+            Err(DatabaseError::CastFail { .. })
+        ));
+        assert!(matches!(
+            date32_to_varchar_cast_eval(Some(10), CharLengthUnits::Characters, &invalid),
+            Err(DatabaseError::CastFail { .. })
+        ));
+        assert!(matches!(
+            date32_to_datetime_cast_eval(&invalid),
+            Err(DatabaseError::CastFail { .. })
+        ));
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/datetime.rs
+++ b/src/types/evaluator/datetime.rs
@@ -72,7 +72,7 @@ crate::define_cast_evaluator!(
                 cast_fail(LogicalType::DateTime, LogicalType::Time(this.precision))
             })?;
 
-        Ok(DataValue::Time32(DataValue::pack(value, 0, 0), precision))
+        Ok(DataValue::Time32(DataValue::pack_time(value, 0, 0), precision))
     }
 );
 crate::define_cast_evaluator!(
@@ -85,9 +85,11 @@ crate::define_cast_evaluator!(
     }
 );
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
+    use crate::errors::DatabaseError;
     use crate::types::value::Utf8Type;
     use crate::types::CharLengthUnits;
 
@@ -127,7 +129,7 @@ mod test {
         );
         assert_eq!(
             date64_to_time_cast_eval(Some(0), &value).unwrap(),
-            DataValue::Time32(DataValue::pack(3 * 3600 + 4 * 60 + 5, 0, 0), 0)
+            DataValue::Time32(DataValue::pack_time(3 * 3600 + 4 * 60 + 5, 0, 0), 0)
         );
         assert_eq!(
             date64_to_timestamp_cast_eval(Some(0), true, &value).unwrap(),
@@ -142,5 +144,28 @@ mod test {
                 true,
             )
         );
+        assert_eq!(
+            date_time_eq_binary_eval(&value, &value).unwrap(),
+            DataValue::Boolean(true)
+        );
+
+        let invalid = DataValue::Date64(i64::MAX);
+        assert!(matches!(
+            date64_to_char_cast_eval(19, CharLengthUnits::Characters, &invalid),
+            Err(DatabaseError::CastFail { .. })
+        ));
+        assert!(matches!(
+            date64_to_varchar_cast_eval(Some(19), CharLengthUnits::Characters, &invalid),
+            Err(DatabaseError::CastFail { .. })
+        ));
+        assert!(matches!(
+            date64_to_date_cast_eval(&invalid),
+            Err(DatabaseError::CastFail { .. })
+        ));
+        assert!(matches!(
+            date64_to_time_cast_eval(Some(0), &invalid),
+            Err(DatabaseError::CastFail { .. })
+        ));
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/decimal.rs
+++ b/src/types/evaluator/decimal.rs
@@ -137,6 +137,7 @@ decimal_binary!(
     |v1: &rust_decimal::Decimal, v2: &rust_decimal::Decimal| DataValue::Decimal(v1 % v2)
 );
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -209,4 +210,74 @@ mod test {
             DataValue::UInt64(12)
         );
     }
+
+    #[test]
+    fn test_decimal_binary_evaluators() {
+        let left = DataValue::Decimal(Decimal::new(55, 1));
+        let right = DataValue::Decimal(Decimal::new(20, 1));
+
+        let cases = vec![
+            (
+                decimal_plus_binary_eval(&left, &right).unwrap(),
+                DataValue::Decimal(Decimal::new(75, 1)),
+            ),
+            (
+                decimal_minus_binary_eval(&left, &right).unwrap(),
+                DataValue::Decimal(Decimal::new(35, 1)),
+            ),
+            (
+                decimal_multiply_binary_eval(&left, &right).unwrap(),
+                DataValue::Decimal(Decimal::new(1100, 2)),
+            ),
+            (
+                decimal_divide_binary_eval(&left, &right).unwrap(),
+                DataValue::Decimal(Decimal::new(275, 2)),
+            ),
+            (
+                decimal_gt_binary_eval(&left, &right).unwrap(),
+                DataValue::Boolean(true),
+            ),
+            (
+                decimal_gt_eq_binary_eval(&left, &right).unwrap(),
+                DataValue::Boolean(true),
+            ),
+            (
+                decimal_lt_binary_eval(&left, &right).unwrap(),
+                DataValue::Boolean(false),
+            ),
+            (
+                decimal_lt_eq_binary_eval(&left, &right).unwrap(),
+                DataValue::Boolean(false),
+            ),
+            (
+                decimal_eq_binary_eval(&left, &right).unwrap(),
+                DataValue::Boolean(false),
+            ),
+            (
+                decimal_not_eq_binary_eval(&left, &right).unwrap(),
+                DataValue::Boolean(true),
+            ),
+            (
+                decimal_mod_binary_eval(&left, &right).unwrap(),
+                DataValue::Decimal(Decimal::new(15, 1)),
+            ),
+        ];
+        for (actual, expected) in cases {
+            assert_eq!(actual, expected);
+        }
+
+        assert_eq!(
+            decimal_plus_binary_eval(&left, &DataValue::Null).unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            decimal_plus_binary_eval(&DataValue::Null, &right).unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            decimal_plus_binary_eval(&DataValue::Null, &DataValue::Null).unwrap(),
+            DataValue::Null
+        );
+    }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/float32.rs
+++ b/src/types/evaluator/float32.rs
@@ -113,6 +113,7 @@ float32_binary!(
 
 crate::define_float_cast_evaluators!(Float32, Float32, f32, LogicalType::Float, from_f32);
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -188,4 +189,81 @@ mod test {
             DataValue::Decimal(Decimal::new(15, 1))
         );
     }
+
+    #[test]
+    fn test_float32_unary_and_binary_evaluators() {
+        let left = DataValue::Float32(OrderedFloat(5.5));
+        let right = DataValue::Float32(OrderedFloat(2.0));
+
+        assert_eq!(float32_plus_unary_eval(&left), left);
+        assert_eq!(
+            float32_minus_unary_eval(&left),
+            DataValue::Float32(OrderedFloat(-5.5))
+        );
+        assert_eq!(float32_minus_unary_eval(&DataValue::Null), DataValue::Null);
+
+        let cases = vec![
+            (
+                float32_plus_binary_eval(&left, &right).unwrap(),
+                DataValue::Float32(OrderedFloat(7.5)),
+            ),
+            (
+                float32_minus_binary_eval(&left, &right).unwrap(),
+                DataValue::Float32(OrderedFloat(3.5)),
+            ),
+            (
+                float32_multiply_binary_eval(&left, &right).unwrap(),
+                DataValue::Float32(OrderedFloat(11.0)),
+            ),
+            (
+                float32_divide_binary_eval(&left, &right).unwrap(),
+                DataValue::Float64(OrderedFloat(2.75)),
+            ),
+            (
+                float32_gt_binary_eval(&left, &right).unwrap(),
+                DataValue::Boolean(true),
+            ),
+            (
+                float32_gt_eq_binary_eval(&left, &right).unwrap(),
+                DataValue::Boolean(true),
+            ),
+            (
+                float32_lt_binary_eval(&left, &right).unwrap(),
+                DataValue::Boolean(false),
+            ),
+            (
+                float32_lt_eq_binary_eval(&left, &right).unwrap(),
+                DataValue::Boolean(false),
+            ),
+            (
+                float32_eq_binary_eval(&left, &right).unwrap(),
+                DataValue::Boolean(false),
+            ),
+            (
+                float32_not_eq_binary_eval(&left, &right).unwrap(),
+                DataValue::Boolean(true),
+            ),
+            (
+                float32_mod_binary_eval(&left, &right).unwrap(),
+                DataValue::Float32(OrderedFloat(1.5)),
+            ),
+        ];
+        for (actual, expected) in cases {
+            assert_eq!(actual, expected);
+        }
+
+        assert_eq!(
+            float32_plus_binary_eval(&left, &DataValue::Null).unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            float32_plus_binary_eval(&DataValue::Null, &right).unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            float32_plus_binary_eval(&DataValue::Null, &DataValue::Null).unwrap(),
+            DataValue::Null
+        );
+    }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/float64.rs
+++ b/src/types/evaluator/float64.rs
@@ -181,6 +181,7 @@ float64_binary!(
     }
 );
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -193,6 +194,28 @@ mod test {
     fn test_float64_binary_and_cast_evaluators() {
         let value = DataValue::Float64(ordered_float::OrderedFloat(1.5));
 
+        assert_eq!(float64_plus_unary_eval(&value), value);
+        assert_eq!(
+            float64_minus_unary_eval(&value),
+            DataValue::Float64(ordered_float::OrderedFloat(-1.5))
+        );
+        assert_eq!(float64_minus_unary_eval(&DataValue::Null), DataValue::Null);
+        assert_eq!(
+            float64_plus_binary_eval(
+                &DataValue::Float64(ordered_float::OrderedFloat(1.5)),
+                &DataValue::Float64(ordered_float::OrderedFloat(2.0)),
+            )
+            .unwrap(),
+            DataValue::Float64(ordered_float::OrderedFloat(3.5))
+        );
+        assert_eq!(
+            float64_minus_binary_eval(
+                &DataValue::Float64(ordered_float::OrderedFloat(1.5)),
+                &DataValue::Float64(ordered_float::OrderedFloat(2.0)),
+            )
+            .unwrap(),
+            DataValue::Float64(ordered_float::OrderedFloat(-0.5))
+        );
         assert_eq!(
             float64_multiply_binary_eval(
                 &DataValue::Float64(ordered_float::OrderedFloat(1.5)),
@@ -200,6 +223,74 @@ mod test {
             )
             .unwrap(),
             DataValue::Float64(ordered_float::OrderedFloat(3.0))
+        );
+        assert_eq!(
+            float64_divide_binary_eval(
+                &DataValue::Float64(ordered_float::OrderedFloat(3.0)),
+                &DataValue::Float64(ordered_float::OrderedFloat(2.0)),
+            )
+            .unwrap(),
+            DataValue::Float64(ordered_float::OrderedFloat(1.5))
+        );
+        assert_eq!(
+            float64_gt_binary_eval(
+                &DataValue::Float64(ordered_float::OrderedFloat(3.0)),
+                &DataValue::Float64(ordered_float::OrderedFloat(2.0)),
+            )
+            .unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            float64_gt_eq_binary_eval(
+                &DataValue::Float64(ordered_float::OrderedFloat(3.0)),
+                &DataValue::Float64(ordered_float::OrderedFloat(3.0)),
+            )
+            .unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            float64_lt_binary_eval(
+                &DataValue::Float64(ordered_float::OrderedFloat(2.0)),
+                &DataValue::Float64(ordered_float::OrderedFloat(3.0)),
+            )
+            .unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            float64_lt_eq_binary_eval(
+                &DataValue::Float64(ordered_float::OrderedFloat(3.0)),
+                &DataValue::Float64(ordered_float::OrderedFloat(3.0)),
+            )
+            .unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            float64_eq_binary_eval(
+                &DataValue::Float64(ordered_float::OrderedFloat(3.0)),
+                &DataValue::Float64(ordered_float::OrderedFloat(3.0)),
+            )
+            .unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            float64_not_eq_binary_eval(
+                &DataValue::Float64(ordered_float::OrderedFloat(3.0)),
+                &DataValue::Float64(ordered_float::OrderedFloat(2.0)),
+            )
+            .unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            float64_mod_binary_eval(
+                &DataValue::Float64(ordered_float::OrderedFloat(5.5)),
+                &DataValue::Float64(ordered_float::OrderedFloat(2.0)),
+            )
+            .unwrap(),
+            DataValue::Float64(ordered_float::OrderedFloat(1.5))
+        );
+        assert_eq!(
+            float64_plus_binary_eval(&value, &DataValue::Null).unwrap(),
+            DataValue::Null
         );
         assert_eq!(
             float64_to_float_cast_eval(&value).unwrap(),
@@ -262,5 +353,15 @@ mod test {
             float64_to_decimal_cast_eval(None, Some(1), &value).unwrap(),
             DataValue::Decimal(Decimal::new(15, 1))
         );
+        #[cfg(feature = "decimal")]
+        assert!(matches!(
+            float64_to_decimal_cast_eval(
+                Some(4),
+                Some(2),
+                &DataValue::Float64(ordered_float::OrderedFloat(f64::NAN)),
+            ),
+            Err(DatabaseError::CastFail { .. })
+        ));
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/int16.rs
+++ b/src/types/evaluator/int16.rs
@@ -20,6 +20,7 @@ numeric_unary_evaluator_definition!(Int16, DataValue::Int16);
 numeric_binary_evaluator_definition!(Int16, DataValue::Int16);
 crate::define_integer_cast_evaluators!(Int16, Int16, i16, LogicalType::Smallint);
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -98,3 +99,4 @@ mod test {
         );
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/int32.rs
+++ b/src/types/evaluator/int32.rs
@@ -20,6 +20,7 @@ numeric_unary_evaluator_definition!(Int32, DataValue::Int32);
 numeric_binary_evaluator_definition!(Int32, DataValue::Int32);
 crate::define_integer_cast_evaluators!(Int32, Int32, i32, LogicalType::Integer);
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -118,3 +119,4 @@ mod test {
         );
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/int64.rs
+++ b/src/types/evaluator/int64.rs
@@ -20,6 +20,7 @@ numeric_unary_evaluator_definition!(Int64, DataValue::Int64);
 numeric_binary_evaluator_definition!(Int64, DataValue::Int64);
 crate::define_integer_cast_evaluators!(Int64, Int64, i64, LogicalType::Bigint);
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -98,3 +99,4 @@ mod test {
         );
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/int8.rs
+++ b/src/types/evaluator/int8.rs
@@ -20,6 +20,7 @@ numeric_unary_evaluator_definition!(Int8, DataValue::Int8);
 numeric_binary_evaluator_definition!(Int8, DataValue::Int8);
 crate::define_integer_cast_evaluators!(Int8, Int8, i8, LogicalType::Tinyint);
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -98,3 +99,4 @@ mod test {
         );
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/null.rs
+++ b/src/types/evaluator/null.rs
@@ -27,6 +27,7 @@ pub fn null_cast_eval(_value: &DataValue) -> Result<DataValue, DatabaseError> {
     Ok(DataValue::Null)
 }
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -40,3 +41,4 @@ mod test {
         assert_eq!(null_cast_eval(&DataValue::Null).unwrap(), DataValue::Null);
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/time32.rs
+++ b/src/types/evaluator/time32.rs
@@ -25,8 +25,8 @@ pub fn time_plus_binary_eval(
 ) -> Result<DataValue, DatabaseError> {
     Ok(match (left, right) {
         (DataValue::Time32(v1, p1), DataValue::Time32(v2, p2)) => {
-            let (mut v1, n1) = DataValue::unpack(*v1, *p1);
-            let (v2, n2) = DataValue::unpack(*v2, *p2);
+            let (mut v1, n1) = DataValue::unpack_time(*v1, *p1);
+            let (v2, n2) = DataValue::unpack_time(*v2, *p2);
             let mut n = n1 + n2;
             while n > ONE_SEC_TO_NANO {
                 v1 += 1;
@@ -36,7 +36,7 @@ pub fn time_plus_binary_eval(
             if v1 + v2 > ONE_DAY_TO_SEC {
                 return Ok(DataValue::Null);
             }
-            DataValue::Time32(DataValue::pack(v1 + v2, n, p), p)
+            DataValue::Time32(DataValue::pack_time(v1 + v2, n, p), p)
         }
         (DataValue::Time32(..), DataValue::Null)
         | (DataValue::Null, DataValue::Time32(..))
@@ -50,8 +50,8 @@ pub fn time_minus_binary_eval(
 ) -> Result<DataValue, DatabaseError> {
     Ok(match (left, right) {
         (DataValue::Time32(v1, p1), DataValue::Time32(v2, p2, ..)) => {
-            let (mut v1, mut n1) = DataValue::unpack(*v1, *p1);
-            let (v2, n2) = DataValue::unpack(*v2, *p2);
+            let (mut v1, mut n1) = DataValue::unpack_time(*v1, *p1);
+            let (v2, n2) = DataValue::unpack_time(*v2, *p2);
             while n1 < n2 {
                 v1 -= 1;
                 n1 += ONE_SEC_TO_NANO;
@@ -60,7 +60,7 @@ pub fn time_minus_binary_eval(
                 return Ok(DataValue::Null);
             }
             let p = if p2 > p1 { *p2 } else { *p1 };
-            DataValue::Time32(DataValue::pack(v1 - v2, n1 - n2, p), p)
+            DataValue::Time32(DataValue::pack_time(v1 - v2, n1 - n2, p), p)
         }
         (DataValue::Time32(..), DataValue::Null)
         | (DataValue::Null, DataValue::Time32(..))
@@ -74,8 +74,8 @@ macro_rules! time32_order_binary {
         pub fn $name(left: &DataValue, right: &DataValue) -> Result<DataValue, DatabaseError> {
             Ok(match (left, right) {
                 (DataValue::Time32(v1, p1), DataValue::Time32(v2, p2, ..)) => {
-                    let (v1, n1) = DataValue::unpack(*v1, *p1);
-                    let (v2, n2) = DataValue::unpack(*v2, *p2);
+                    let (v1, n1) = DataValue::unpack_time(*v1, *p1);
+                    let (v2, n2) = DataValue::unpack_time(*v2, *p2);
                     DataValue::Boolean(v1.cmp(&v2).then_with(|| n1.cmp(&n2)).$is_order())
                 }
                 (DataValue::Time32(..), DataValue::Null)
@@ -147,6 +147,7 @@ pub fn time_not_eq_binary_eval(
     })
 }
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -170,11 +171,102 @@ mod test {
             .unwrap(),
             DataValue::Boolean(true)
         );
+        assert_eq!(
+            time_minus_binary_eval(
+                &DataValue::Time32(DataValue::pack_time(10, 500_000_000, 3), 3),
+                &DataValue::Time32(DataValue::pack_time(3, 700_000_000, 3), 3),
+            )
+            .unwrap(),
+            DataValue::Time32(DataValue::pack_time(6, 800_000_000, 3), 3)
+        );
+        assert_eq!(
+            time_minus_binary_eval(
+                &DataValue::Time32(DataValue::pack_time(1, 0, 0), 0),
+                &DataValue::Time32(DataValue::pack_time(2, 0, 0), 0),
+            )
+            .unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            time_plus_binary_eval(
+                &DataValue::Time32(DataValue::pack_time(ONE_DAY_TO_SEC, 0, 0), 0),
+                &DataValue::Time32(DataValue::pack_time(1, 0, 0), 0),
+            )
+            .unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            time_lt_binary_eval(
+                &DataValue::Time32(DataValue::pack_time(1, 0, 0), 0),
+                &DataValue::Time32(DataValue::pack_time(2, 0, 0), 0),
+            )
+            .unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            time_lt_eq_binary_eval(
+                &DataValue::Time32(DataValue::pack_time(2, 0, 0), 0),
+                &DataValue::Time32(DataValue::pack_time(2, 0, 0), 0),
+            )
+            .unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            time_eq_binary_eval(
+                &DataValue::Time32(DataValue::pack_time(2, 0, 0), 0),
+                &DataValue::Time32(DataValue::pack_time(2, 0, 0), 0),
+            )
+            .unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            time_not_eq_binary_eval(
+                &DataValue::Time32(DataValue::pack_time(2, 0, 0), 0),
+                &DataValue::Time32(DataValue::pack_time(3, 0, 0), 0),
+            )
+            .unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            time_not_eq_binary_eval(
+                &DataValue::Time32(DataValue::pack_time(2, 0, 0), 0),
+                &DataValue::Null
+            )
+            .unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            time_plus_binary_eval(
+                &DataValue::Null,
+                &DataValue::Time32(DataValue::pack_time(1, 0, 0), 0),
+            )
+            .unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            time_minus_binary_eval(
+                &DataValue::Null,
+                &DataValue::Time32(DataValue::pack_time(1, 0, 0), 0),
+            )
+            .unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            time_eq_binary_eval(
+                &DataValue::Null,
+                &DataValue::Time32(DataValue::pack_time(1, 0, 0), 0),
+            )
+            .unwrap(),
+            DataValue::Null
+        );
     }
 
     #[test]
     fn test_time32_cast_evaluators() {
-        let value = DataValue::Time32(DataValue::pack(3 * 3600 + 4 * 60 + 5, 123_000_000, 3), 3);
+        let value = DataValue::Time32(
+            DataValue::pack_time(3 * 3600 + 4 * 60 + 5, 123_000_000, 3),
+            3,
+        );
         assert_eq!(
             time32_to_char_cast_eval(12, CharLengthUnits::Characters, &value).unwrap(),
             DataValue::Utf8 {
@@ -192,5 +284,15 @@ mod test {
             }
         );
         assert_eq!(time32_to_time_cast_eval(Some(3), &value).unwrap(), value);
+        let invalid = DataValue::Time32(u32::MAX, 0);
+        assert!(matches!(
+            time32_to_char_cast_eval(8, CharLengthUnits::Characters, &invalid),
+            Err(DatabaseError::CastFail { .. })
+        ));
+        assert!(matches!(
+            time32_to_varchar_cast_eval(Some(8), CharLengthUnits::Characters, &invalid),
+            Err(DatabaseError::CastFail { .. })
+        ));
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/time64.rs
+++ b/src/types/evaluator/time64.rs
@@ -139,7 +139,7 @@ crate::define_cast_evaluator!(
             })?;
 
         Ok(DataValue::Time32(
-            DataValue::pack(value, nano, target_precision),
+            DataValue::pack_time(value, nano, target_precision),
             target_precision,
         ))
     }
@@ -158,6 +158,7 @@ time64_binary!(time64_lt_eq_binary_eval, <=);
 time64_binary!(time64_eq_binary_eval, ==);
 time64_binary!(time64_not_eq_binary_eval, !=);
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -173,6 +174,44 @@ mod test {
             )
             .unwrap(),
             DataValue::Boolean(true)
+        );
+        let left = DataValue::Time64(1_738_734_177_256, 3, false);
+        let right = DataValue::Time64(1_738_734_177_000, 3, false);
+        assert_eq!(
+            time64_gt_binary_eval(&left, &right).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            time64_gt_eq_binary_eval(&left, &left).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            time64_lt_binary_eval(&right, &left).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            time64_lt_eq_binary_eval(&right, &right).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            time64_not_eq_binary_eval(&left, &right).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            time64_eq_binary_eval(&left, &DataValue::Null).unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            time64_eq_binary_eval(&DataValue::Null, &left).unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            time64_eq_binary_eval(&DataValue::Null, &DataValue::Null).unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            time64_eq_binary_eval(&DataValue::Time64(i64::MAX, 0, false), &left).unwrap(),
+            DataValue::Null
         );
     }
 
@@ -222,11 +261,22 @@ mod test {
         );
         assert_eq!(
             time64_to_time_cast_eval(Some(3), &value).unwrap(),
-            DataValue::Time32(DataValue::pack(3 * 3600 + 4 * 60 + 5, 123_000_000, 3), 3)
+            DataValue::Time32(
+                DataValue::pack_time(3 * 3600 + 4 * 60 + 5, 123_000_000, 3),
+                3
+            )
         );
         assert_eq!(
             time64_to_timestamp_cast_eval(Some(3), true, &value).unwrap(),
             DataValue::Time64(timestamp, 3, true)
         );
+
+        let invalid = DataValue::Time64(i64::MAX, 0, false);
+        assert!(time64_to_char_cast_eval(23, CharLengthUnits::Characters, &invalid).is_err());
+        assert!(time64_to_varchar_cast_eval(None, CharLengthUnits::Characters, &invalid).is_err());
+        assert!(time64_to_date_cast_eval(&invalid).is_err());
+        assert!(time64_to_datetime_cast_eval(&invalid).is_err());
+        assert!(time64_to_time_cast_eval(Some(0), &invalid).is_err());
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/tuple.rs
+++ b/src/types/evaluator/tuple.rs
@@ -114,6 +114,8 @@ pub(crate) fn eval_tuple_cast(
         _ => unsafe { hint::unreachable_unchecked() },
     }
 }
+
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -121,6 +123,73 @@ mod test {
     use crate::types::CharLengthUnits;
     use crate::types::LogicalType;
     use std::borrow::Cow;
+
+    fn tuple(values: Vec<DataValue>) -> DataValue {
+        DataValue::Tuple(values, false)
+    }
+
+    #[test]
+    fn test_tuple_binary_evaluators() {
+        let left = tuple(vec![DataValue::Int32(1), DataValue::Int32(2)]);
+        let same = tuple(vec![DataValue::Int32(1), DataValue::Int32(2)]);
+        let greater = tuple(vec![DataValue::Int32(1), DataValue::Int32(3)]);
+        let shorter_lower = tuple(vec![DataValue::Int32(1)]);
+        let shorter_upper = DataValue::Tuple(vec![DataValue::Int32(1)], true);
+        let incomparable = tuple(vec![DataValue::Int32(1), DataValue::Boolean(true)]);
+
+        assert_eq!(
+            tuple_eq_binary_eval(&left, &same).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            tuple_not_eq_binary_eval(&left, &greater).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            tuple_gt_binary_eval(&greater, &left).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            tuple_gt_eq_binary_eval(&left, &same).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            tuple_lt_binary_eval(&left, &greater).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            tuple_lt_eq_binary_eval(&left, &same).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            tuple_lt_binary_eval(&shorter_lower, &left).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            tuple_gt_binary_eval(&shorter_upper, &left).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            tuple_lt_binary_eval(&incomparable, &left).unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            tuple_eq_binary_eval(&DataValue::Null, &DataValue::Null).unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            tuple_not_eq_binary_eval(&DataValue::Boolean(true), &DataValue::Null).unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            tuple_gt_binary_eval(&DataValue::Null, &DataValue::Boolean(true)).unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            tuple_lt_eq_binary_eval(&DataValue::Null, &DataValue::Null).unwrap(),
+            DataValue::Null
+        );
+    }
 
     #[test]
     fn test_tuple_cast_eval() {
@@ -152,5 +221,7 @@ mod test {
                 .unwrap(),
             DataValue::Tuple(vec![DataValue::Int64(1), DataValue::Int32(2)], false)
         );
+        assert_eq!(evaluator.eval(&DataValue::Null).unwrap(), DataValue::Null);
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/uint16.rs
+++ b/src/types/evaluator/uint16.rs
@@ -19,6 +19,7 @@ use crate::types::LogicalType;
 numeric_binary_evaluator_definition!(Uint16, DataValue::UInt16);
 crate::define_integer_cast_evaluators!(Uint16, UInt16, u16, LogicalType::USmallint);
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -97,3 +98,4 @@ mod test {
         );
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/uint32.rs
+++ b/src/types/evaluator/uint32.rs
@@ -19,6 +19,7 @@ use crate::types::LogicalType;
 numeric_binary_evaluator_definition!(Uint32, DataValue::UInt32);
 crate::define_integer_cast_evaluators!(Uint32, UInt32, u32, LogicalType::UInteger);
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -97,3 +98,4 @@ mod test {
         );
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/uint64.rs
+++ b/src/types/evaluator/uint64.rs
@@ -19,6 +19,7 @@ use crate::types::LogicalType;
 numeric_binary_evaluator_definition!(Uint64, DataValue::UInt64);
 crate::define_integer_cast_evaluators!(Uint64, UInt64, u64, LogicalType::UBigint);
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -97,3 +98,4 @@ mod test {
         );
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/uint8.rs
+++ b/src/types/evaluator/uint8.rs
@@ -19,6 +19,7 @@ use crate::types::LogicalType;
 numeric_binary_evaluator_definition!(Uint8, DataValue::UInt8);
 crate::define_integer_cast_evaluators!(Uint8, UInt8, u8, LogicalType::UTinyint);
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -97,3 +98,4 @@ mod test {
         );
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/unary.rs
+++ b/src/types/evaluator/unary.rs
@@ -120,6 +120,7 @@ macro_rules! numeric_unary_evaluator_definition {
     };
 }
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -136,6 +137,10 @@ mod test {
 
     fn create(ty: LogicalType, op: UnaryOperator) -> Result<UnaryEvaluatorRef, DatabaseError> {
         unary_create(Cow::Owned(ty), op)
+    }
+
+    fn assert_panics(f: impl FnOnce() + std::panic::UnwindSafe) {
+        assert!(std::panic::catch_unwind(f).is_err());
     }
 
     #[test]
@@ -157,8 +162,40 @@ mod test {
     }
 
     #[test]
+    fn test_unary_eval_rejects_invalid_positions() {
+        assert_panics(|| {
+            let evaluator = UnaryEvaluatorRef::new(u16::MAX);
+            let _ = evaluator.unary_eval(&DataValue::Int32(1));
+        });
+    }
+
+    #[test]
     fn test_numeric_unary_evaluators() -> Result<(), DatabaseError> {
         let cases = vec![
+            (
+                LogicalType::Tinyint,
+                UnaryOperator::Plus,
+                DataValue::Int8(7),
+                DataValue::Int8(7),
+            ),
+            (
+                LogicalType::Tinyint,
+                UnaryOperator::Minus,
+                DataValue::Int8(7),
+                DataValue::Int8(-7),
+            ),
+            (
+                LogicalType::Smallint,
+                UnaryOperator::Plus,
+                DataValue::Int16(7),
+                DataValue::Int16(7),
+            ),
+            (
+                LogicalType::Smallint,
+                UnaryOperator::Minus,
+                DataValue::Int16(7),
+                DataValue::Int16(-7),
+            ),
             (
                 LogicalType::Integer,
                 UnaryOperator::Plus,
@@ -173,15 +210,33 @@ mod test {
             ),
             (
                 LogicalType::Bigint,
+                UnaryOperator::Plus,
+                DataValue::Int64(7),
+                DataValue::Int64(7),
+            ),
+            (
+                LogicalType::Bigint,
                 UnaryOperator::Minus,
                 DataValue::Int64(7),
                 DataValue::Int64(-7),
+            ),
+            (
+                LogicalType::Float,
+                UnaryOperator::Plus,
+                DataValue::Float32(OrderedFloat(1.5)),
+                DataValue::Float32(OrderedFloat(1.5)),
             ),
             (
                 LogicalType::Double,
                 UnaryOperator::Minus,
                 DataValue::Float64(OrderedFloat(1.5)),
                 DataValue::Float64(OrderedFloat(-1.5)),
+            ),
+            (
+                LogicalType::Float,
+                UnaryOperator::Minus,
+                DataValue::Float32(OrderedFloat(1.5)),
+                DataValue::Float32(OrderedFloat(-1.5)),
             ),
         ];
 
@@ -212,6 +267,20 @@ mod test {
             err,
             DatabaseError::UnsupportedUnaryOperator(LogicalType::Boolean, UnaryOperator::Plus)
         ));
+        assert!(matches!(
+            create(LogicalType::Date, UnaryOperator::Plus),
+            Err(DatabaseError::UnsupportedUnaryOperator(
+                LogicalType::Date,
+                UnaryOperator::Plus
+            ))
+        ));
+        assert!(matches!(
+            create(LogicalType::Integer, UnaryOperator::Not),
+            Err(DatabaseError::UnsupportedUnaryOperator(
+                LogicalType::Integer,
+                UnaryOperator::Not
+            ))
+        ));
     }
 
     #[test]
@@ -237,3 +306,4 @@ mod test {
         Ok(())
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/evaluator/utf8.rs
+++ b/src/types/evaluator/utf8.rs
@@ -143,7 +143,7 @@ mod chrono_cast {
                     .map(|time| (time.num_seconds_from_midnight(), time.nanosecond()))?,
             };
 
-            Ok(DataValue::Time32(DataValue::pack(value, nano, precision), precision))
+            Ok(DataValue::Time32(DataValue::pack_time(value, nano, precision), precision))
         }
     );
 
@@ -344,6 +344,7 @@ fn next_char_at(input: &str, index: usize) -> Option<(char, usize)> {
     Some((ch, index + ch.len_utf8()))
 }
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use super::*;
@@ -357,10 +358,34 @@ mod test {
         }
     }
 
+    fn assert_panics(f: impl FnOnce() + std::panic::UnwindSafe) {
+        assert!(std::panic::catch_unwind(f).is_err());
+    }
+
     #[test]
     fn test_utf8_binary_evaluators() {
         assert_eq!(
+            utf8_gt_binary_eval(&utf8("b"), &utf8("a")).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            utf8_gt_eq_binary_eval(&utf8("a"), &utf8("a")).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
             utf8_lt_binary_eval(&utf8("a"), &utf8("b")).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            utf8_lt_eq_binary_eval(&utf8("a"), &utf8("a")).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            utf8_eq_binary_eval(&utf8("a"), &utf8("a")).unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            utf8_not_eq_binary_eval(&utf8("a"), &utf8("b")).unwrap(),
             DataValue::Boolean(true)
         );
         assert_eq!(
@@ -374,6 +399,14 @@ mod test {
         assert_eq!(
             utf8_not_like_binary_eval(None, &utf8("kite"), &utf8("ki%")).unwrap(),
             DataValue::Boolean(false)
+        );
+        assert_eq!(
+            utf8_like_binary_eval(None, &utf8("kite"), &DataValue::Null).unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            utf8_not_like_binary_eval(None, &DataValue::Null, &utf8("ki%")).unwrap(),
+            DataValue::Null
         );
     }
 
@@ -414,6 +447,12 @@ mod test {
             ("好a", "__", None, true),
             ("好a", "_", None, false),
             ("你好", "你%", None, true),
+            ("abc", "a_d", None, false),
+            ("abc", "a%_d", None, false),
+            ("abc", "a%c_", None, false),
+            ("a%b", "a@%b", Some('@'), true),
+            ("a_b", "a@_b", Some('@'), true),
+            ("ab", "a@", Some('@'), false),
         ];
 
         for (value, pattern, escape_char, expected) in cases {
@@ -508,7 +547,7 @@ mod test {
         );
         assert_eq!(
             utf8_to_time_cast_eval(Some(0), &utf8("03:04:05")).unwrap(),
-            DataValue::Time32(DataValue::pack(3 * 3600 + 4 * 60 + 5, 0, 0), 0)
+            DataValue::Time32(DataValue::pack_time(3 * 3600 + 4 * 60 + 5, 0, 0), 0)
         );
         assert_eq!(
             utf8_to_time_cast_eval(Some(3), &utf8("03:04:05.123")).unwrap(),
@@ -519,7 +558,7 @@ mod test {
                 )
                 .unwrap();
                 DataValue::Time32(
-                    DataValue::pack(time.num_seconds_from_midnight(), time.nanosecond(), 3),
+                    DataValue::pack_time(time.num_seconds_from_midnight(), time.nanosecond(), 3),
                     3,
                 )
             }
@@ -551,8 +590,80 @@ mod test {
             )
         );
         assert_eq!(
+            utf8_to_timestamp_cast_eval(Some(0), true, &utf8("2024-01-02 03:04:05")).unwrap(),
+            DataValue::Time64(
+                chrono::NaiveDate::from_ymd_opt(2024, 1, 2)
+                    .unwrap()
+                    .and_hms_opt(3, 4, 5)
+                    .unwrap()
+                    .and_utc()
+                    .timestamp(),
+                0,
+                true,
+            )
+        );
+        assert_eq!(
+            utf8_to_timestamp_cast_eval(Some(6), false, &utf8("2024-01-02 03:04:05.123456"))
+                .unwrap(),
+            DataValue::Time64(
+                chrono::NaiveDate::from_ymd_opt(2024, 1, 2)
+                    .unwrap()
+                    .and_hms_micro_opt(3, 4, 5, 123_456)
+                    .unwrap()
+                    .and_utc()
+                    .timestamp_micros(),
+                6,
+                false,
+            )
+        );
+        assert_eq!(
+            utf8_to_timestamp_cast_eval(
+                Some(9),
+                true,
+                &utf8("2024-01-02 03:04:05.123456789+00:00")
+            )
+            .unwrap(),
+            DataValue::Time64(
+                chrono::NaiveDate::from_ymd_opt(2024, 1, 2)
+                    .unwrap()
+                    .and_hms_nano_opt(3, 4, 5, 123_456_789)
+                    .unwrap()
+                    .and_utc()
+                    .timestamp_nanos_opt()
+                    .unwrap(),
+                9,
+                true,
+            )
+        );
+        assert_eq!(
+            utf8_to_timestamp_cast_eval(Some(9), false, &utf8("2024-01-02 03:04:05.123456789"))
+                .unwrap(),
+            DataValue::Time64(
+                chrono::NaiveDate::from_ymd_opt(2024, 1, 2)
+                    .unwrap()
+                    .and_hms_nano_opt(3, 4, 5, 123_456_789)
+                    .unwrap()
+                    .and_utc()
+                    .timestamp_nanos_opt()
+                    .unwrap(),
+                9,
+                false,
+            )
+        );
+        assert_eq!(
             utf8_to_decimal_cast_eval(&utf8("12.34")).unwrap(),
             DataValue::Decimal(Decimal::from_str("12.34").unwrap())
         );
+
+        assert_panics(|| {
+            let _ = utf8_to_timestamp_cast_eval(Some(4), false, &utf8("2024-01-02 03:04:05.1234"))
+                .unwrap();
+        });
+        assert_panics(|| {
+            let _ =
+                utf8_to_timestamp_cast_eval(Some(4), true, &utf8("2024-01-02 03:04:05.1234+00:00"))
+                    .unwrap();
+        });
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/index.rs
+++ b/src/types/index.rs
@@ -179,3 +179,244 @@ impl fmt::Display for IndexMetaRef {
         write!(f, "#{}", self.pos)
     }
 }
+
+// GRCOV_EXCL_START
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use crate::catalog::{ColumnCatalog, ColumnDesc, TableCatalog};
+    use crate::planner::{PlanArena, TableArena, TableArenaCell};
+    use crate::serdes::{ReferenceSerialization, ReferenceTables};
+    use crate::storage::rocksdb::RocksTransaction;
+    use std::fmt::Debug;
+    use std::io::{Cursor, Seek, SeekFrom};
+
+    fn index_info(lookup: Option<IndexLookup>) -> IndexInfo {
+        IndexInfo {
+            meta: IndexMetaRef::new(7),
+            sort_option: SortOption::None,
+            lookup,
+            residual_predicate: None,
+            covered_deserializers: None,
+            cover_mapping: None,
+            sort_elimination_hint: None,
+            stream_distinct_hint: None,
+        }
+    }
+
+    fn index_meta() -> IndexMeta {
+        IndexMeta {
+            id: 1,
+            column_ids: vec![10],
+            table_name: "t".into(),
+            pk_ty: LogicalType::Integer,
+            value_ty: LogicalType::Integer,
+            name: "idx_t".to_string(),
+            ty: IndexType::Normal,
+        }
+    }
+
+    fn roundtrip_with_arena<T>(
+        value: T,
+        encode_arena: &TableArena,
+        decode_arena: &mut TableArena,
+    ) -> Result<T, DatabaseError>
+    where
+        T: ReferenceSerialization + Debug + PartialEq,
+    {
+        let mut cursor = Cursor::new(Vec::new());
+        let mut reference_tables = ReferenceTables::new();
+
+        value.encode(&mut cursor, false, &mut reference_tables, encode_arena)?;
+        cursor.seek(SeekFrom::Start(0))?;
+
+        T::decode::<RocksTransaction, _, _>(&mut cursor, None, &reference_tables, decode_arena)
+    }
+
+    #[test]
+    fn test_index_helpers_and_display() {
+        let meta_ref = IndexMetaRef::new(3);
+        assert_eq!(meta_ref.pos(), 3);
+        assert_eq!(meta_ref.to_string(), "#3");
+
+        let mut hint = IndexOrderHint::new(2);
+        assert_eq!(hint.cover_num(), 2);
+        hint.merge_cover_num(5);
+        assert_eq!(hint.cover_num(), 5);
+        hint.merge_cover_num(3);
+        assert_eq!(hint.cover_num(), 5);
+
+        let meta = index_meta();
+        assert_eq!(meta.to_string(), "idx_t");
+
+        assert_eq!(index_info(None).to_string(), "#7 => EMPTY");
+        assert_eq!(
+            index_info(Some(IndexLookup::Probe)).to_string(),
+            "#7 => Probe ?"
+        );
+        let mut info = index_info(Some(IndexLookup::Static(Range::Eq(DataValue::Int32(1)))));
+        info.covered_deserializers = Some(vec![LogicalType::Integer.serializable()]);
+        assert_eq!(info.to_string(), "#7 => 1 Covered");
+
+        let value = DataValue::Int32(1);
+        let index = Index::new(9, &value, IndexType::Unique);
+        assert_eq!(index.id, 9);
+        assert_eq!(index.value, &value);
+        assert_eq!(index.ty, IndexType::Unique);
+    }
+
+    #[test]
+    fn test_index_types_hash() {
+        use std::collections::HashSet;
+
+        let mut set = HashSet::new();
+        set.insert(IndexType::PrimaryKey { is_multiple: false });
+        set.insert(IndexType::PrimaryKey { is_multiple: true });
+        set.insert(IndexType::Unique);
+        set.insert(IndexType::Normal);
+        set.insert(IndexType::Composite);
+        assert!(set.contains(&IndexType::Unique));
+        assert!(!set.insert(IndexType::Normal));
+
+        let mut probes = HashSet::new();
+        probes.insert(RuntimeIndexProbe::Eq(DataValue::Int32(1)));
+        probes.insert(RuntimeIndexProbe::Scope {
+            min: Bound::Included(DataValue::Int32(1)),
+            max: Bound::Excluded(DataValue::Int32(2)),
+        });
+        assert!(probes.contains(&RuntimeIndexProbe::Eq(DataValue::Int32(1))));
+
+        let mut lookups = HashSet::new();
+        lookups.insert(IndexLookup::Static(Range::Eq(DataValue::Int32(1))));
+        lookups.insert(IndexLookup::Probe);
+        assert!(lookups.contains(&IndexLookup::Probe));
+
+        let mut hints = HashSet::new();
+        hints.insert(IndexOrderHint::new(1));
+        assert!(hints.contains(&IndexOrderHint::new(1)));
+
+        let mut metas = HashSet::new();
+        metas.insert(index_meta());
+        assert!(metas.contains(&index_meta()));
+
+        let mut infos = HashSet::new();
+        infos.insert(index_info(Some(IndexLookup::Probe)));
+        assert!(infos.contains(&index_info(Some(IndexLookup::Probe))));
+    }
+
+    #[test]
+    fn test_index_serialization_roundtrips() -> Result<(), DatabaseError> {
+        let mut encode_arena = TableArena::default();
+        let mut decode_arena = TableArena::default();
+
+        for ty in [
+            IndexType::PrimaryKey { is_multiple: false },
+            IndexType::PrimaryKey { is_multiple: true },
+            IndexType::Unique,
+            IndexType::Normal,
+            IndexType::Composite,
+        ] {
+            assert_eq!(
+                roundtrip_with_arena(ty, &encode_arena, &mut decode_arena)?,
+                ty
+            );
+        }
+
+        for probe in [
+            RuntimeIndexProbe::Eq(DataValue::Int32(1)),
+            RuntimeIndexProbe::Scope {
+                min: Bound::Included(DataValue::Int32(1)),
+                max: Bound::Excluded(DataValue::Int32(2)),
+            },
+        ] {
+            assert_eq!(
+                roundtrip_with_arena(probe.clone(), &encode_arena, &mut decode_arena)?,
+                probe
+            );
+        }
+
+        for lookup in [
+            IndexLookup::Static(Range::Eq(DataValue::Int32(1))),
+            IndexLookup::Probe,
+        ] {
+            assert_eq!(
+                roundtrip_with_arena(lookup.clone(), &encode_arena, &mut decode_arena)?,
+                lookup
+            );
+        }
+
+        assert_eq!(
+            roundtrip_with_arena(IndexOrderHint::new(3), &encode_arena, &mut decode_arena)?,
+            IndexOrderHint::new(3)
+        );
+        assert_eq!(
+            roundtrip_with_arena(index_meta(), &encode_arena, &mut decode_arena)?,
+            index_meta()
+        );
+
+        let meta = encode_arena.alloc_index(index_meta());
+        let info = IndexInfo {
+            meta,
+            sort_option: SortOption::None,
+            lookup: Some(IndexLookup::Probe),
+            residual_predicate: None,
+            covered_deserializers: Some(vec![LogicalType::Integer.serializable()]),
+            cover_mapping: Some(vec![0]),
+            sort_elimination_hint: Some(IndexOrderHint::new(1)),
+            stream_distinct_hint: Some(IndexOrderHint::new(1)),
+        };
+
+        assert_eq!(
+            roundtrip_with_arena(info.clone(), &encode_arena, &mut decode_arena)?,
+            info
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_index_meta_column_exprs() -> Result<(), DatabaseError> {
+        let table_arena = TableArenaCell::default();
+        let mut arena = PlanArena::new(&table_arena);
+        let id_col = ColumnCatalog::new(
+            "id".to_string(),
+            false,
+            ColumnDesc::new(LogicalType::Integer, Some(0), false, None)?,
+        );
+        let name_col = ColumnCatalog::new(
+            "name".to_string(),
+            true,
+            ColumnDesc::new(
+                LogicalType::Varchar(None, crate::types::CharLengthUnits::Characters),
+                None,
+                false,
+                None,
+            )?,
+        );
+        let table = TableCatalog::new("t".into(), vec![id_col, name_col], &mut arena)?;
+        let id_column = arena.column(*table.columns().next().unwrap()).id().unwrap();
+        let meta = IndexMeta {
+            id: 1,
+            column_ids: vec![id_column],
+            table_name: "t".into(),
+            pk_ty: LogicalType::Integer,
+            value_ty: LogicalType::Integer,
+            name: "idx_id".to_string(),
+            ty: IndexType::Normal,
+        };
+
+        assert_eq!(meta.column_exprs(&table, &arena)?.len(), 1);
+
+        let missing = IndexMeta {
+            column_ids: vec![u64::MAX],
+            ..meta
+        };
+        assert!(matches!(
+            missing.column_exprs(&table, &arena),
+            Err(DatabaseError::ColumnNotFound { .. })
+        ));
+
+        Ok(())
+    }
+}
+// GRCOV_EXCL_STOP

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -458,6 +458,7 @@ impl std::fmt::Display for LogicalType {
     }
 }
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 pub(crate) mod test {
     use crate::errors::DatabaseError;
@@ -465,7 +466,420 @@ pub(crate) mod test {
     use crate::storage::rocksdb::RocksTransaction;
     use crate::types::CharLengthUnits;
     use crate::types::LogicalType;
+    #[cfg(feature = "time")]
+    use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+    #[cfg(feature = "decimal")]
+    use rust_decimal::Decimal;
+    use std::borrow::Cow;
     use std::io::{Cursor, Seek, SeekFrom};
+
+    #[test]
+    fn test_char_length_units_display() {
+        assert_eq!(CharLengthUnits::Characters.to_string(), "CHARACTERS");
+        assert_eq!(CharLengthUnits::Octets.to_string(), "OCTETS");
+    }
+
+    #[test]
+    fn test_logical_type_type_trans() {
+        assert_eq!(
+            LogicalType::type_trans::<bool>(),
+            Some(LogicalType::Boolean)
+        );
+        assert_eq!(LogicalType::type_trans::<i8>(), Some(LogicalType::Tinyint));
+        assert_eq!(
+            LogicalType::type_trans::<i16>(),
+            Some(LogicalType::Smallint)
+        );
+        assert_eq!(LogicalType::type_trans::<i32>(), Some(LogicalType::Integer));
+        assert_eq!(LogicalType::type_trans::<i64>(), Some(LogicalType::Bigint));
+        assert_eq!(LogicalType::type_trans::<u8>(), Some(LogicalType::UTinyint));
+        assert_eq!(
+            LogicalType::type_trans::<u16>(),
+            Some(LogicalType::USmallint)
+        );
+        assert_eq!(
+            LogicalType::type_trans::<u32>(),
+            Some(LogicalType::UInteger)
+        );
+        assert_eq!(LogicalType::type_trans::<u64>(), Some(LogicalType::UBigint));
+        assert_eq!(LogicalType::type_trans::<f32>(), Some(LogicalType::Float));
+        assert_eq!(LogicalType::type_trans::<f64>(), Some(LogicalType::Double));
+        assert_eq!(
+            LogicalType::type_trans::<String>(),
+            Some(LogicalType::Varchar(None, CharLengthUnits::Characters))
+        );
+        assert_eq!(LogicalType::type_trans::<Vec<u8>>(), None);
+
+        #[cfg(feature = "decimal")]
+        assert_eq!(
+            LogicalType::type_trans::<Decimal>(),
+            Some(LogicalType::Decimal(None, None))
+        );
+        #[cfg(feature = "time")]
+        {
+            assert_eq!(
+                LogicalType::type_trans::<NaiveDate>(),
+                Some(LogicalType::Date)
+            );
+            assert_eq!(
+                LogicalType::type_trans::<NaiveDateTime>(),
+                Some(LogicalType::DateTime)
+            );
+            assert_eq!(
+                LogicalType::type_trans::<NaiveTime>(),
+                Some(LogicalType::Time(Some(0)))
+            );
+        }
+    }
+
+    #[test]
+    fn test_logical_type_raw_len() {
+        let fixed = vec![
+            (LogicalType::SqlNull, Some(0)),
+            (LogicalType::Boolean, Some(1)),
+            (LogicalType::Tinyint, Some(1)),
+            (LogicalType::UTinyint, Some(1)),
+            (LogicalType::Smallint, Some(2)),
+            (LogicalType::USmallint, Some(2)),
+            (LogicalType::Integer, Some(4)),
+            (LogicalType::UInteger, Some(4)),
+            (LogicalType::Bigint, Some(8)),
+            (LogicalType::UBigint, Some(8)),
+            (LogicalType::Float, Some(4)),
+            (LogicalType::Double, Some(8)),
+            (LogicalType::Char(4, CharLengthUnits::Octets), Some(4)),
+            (LogicalType::Decimal(None, None), Some(16)),
+            (LogicalType::Date, Some(4)),
+            (LogicalType::DateTime, Some(8)),
+            (LogicalType::Time(None), Some(4)),
+            (LogicalType::TimeStamp(None, false), Some(8)),
+        ];
+        for (ty, len) in fixed {
+            assert_eq!(ty.raw_len(), len);
+        }
+
+        assert_eq!(
+            LogicalType::Char(4, CharLengthUnits::Characters).raw_len(),
+            None
+        );
+        assert_eq!(
+            LogicalType::Varchar(Some(4), CharLengthUnits::Octets).raw_len(),
+            None
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_logical_type_raw_len_tuple_panics() {
+        let _ = LogicalType::Tuple(vec![LogicalType::Integer]).raw_len();
+    }
+
+    #[test]
+    fn test_logical_type_numeric_helpers() {
+        assert_eq!(
+            LogicalType::numeric(),
+            vec![
+                LogicalType::Tinyint,
+                LogicalType::UTinyint,
+                LogicalType::Smallint,
+                LogicalType::USmallint,
+                LogicalType::Integer,
+                LogicalType::UInteger,
+                LogicalType::Bigint,
+                LogicalType::UBigint,
+                LogicalType::Float,
+                LogicalType::Double,
+            ]
+        );
+
+        for ty in LogicalType::numeric() {
+            assert!(ty.is_numeric());
+        }
+        assert!(LogicalType::Decimal(None, None).is_numeric());
+        assert!(!LogicalType::Boolean.is_numeric());
+        assert!(LogicalType::Integer.is_signed_numeric());
+        assert!(!LogicalType::UInteger.is_signed_numeric());
+        assert!(LogicalType::UInteger.is_unsigned_numeric());
+        assert!(!LogicalType::Integer.is_unsigned_numeric());
+        assert!(LogicalType::Float.is_floating_point_numeric());
+        assert!(LogicalType::Double.is_floating_point_numeric());
+        assert!(!LogicalType::Bigint.is_floating_point_numeric());
+    }
+
+    #[test]
+    fn test_logical_type_max_logical_type() -> Result<(), DatabaseError> {
+        let integer = LogicalType::Integer;
+        assert!(matches!(
+            LogicalType::max_logical_type(&integer, &integer)?,
+            Cow::Borrowed(LogicalType::Integer)
+        ));
+        assert_eq!(
+            LogicalType::max_logical_type(&LogicalType::SqlNull, &LogicalType::Boolean)?.as_ref(),
+            &LogicalType::Boolean
+        );
+        assert_eq!(
+            LogicalType::max_logical_type(&LogicalType::Boolean, &LogicalType::SqlNull)?.as_ref(),
+            &LogicalType::Boolean
+        );
+        assert_eq!(
+            LogicalType::max_logical_type(
+                &LogicalType::Tuple(vec![LogicalType::Integer, LogicalType::Bigint]),
+                &LogicalType::Tuple(vec![LogicalType::Integer])
+            )?
+            .as_ref(),
+            &LogicalType::Tuple(vec![LogicalType::Integer, LogicalType::Bigint])
+        );
+        assert_eq!(
+            LogicalType::max_logical_type(
+                &LogicalType::Tuple(vec![LogicalType::Integer]),
+                &LogicalType::Tuple(vec![LogicalType::Integer, LogicalType::Bigint])
+            )?
+            .as_ref(),
+            &LogicalType::Tuple(vec![LogicalType::Integer, LogicalType::Bigint])
+        );
+
+        let numeric_cases = vec![
+            (
+                LogicalType::Integer,
+                LogicalType::Bigint,
+                LogicalType::Bigint,
+            ),
+            (
+                LogicalType::UInteger,
+                LogicalType::Bigint,
+                LogicalType::Bigint,
+            ),
+            (
+                LogicalType::UTinyint,
+                LogicalType::Smallint,
+                LogicalType::Smallint,
+            ),
+            (
+                LogicalType::Decimal(Some(4), Some(1)),
+                LogicalType::Decimal(None, Some(2)),
+                LogicalType::Decimal(Some(4), Some(2)),
+            ),
+            (
+                LogicalType::Tinyint,
+                LogicalType::Tinyint,
+                LogicalType::Tinyint,
+            ),
+            (
+                LogicalType::Bigint,
+                LogicalType::UInteger,
+                LogicalType::Bigint,
+            ),
+            (
+                LogicalType::Integer,
+                LogicalType::USmallint,
+                LogicalType::Integer,
+            ),
+            (
+                LogicalType::Smallint,
+                LogicalType::UTinyint,
+                LogicalType::Smallint,
+            ),
+            (
+                LogicalType::Decimal(None, None),
+                LogicalType::Decimal(None, None),
+                LogicalType::Decimal(None, None),
+            ),
+            (
+                LogicalType::Decimal(None, Some(1)),
+                LogicalType::Decimal(None, Some(2)),
+                LogicalType::Decimal(None, Some(2)),
+            ),
+        ];
+        for (left, right, expected) in numeric_cases {
+            assert_eq!(
+                LogicalType::max_logical_type(&left, &right)?.as_ref(),
+                &expected
+            );
+        }
+        assert!(matches!(
+            LogicalType::max_logical_type(&LogicalType::Bigint, &LogicalType::UBigint),
+            Err(DatabaseError::Incomparable(..))
+        ));
+        assert!(matches!(
+            LogicalType::max_logical_type(&LogicalType::Integer, &LogicalType::UInteger),
+            Err(DatabaseError::Incomparable(..))
+        ));
+        assert!(matches!(
+            LogicalType::max_logical_type(&LogicalType::Tinyint, &LogicalType::UTinyint),
+            Err(DatabaseError::Incomparable(..))
+        ));
+
+        assert_eq!(
+            LogicalType::combine_numeric_types(&LogicalType::Bigint, &LogicalType::Boolean)?
+                .as_ref(),
+            &LogicalType::Double
+        );
+        assert_eq!(
+            LogicalType::combine_numeric_types(&LogicalType::Integer, &LogicalType::Boolean)?
+                .as_ref(),
+            &LogicalType::Bigint
+        );
+        assert_eq!(
+            LogicalType::combine_numeric_types(&LogicalType::Smallint, &LogicalType::Boolean)?
+                .as_ref(),
+            &LogicalType::Integer
+        );
+        assert_eq!(
+            LogicalType::combine_numeric_types(&LogicalType::Tinyint, &LogicalType::Boolean)?
+                .as_ref(),
+            &LogicalType::Smallint
+        );
+
+        assert_eq!(
+            LogicalType::max_logical_type(
+                &LogicalType::Char(2, CharLengthUnits::Characters),
+                &LogicalType::Varchar(Some(8), CharLengthUnits::Octets)
+            )?,
+            Cow::Owned(LogicalType::Varchar(None, CharLengthUnits::Characters))
+        );
+        #[cfg(feature = "time")]
+        {
+            assert_eq!(
+                LogicalType::max_logical_type(
+                    &LogicalType::Date,
+                    &LogicalType::Varchar(None, CharLengthUnits::Characters)
+                )?,
+                Cow::Owned(LogicalType::Date)
+            );
+            assert_eq!(
+                LogicalType::max_logical_type(&LogicalType::Date, &LogicalType::DateTime)?,
+                Cow::Owned(LogicalType::DateTime)
+            );
+            assert_eq!(
+                LogicalType::max_logical_type(
+                    &LogicalType::DateTime,
+                    &LogicalType::Varchar(None, CharLengthUnits::Characters)
+                )?,
+                Cow::Owned(LogicalType::DateTime)
+            );
+        }
+
+        assert!(matches!(
+            LogicalType::max_logical_type(&LogicalType::Boolean, &LogicalType::Date),
+            Err(DatabaseError::Incomparable(..))
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_logical_type_can_implicit_cast() {
+        let castable = vec![
+            (LogicalType::Integer, LogicalType::Integer),
+            (LogicalType::SqlNull, LogicalType::Boolean),
+            (LogicalType::Tinyint, LogicalType::Smallint),
+            (LogicalType::Tinyint, LogicalType::Decimal(None, None)),
+            (LogicalType::UTinyint, LogicalType::Integer),
+            (LogicalType::UTinyint, LogicalType::Decimal(None, None)),
+            (LogicalType::Smallint, LogicalType::Bigint),
+            (LogicalType::Smallint, LogicalType::Decimal(None, None)),
+            (LogicalType::USmallint, LogicalType::Bigint),
+            (LogicalType::USmallint, LogicalType::Decimal(None, None)),
+            (LogicalType::Integer, LogicalType::Double),
+            (LogicalType::UInteger, LogicalType::Double),
+            (LogicalType::Bigint, LogicalType::Decimal(None, None)),
+            (LogicalType::UBigint, LogicalType::Decimal(None, None)),
+            (LogicalType::Float, LogicalType::Decimal(None, None)),
+            (LogicalType::Double, LogicalType::Decimal(None, None)),
+            (LogicalType::Date, LogicalType::DateTime),
+            (
+                LogicalType::Date,
+                LogicalType::Char(10, CharLengthUnits::Characters),
+            ),
+            (
+                LogicalType::DateTime,
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+            ),
+            (LogicalType::TimeStamp(None, false), LogicalType::Date),
+            (
+                LogicalType::Time(None),
+                LogicalType::Char(8, CharLengthUnits::Characters),
+            ),
+        ];
+        for (from, to) in castable {
+            assert!(LogicalType::can_implicit_cast(&from, &to), "{from} -> {to}");
+        }
+
+        let not_castable = vec![
+            (LogicalType::Boolean, LogicalType::Integer),
+            (LogicalType::Tinyint, LogicalType::UTinyint),
+            (LogicalType::UTinyint, LogicalType::Tinyint),
+            (LogicalType::Smallint, LogicalType::USmallint),
+            (LogicalType::USmallint, LogicalType::Smallint),
+            (
+                LogicalType::Char(1, CharLengthUnits::Characters),
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+            ),
+            (
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+                LogicalType::Integer,
+            ),
+            (LogicalType::Decimal(None, None), LogicalType::Double),
+            (
+                LogicalType::Tuple(vec![LogicalType::Integer]),
+                LogicalType::Integer,
+            ),
+        ];
+        for (from, to) in not_castable {
+            assert!(
+                !LogicalType::can_implicit_cast(&from, &to),
+                "{from} -> {to}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_logical_type_display() {
+        let cases = vec![
+            (LogicalType::SqlNull, "SqlNull"),
+            (LogicalType::Boolean, "Boolean"),
+            (LogicalType::Tinyint, "Tinyint"),
+            (LogicalType::UTinyint, "UTinyint"),
+            (LogicalType::Smallint, "Smallint"),
+            (LogicalType::USmallint, "USmallint"),
+            (LogicalType::Integer, "Integer"),
+            (LogicalType::UInteger, "UInteger"),
+            (LogicalType::Bigint, "Bigint"),
+            (LogicalType::UBigint, "UBigint"),
+            (LogicalType::Float, "Float"),
+            (LogicalType::Double, "Double"),
+            (
+                LogicalType::Char(4, CharLengthUnits::Characters),
+                "Char(4, CHARACTERS)",
+            ),
+            (
+                LogicalType::Varchar(Some(4), CharLengthUnits::Octets),
+                "Varchar(Some(4), OCTETS)",
+            ),
+            (LogicalType::Date, "Date"),
+            (LogicalType::DateTime, "DateTime"),
+            (
+                LogicalType::TimeStamp(Some(3), true),
+                "TimeStamp(Some(3), true)",
+            ),
+            (LogicalType::Time(Some(3)), "Time(Some(3))"),
+            (
+                LogicalType::Decimal(Some(4), Some(2)),
+                "Decimal(Some(4), Some(2))",
+            ),
+            (
+                LogicalType::Tuple(vec![
+                    LogicalType::Integer,
+                    LogicalType::Varchar(None, CharLengthUnits::Characters),
+                ]),
+                "(Integer, Varchar(None, CHARACTERS))",
+            ),
+        ];
+
+        for (ty, expected) in cases {
+            assert_eq!(ty.to_string(), expected);
+        }
+    }
 
     #[test]
     fn test_logic_type_serialization() -> Result<(), DatabaseError> {
@@ -594,3 +1008,4 @@ pub(crate) mod test {
         Ok(())
     }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/serialize.rs
+++ b/src/types/serialize.rs
@@ -646,3 +646,168 @@ impl LogicalType {
         }
     }
 }
+
+// GRCOV_EXCL_START
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    fn roundtrip(
+        serializer: TupleValueSerializableImpl,
+        value: DataValue,
+    ) -> Result<DataValue, DatabaseError> {
+        let mut bytes = Vec::new();
+        serializer.to_raw(&value, &mut bytes)?;
+        serializer.from_raw(&mut Cursor::new(bytes.as_slice()))
+    }
+
+    fn assert_panics(f: impl FnOnce() + std::panic::UnwindSafe) {
+        assert!(std::panic::catch_unwind(f).is_err());
+    }
+
+    #[test]
+    fn test_tuple_value_serializable_impl_roundtrips_all_value_variants(
+    ) -> Result<(), DatabaseError> {
+        let cases = vec![
+            (
+                TupleValueSerializableImpl::Boolean,
+                DataValue::Boolean(true),
+            ),
+            (TupleValueSerializableImpl::Int8, DataValue::Int8(-1)),
+            (TupleValueSerializableImpl::Int16, DataValue::Int16(-2)),
+            (TupleValueSerializableImpl::Int32, DataValue::Int32(-3)),
+            (TupleValueSerializableImpl::Int64, DataValue::Int64(-4)),
+            (TupleValueSerializableImpl::UInt8, DataValue::UInt8(1)),
+            (TupleValueSerializableImpl::UInt16, DataValue::UInt16(2)),
+            (TupleValueSerializableImpl::UInt32, DataValue::UInt32(3)),
+            (TupleValueSerializableImpl::UInt64, DataValue::UInt64(4)),
+            (
+                TupleValueSerializableImpl::Float32,
+                DataValue::Float32(OrderedFloat(1.5)),
+            ),
+            (
+                TupleValueSerializableImpl::Float64,
+                DataValue::Float64(OrderedFloat(2.5)),
+            ),
+            (
+                TupleValueSerializableImpl::Char {
+                    len: 4,
+                    unit: CharLengthUnits::Characters,
+                },
+                DataValue::Utf8 {
+                    value: "ab".to_string(),
+                    ty: Utf8Type::Fixed(4),
+                    unit: CharLengthUnits::Characters,
+                },
+            ),
+            (
+                TupleValueSerializableImpl::Char {
+                    len: 70,
+                    unit: CharLengthUnits::Octets,
+                },
+                DataValue::Utf8 {
+                    value: "ab".to_string(),
+                    ty: Utf8Type::Fixed(70),
+                    unit: CharLengthUnits::Octets,
+                },
+            ),
+            (
+                TupleValueSerializableImpl::Varchar {
+                    len: Some(8),
+                    unit: CharLengthUnits::Characters,
+                },
+                DataValue::Utf8 {
+                    value: "kite".to_string(),
+                    ty: Utf8Type::Variable(Some(8)),
+                    unit: CharLengthUnits::Characters,
+                },
+            ),
+            (TupleValueSerializableImpl::Date, DataValue::Date32(123)),
+            (TupleValueSerializableImpl::DateTime, DataValue::Date64(456)),
+            (
+                TupleValueSerializableImpl::Time { precision: Some(3) },
+                DataValue::Time32(789, 3),
+            ),
+            (
+                TupleValueSerializableImpl::Timestamp {
+                    precision: Some(6),
+                    zone: true,
+                },
+                DataValue::Time64(101_112, 6, true),
+            ),
+            #[cfg(feature = "decimal")]
+            (
+                TupleValueSerializableImpl::Decimal,
+                DataValue::Decimal(Decimal::new(1234, 2)),
+            ),
+        ];
+
+        for (serializer, value) in cases {
+            assert_eq!(roundtrip(serializer, value.clone())?, value);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_tuple_value_serializable_impl_filling_and_skip() -> Result<(), DatabaseError> {
+        let serializer = TupleValueSerializableImpl::UInt64;
+        let value = DataValue::UInt64(42);
+        let mut bytes = Vec::new();
+        serializer.to_raw(&value, &mut bytes)?;
+
+        let mut values = Vec::new();
+        serializer.filling_value(&mut Cursor::new(bytes.as_slice()), &mut values)?;
+        assert_eq!(values, vec![value]);
+
+        let skip_fixed = TupleValueSerializableImpl::SkipFixed(2);
+        assert_eq!(
+            skip_fixed.from_raw(&mut Cursor::new([1_u8, 2, 3].as_slice()))?,
+            DataValue::Null
+        );
+        let mut values = vec![DataValue::Int32(1)];
+        skip_fixed.filling_value(&mut Cursor::new([1_u8, 2, 3].as_slice()), &mut values)?;
+        assert_eq!(values, vec![DataValue::Int32(1)]);
+
+        let skip_variable = TupleValueSerializableImpl::SkipVariable;
+        let mut bytes = Vec::new();
+        write_u32_le(&mut bytes, 3)?;
+        bytes.extend_from_slice(&[1, 2, 3, 4]);
+        assert_eq!(
+            skip_variable.from_raw(&mut Cursor::new(bytes.as_slice()))?,
+            DataValue::Null
+        );
+        let mut values = vec![DataValue::Int32(2)];
+        skip_variable.filling_value(&mut Cursor::new(bytes.as_slice()), &mut values)?;
+        assert_eq!(values, vec![DataValue::Int32(2)]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_logical_type_serializable_and_skip_serializable() {
+        assert_eq!(
+            LogicalType::UBigint.serializable(),
+            TupleValueSerializableImpl::UInt64
+        );
+        assert_eq!(
+            LogicalType::Char(8, CharLengthUnits::Octets).skip_serializable(),
+            TupleValueSerializableImpl::SkipFixed(8)
+        );
+        assert_eq!(
+            LogicalType::Varchar(None, CharLengthUnits::Characters).skip_serializable(),
+            TupleValueSerializableImpl::SkipVariable
+        );
+        assert_eq!(
+            LogicalType::SqlNull.skip_serializable(),
+            TupleValueSerializableImpl::SkipFixed(0)
+        );
+        assert_panics(|| {
+            let _ = LogicalType::SqlNull.serializable();
+        });
+        assert_panics(|| {
+            let _ = LogicalType::Tuple(vec![LogicalType::Integer]).serializable();
+        });
+    }
+}
+// GRCOV_EXCL_STOP

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -275,10 +275,14 @@ impl Tuple {
     }
 }
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
+    use super::TupleLike;
     use crate::catalog::{ColumnCatalog, ColumnDesc};
     use crate::iter_ext::Itertools;
+    use crate::planner::{PlanArena, TableArenaCell};
+    use crate::types::serialize::TupleValueSerializable;
     use crate::types::tuple::Tuple;
     use crate::types::value::{DataValue, Utf8Type};
     use crate::types::CharLengthUnits;
@@ -286,6 +290,15 @@ mod tests {
     use ordered_float::OrderedFloat;
     use rust_decimal::Decimal;
     use std::sync::Arc;
+
+    struct OneValueTupleLike(DataValue);
+
+    impl super::TupleLike for OneValueTupleLike {
+        fn value_at(&self, index: usize) -> &DataValue {
+            assert_eq!(index, 0);
+            &self.0
+        }
+    }
 
     #[test]
     fn test_tuple_serialize_to_and_deserialize_from() {
@@ -573,4 +586,118 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn test_schema_view_and_tuple_like_impls() {
+        let table_arena = TableArenaCell::default();
+        let mut arena = PlanArena::new(&table_arena);
+        let schema = vec![
+            arena.alloc_column(ColumnCatalog::new(
+                "id".to_string(),
+                false,
+                ColumnDesc::new(LogicalType::Integer, Some(0), false, None).unwrap(),
+            )),
+            arena.alloc_column(ColumnCatalog::new(
+                "name".to_string(),
+                true,
+                ColumnDesc::new(
+                    LogicalType::Varchar(None, CharLengthUnits::Characters),
+                    None,
+                    true,
+                    None,
+                )
+                .unwrap(),
+            )),
+        ];
+        let view = super::SchemaView::new(&schema, &arena);
+
+        assert_eq!(view.len(), 2);
+        assert!(!view.is_empty());
+        assert_eq!(view.get(0).unwrap().name(), "id");
+        assert_eq!(view.position("name"), Some(1));
+        assert_eq!(
+            view.iter()
+                .map(|column| column.name().to_string())
+                .collect_vec(),
+            vec!["id".to_string(), "name".to_string()]
+        );
+
+        let tuple = Tuple::new(None, vec![DataValue::Int32(1), DataValue::Int32(2)]);
+        assert_eq!(super::TupleLike::value_at(&tuple, 1), &DataValue::Int32(2));
+        assert_eq!(
+            super::TupleLike::as_slice(&tuple).unwrap(),
+            tuple.values.as_slice()
+        );
+        assert_eq!(
+            super::TupleLike::value_at(&tuple.values[..], 0),
+            &DataValue::Int32(1)
+        );
+        assert_eq!(super::TupleLike::value_at(&&tuple, 0), &DataValue::Int32(1));
+        assert_eq!(
+            super::TupleLike::as_slice(&&tuple).unwrap(),
+            tuple.values.as_slice()
+        );
+        assert_eq!(
+            super::TupleLike::value_at(&tuple.values.as_slice(), 1),
+            &DataValue::Int32(2)
+        );
+        let tuple_like: &dyn super::TupleLike = &tuple;
+        assert_eq!(
+            super::TupleLike::value_at(&tuple_like, 1),
+            &DataValue::Int32(2)
+        );
+        assert_eq!(
+            super::TupleLike::as_slice(&tuple_like).unwrap(),
+            tuple.values.as_slice()
+        );
+        let one = OneValueTupleLike(DataValue::Int32(9));
+        assert_eq!(super::TupleLike::as_slice(&one), None);
+        assert_eq!(super::TupleLike::value_at(&one, 0), &DataValue::Int32(9));
+
+        let left = Tuple::new(None, vec![DataValue::Int32(1)]);
+        let right = Tuple::new(None, vec![DataValue::Int32(2)]);
+        let split = super::SplitTupleRef::new(&left, &right);
+        assert_eq!(split.value_at(0), &DataValue::Int32(1));
+        assert_eq!(split.value_at(1), &DataValue::Int32(2));
+        let split = super::SplitTupleRef::from_slices(&left.values, &right.values);
+        assert_eq!(split.value_at(1), &DataValue::Int32(2));
+        let tuple_slice: &[DataValue] = (&tuple).into();
+        assert_eq!(tuple_slice, tuple.values.as_slice());
+        assert_eq!(
+            super::TupleLike::as_slice(&tuple.values[..]).unwrap(),
+            tuple.values.as_slice()
+        );
+        assert_eq!(
+            super::TupleLike::as_slice(&tuple.values.as_slice()).unwrap(),
+            tuple.values.as_slice()
+        );
+    }
+
+    #[test]
+    fn test_tuple_deserialize_null_bits_and_primary_projection() {
+        let serializers = [
+            LogicalType::Integer.serializable(),
+            LogicalType::Integer.serializable(),
+        ];
+        let mut bytes = vec![0b1000_0000];
+        serializers[1]
+            .to_raw(&DataValue::Int32(7), &mut bytes)
+            .unwrap();
+
+        let mut tuple = Tuple::default();
+        tuple
+            .deserialize_from_into(serializers.iter(), &bytes, 2)
+            .unwrap();
+        assert_eq!(tuple.values, vec![DataValue::Null, DataValue::Int32(7)]);
+
+        assert_eq!(
+            Tuple::primary_projection(&[1], &tuple.values),
+            DataValue::Int32(7)
+        );
+        assert_eq!(
+            Tuple::primary_projection(&[0, 1], &tuple.values),
+            DataValue::Tuple(vec![DataValue::Null, DataValue::Int32(7)], false)
+        );
+    }
 }
+// GRCOV_EXCL_STOP

--- a/src/types/tuple_builder.rs
+++ b/src/types/tuple_builder.rs
@@ -78,3 +78,48 @@ impl<'a> TupleBuilder<'a> {
         Ok(Tuple::new(pk, values))
     }
 }
+
+// GRCOV_EXCL_START
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tuple_builder_result_helpers_and_build_with_row() {
+        let tuple = TupleBuilder::build_result("ok".to_string());
+        assert_eq!(tuple.pk, None);
+        assert_eq!(tuple.values, vec![DataValue::from("ok".to_string())]);
+
+        let mut tuple = Tuple::new(Some(DataValue::Int32(1)), vec![DataValue::Int32(1)]);
+        TupleBuilder::build_result_into(&mut tuple, "done".to_string());
+        assert_eq!(tuple.pk, None);
+        assert_eq!(tuple.values, vec![DataValue::from("done".to_string())]);
+
+        let pk_indices = [0, 1];
+        let builder = TupleBuilder::new(
+            vec![
+                LogicalType::Integer,
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+            ],
+            Some(&pk_indices),
+        );
+        let tuple = builder.build_with_row(["7", "kite"]).unwrap();
+        assert_eq!(
+            tuple.pk,
+            Some(DataValue::Tuple(
+                vec![DataValue::Int32(7), DataValue::from("kite".to_string())],
+                false,
+            ))
+        );
+        assert_eq!(
+            tuple.values,
+            vec![DataValue::Int32(7), DataValue::from("kite".to_string())]
+        );
+
+        assert!(matches!(
+            builder.build_with_row(["7"]),
+            Err(DatabaseError::MisMatch("types", "values"))
+        ));
+    }
+}
+// GRCOV_EXCL_STOP

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -1732,6 +1732,14 @@ mod test {
     use std::cmp::Ordering;
     use std::io::Cursor;
 
+    fn utf8(value: &str) -> DataValue {
+        DataValue::Utf8 {
+            value: value.to_string(),
+            ty: Utf8Type::Variable(None),
+            unit: CharLengthUnits::Characters,
+        }
+    }
+
     #[test]
     fn test_tuple_partial_cmp() {
         let tuple_1 = DataValue::Tuple(vec![DataValue::Int32(1), DataValue::Int32(2)], false);
@@ -1744,7 +1752,107 @@ mod test {
         assert_eq!(tuple_2.partial_cmp(&tuple_with_null), Some(Ordering::Less));
         assert_eq!(lower_prefix.partial_cmp(&tuple_1), Some(Ordering::Less));
         assert_eq!(upper_prefix.partial_cmp(&tuple_1), Some(Ordering::Greater));
+        assert_eq!(tuple_1.partial_cmp(&lower_prefix), Some(Ordering::Greater));
+        assert_eq!(tuple_1.partial_cmp(&upper_prefix), Some(Ordering::Less));
         assert_eq!(DataValue::Null.partial_cmp(&DataValue::Int32(1)), None);
+    }
+
+    #[test]
+    fn test_data_value_eq_and_partial_cmp_scalar_variants() {
+        let same_type_ordered = vec![
+            (DataValue::Boolean(false), DataValue::Boolean(true)),
+            (
+                DataValue::Float32(OrderedFloat(1.0)),
+                DataValue::Float32(OrderedFloat(2.0)),
+            ),
+            (
+                DataValue::Float64(OrderedFloat(1.0)),
+                DataValue::Float64(OrderedFloat(2.0)),
+            ),
+            (DataValue::Int8(1), DataValue::Int8(2)),
+            (DataValue::Int16(1), DataValue::Int16(2)),
+            (DataValue::Int32(1), DataValue::Int32(2)),
+            (DataValue::Int64(1), DataValue::Int64(2)),
+            (DataValue::UInt8(1), DataValue::UInt8(2)),
+            (DataValue::UInt16(1), DataValue::UInt16(2)),
+            (DataValue::UInt32(1), DataValue::UInt32(2)),
+            (DataValue::UInt64(1), DataValue::UInt64(2)),
+            (utf8("a"), utf8("b")),
+            (DataValue::Date32(1), DataValue::Date32(2)),
+            (DataValue::Date64(1), DataValue::Date64(2)),
+            (DataValue::Time32(1, 0), DataValue::Time32(2, 0)),
+            (
+                DataValue::Time64(1, 0, false),
+                DataValue::Time64(2, 0, false),
+            ),
+            #[cfg(feature = "decimal")]
+            (
+                DataValue::Decimal(Decimal::new(1, 0)),
+                DataValue::Decimal(Decimal::new(2, 0)),
+            ),
+            (
+                DataValue::Tuple(vec![DataValue::Int32(1)], false),
+                DataValue::Tuple(vec![DataValue::Int32(2)], false),
+            ),
+        ];
+
+        for (lower, upper) in same_type_ordered {
+            assert_eq!(lower, lower.clone());
+            assert_eq!(upper, upper.clone());
+            assert_ne!(lower, upper);
+            assert_eq!(lower.partial_cmp(&upper), Some(Ordering::Less));
+            assert_eq!(upper.partial_cmp(&lower), Some(Ordering::Greater));
+        }
+
+        assert_eq!(DataValue::Null, DataValue::Null);
+        assert_eq!(
+            DataValue::Null.partial_cmp(&DataValue::Null),
+            Some(Ordering::Equal)
+        );
+    }
+
+    #[test]
+    fn test_data_value_mismatched_variants_are_not_comparable() {
+        let mismatch_cases = vec![
+            (DataValue::Boolean(true), DataValue::Null),
+            (DataValue::Float32(OrderedFloat(1.0)), DataValue::Null),
+            (DataValue::Float64(OrderedFloat(1.0)), DataValue::Null),
+            (DataValue::Int8(1), DataValue::Null),
+            (DataValue::Int16(1), DataValue::Null),
+            (DataValue::Int32(1), DataValue::Null),
+            (DataValue::Int64(1), DataValue::Null),
+            (DataValue::UInt8(1), DataValue::Null),
+            (DataValue::UInt16(1), DataValue::Null),
+            (DataValue::UInt32(1), DataValue::Null),
+            (DataValue::UInt64(1), DataValue::Null),
+            (utf8("kite"), DataValue::Null),
+            (DataValue::Null, DataValue::Int32(1)),
+            (DataValue::Date32(1), DataValue::Null),
+            (DataValue::Date64(1), DataValue::Null),
+            (DataValue::Time32(1, 0), DataValue::Null),
+            (DataValue::Time64(1, 0, false), DataValue::Null),
+            #[cfg(feature = "decimal")]
+            (DataValue::Decimal(Decimal::new(1, 0)), DataValue::Null),
+            (
+                DataValue::Tuple(vec![DataValue::Int32(1)], false),
+                DataValue::Null,
+            ),
+        ];
+
+        for (left, right) in mismatch_cases {
+            assert_ne!(left, right);
+            assert_eq!(left.partial_cmp(&right), None);
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_decimal_accessor_rejects_non_decimal_values() {
+        assert_eq!(
+            DataValue::Decimal(Decimal::new(123, 2)).decimal(),
+            Some(Decimal::new(123, 2))
+        );
+        assert_eq!(DataValue::Int32(123).decimal(), None);
     }
 
     #[test]

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -651,11 +651,11 @@ impl DataValue {
         Ok(())
     }
 
-    pub fn pack(a: u32, b: u32, precision: u64) -> u32 {
-        assert!(b <= ONE_SEC_TO_NANO);
-        assert!(a <= ONE_DAY_TO_SEC);
-        // Scale down `a` to fit
-        let scaled_b = b / (1000000000 / 10_u32.pow(precision as u32)); // Now 0-1_000_000
+    pub fn pack_time(secs: u32, nanos: u32, precision: u64) -> u32 {
+        assert!(nanos <= ONE_SEC_TO_NANO);
+        assert!(secs <= ONE_DAY_TO_SEC);
+        // Scale down `nanos` to fit
+        let scaled_nanos = nanos / (1000000000 / 10_u32.pow(precision as u32)); // Now 0-1_000_000
         let p = match precision {
             1 => 28,
             2 => 25,
@@ -663,10 +663,10 @@ impl DataValue {
             4 => 18,
             _ => 31,
         };
-        (scaled_b << p) | a
+        (scaled_nanos << p) | secs
     }
 
-    pub fn unpack(combined: u32, precision: u64) -> (u32, u32) {
+    pub fn unpack_time(combined: u32, precision: u64) -> (u32, u32) {
         let p = match precision {
             1 => 28,
             2 => 25,
@@ -674,9 +674,12 @@ impl DataValue {
             4 => 18,
             _ => 31,
         };
-        let scaled_a = combined >> p;
-        let b = combined & (2_u32.pow(p) - 1);
-        (b, scaled_a * (1000000000 / 10_u32.pow(precision as u32)))
+        let scaled_nanos = combined >> p;
+        let secs = combined & (2_u32.pow(p) - 1);
+        (
+            secs,
+            scaled_nanos * (1000000000 / 10_u32.pow(precision as u32)),
+        )
     }
 
     #[inline]
@@ -1417,7 +1420,7 @@ impl DataValue {
     }
 
     fn time_format<'a>(v: u32, precision: u64) -> Option<DelayedFormat<StrftimeItems<'a>>> {
-        let (v, n) = Self::unpack(v, precision);
+        let (v, n) = Self::unpack_time(v, precision);
         NaiveTime::from_num_seconds_from_midnight_opt(v, n)
             .map(|time| time.format(TIME_FMT_WITHOUT_ZONE))
     }
@@ -1584,7 +1587,7 @@ impl From<Option<&NaiveDateTime>> for DataValue {
 impl From<&NaiveTime> for DataValue {
     fn from(value: &NaiveTime) -> Self {
         DataValue::Time32(
-            Self::pack(value.num_seconds_from_midnight(), value.nanosecond(), 4),
+            Self::pack_time(value.num_seconds_from_midnight(), value.nanosecond(), 4),
             6,
         )
     }
@@ -1595,7 +1598,7 @@ impl From<Option<&NaiveTime>> for DataValue {
     fn from(value: Option<&NaiveTime>) -> Self {
         if let Some(value) = value {
             DataValue::Time32(
-                Self::pack(value.num_seconds_from_midnight(), value.nanosecond(), 4),
+                Self::pack_time(value.num_seconds_from_midnight(), value.nanosecond(), 4),
                 0,
             )
         } else {
@@ -1719,14 +1722,17 @@ impl fmt::Debug for DataValue {
     }
 }
 
+// GRCOV_EXCL_START
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod test {
     use crate::errors::DatabaseError;
-    use crate::storage::table_codec::BumpBytes;
+    use crate::storage::table_codec::{BumpBytes, NOTNULL_TAG, NULL_TAG};
     use crate::types::value::{DataValue, TupleMappingRef, Utf8Type};
     use crate::types::CharLengthUnits;
     use crate::types::LogicalType;
     use bumpalo::Bump;
+    #[cfg(feature = "time")]
+    use chrono::{Datelike, Timelike};
     use ordered_float::OrderedFloat;
     use rust_decimal::Decimal;
     use std::cmp::Ordering;
@@ -1738,6 +1744,659 @@ mod test {
             ty: Utf8Type::Variable(None),
             unit: CharLengthUnits::Characters,
         }
+    }
+
+    fn fixed_utf8(value: &str, len: u32, unit: CharLengthUnits) -> DataValue {
+        DataValue::Utf8 {
+            value: value.to_string(),
+            ty: Utf8Type::Fixed(len),
+            unit,
+        }
+    }
+
+    fn roundtrip_memcomparable(value: &DataValue, ty: &LogicalType) -> DataValue {
+        let mut bytes = Vec::new();
+        value.memcomparable_encode(&mut bytes).unwrap();
+        DataValue::memcomparable_decode(&mut Cursor::new(bytes), ty).unwrap()
+    }
+
+    fn assert_panics(f: impl FnOnce() + std::panic::UnwindSafe) {
+        assert!(std::panic::catch_unwind(f).is_err());
+    }
+
+    #[test]
+    fn test_data_value_accessors_and_constructors() {
+        assert_eq!(DataValue::Boolean(true).bool(), Some(true));
+        assert_eq!(DataValue::Int8(-1).i8(), Some(-1));
+        assert_eq!(DataValue::Int16(-2).i16(), Some(-2));
+        assert_eq!(DataValue::Int32(-3).i32(), Some(-3));
+        assert_eq!(DataValue::Int64(-4).i64(), Some(-4));
+        assert_eq!(DataValue::UInt8(1).u8(), Some(1));
+        assert_eq!(DataValue::UInt16(2).u16(), Some(2));
+        assert_eq!(DataValue::UInt32(3).u32(), Some(3));
+        assert_eq!(DataValue::UInt64(4).u64(), Some(4));
+        assert_eq!(DataValue::Float32(OrderedFloat(1.25)).float(), Some(1.25));
+        assert_eq!(DataValue::Float64(OrderedFloat(2.5)).double(), Some(2.5));
+        assert_eq!(utf8("kite").utf8(), Some("kite"));
+        assert_eq!(DataValue::Int32(1).utf8(), None);
+
+        assert_eq!(
+            DataValue::new_utf8("kite".to_string()),
+            DataValue::Utf8 {
+                value: "kite".to_string(),
+                ty: Utf8Type::Fixed(4),
+                unit: CharLengthUnits::Characters,
+            }
+        );
+        assert_eq!(DataValue::Null.bool(), None);
+        assert_eq!(DataValue::Null.float(), None);
+        assert_eq!(DataValue::Null.double(), None);
+    }
+
+    #[test]
+    fn test_data_value_len_helpers() {
+        assert!(!DataValue::check_string_len(
+            "中",
+            1,
+            CharLengthUnits::Characters
+        ));
+        assert!(DataValue::check_string_len(
+            "中",
+            2,
+            CharLengthUnits::Octets
+        ));
+
+        assert_eq!(utf8("ab").serialized_len_hint(), 6);
+        assert_eq!(
+            fixed_utf8("ab", 4, CharLengthUnits::Characters).serialized_len_hint(),
+            8
+        );
+        assert_eq!(
+            fixed_utf8("ab", 4, CharLengthUnits::Octets).serialized_len_hint(),
+            4
+        );
+        assert_eq!(DataValue::Null.serialized_len_hint(), 0);
+        assert_eq!(DataValue::Boolean(true).serialized_len_hint(), 1);
+        assert_eq!(DataValue::Int16(1).serialized_len_hint(), 2);
+        assert_eq!(DataValue::Int32(1).serialized_len_hint(), 4);
+        assert_eq!(DataValue::Int64(1).serialized_len_hint(), 8);
+        assert_eq!(
+            DataValue::Tuple(vec![DataValue::Int8(1), DataValue::Int32(2)], false)
+                .serialized_len_hint(),
+            5
+        );
+        #[cfg(feature = "decimal")]
+        assert_eq!(
+            DataValue::Decimal(Decimal::new(1, 0)).serialized_len_hint(),
+            16
+        );
+
+        assert!(utf8("ab")
+            .check_len(&LogicalType::Varchar(Some(2), CharLengthUnits::Characters))
+            .is_ok());
+        assert!(matches!(
+            utf8("abc").check_len(&LogicalType::Varchar(Some(2), CharLengthUnits::Characters)),
+            Err(DatabaseError::TooLong)
+        ));
+        assert!(matches!(
+            fixed_utf8("中", 2, CharLengthUnits::Octets)
+                .check_len(&LogicalType::Char(2, CharLengthUnits::Octets)),
+            Err(DatabaseError::TooLong)
+        ));
+
+        #[cfg(feature = "decimal")]
+        {
+            assert!(DataValue::Decimal(Decimal::new(123, 2))
+                .check_len(&LogicalType::Decimal(Some(3), Some(2)))
+                .is_ok());
+            assert!(matches!(
+                DataValue::Decimal(Decimal::new(1234, 2))
+                    .check_len(&LogicalType::Decimal(Some(3), Some(2))),
+                Err(DatabaseError::TooLong)
+            ));
+            assert!(matches!(
+                DataValue::Decimal(Decimal::new(123, 3))
+                    .check_len(&LogicalType::Decimal(Some(3), Some(2))),
+                Err(DatabaseError::TooLong)
+            ));
+        }
+    }
+
+    #[test]
+    fn test_data_value_pack_unpack_init_and_logical_type() {
+        for precision in [0, 1, 2, 3, 4] {
+            let packed = DataValue::pack_time(3, 400_000_000, precision);
+            let (seconds, nanos) = DataValue::unpack_time(packed, precision);
+            assert_eq!(seconds, 3);
+            assert_eq!(
+                nanos,
+                400_000_000 / (1_000_000_000 / 10_u32.pow(precision as u32))
+                    * (1_000_000_000 / 10_u32.pow(precision as u32))
+            );
+        }
+
+        let init_cases = vec![
+            (LogicalType::SqlNull, DataValue::Null),
+            (LogicalType::Boolean, DataValue::Boolean(false)),
+            (LogicalType::Tinyint, DataValue::Int8(0)),
+            (LogicalType::UTinyint, DataValue::UInt8(0)),
+            (LogicalType::Smallint, DataValue::Int16(0)),
+            (LogicalType::USmallint, DataValue::UInt16(0)),
+            (LogicalType::Integer, DataValue::Int32(0)),
+            (LogicalType::UInteger, DataValue::UInt32(0)),
+            (LogicalType::Bigint, DataValue::Int64(0)),
+            (LogicalType::UBigint, DataValue::UInt64(0)),
+            (LogicalType::Float, DataValue::Float32(OrderedFloat(0.0))),
+            (LogicalType::Double, DataValue::Float64(OrderedFloat(0.0))),
+            (
+                LogicalType::Char(3, CharLengthUnits::Characters),
+                fixed_utf8("", 3, CharLengthUnits::Characters),
+            ),
+            (
+                LogicalType::Varchar(Some(3), CharLengthUnits::Octets),
+                DataValue::Utf8 {
+                    value: String::new(),
+                    ty: Utf8Type::Variable(Some(3)),
+                    unit: CharLengthUnits::Octets,
+                },
+            ),
+            #[cfg(feature = "decimal")]
+            (
+                LogicalType::Decimal(None, None),
+                DataValue::Decimal(Decimal::new(0, 0)),
+            ),
+        ];
+        for (ty, expected) in init_cases {
+            assert_eq!(DataValue::init(&ty), expected);
+        }
+
+        assert_eq!(
+            DataValue::init(&LogicalType::Tuple(vec![LogicalType::Integer])),
+            DataValue::Tuple(vec![DataValue::Int32(0)], false)
+        );
+        assert_eq!(
+            DataValue::init(&LogicalType::Date).logical_type(),
+            LogicalType::Date
+        );
+        assert_eq!(
+            DataValue::init(&LogicalType::DateTime).logical_type(),
+            LogicalType::DateTime
+        );
+        assert_eq!(
+            DataValue::init(&LogicalType::Time(Some(3))),
+            DataValue::Time32(0, 3)
+        );
+        assert_eq!(
+            DataValue::init(&LogicalType::Time(None)),
+            DataValue::Time32(0, 0)
+        );
+        assert_eq!(
+            DataValue::init(&LogicalType::TimeStamp(None, true)).logical_type(),
+            LogicalType::TimeStamp(None, false)
+        );
+        assert_eq!(
+            DataValue::init(&LogicalType::TimeStamp(Some(3), false)).logical_type(),
+            LogicalType::TimeStamp(None, false)
+        );
+        assert_eq!(
+            DataValue::init(&LogicalType::TimeStamp(Some(6), false)).logical_type(),
+            LogicalType::TimeStamp(None, false)
+        );
+        assert_eq!(
+            DataValue::init(&LogicalType::TimeStamp(Some(9), false)).logical_type(),
+            LogicalType::TimeStamp(None, false)
+        );
+        assert_panics(|| {
+            let _ = DataValue::init(&LogicalType::TimeStamp(Some(5), false));
+        });
+
+        let logical_type_cases = vec![
+            (DataValue::Null, LogicalType::SqlNull),
+            (DataValue::Boolean(true), LogicalType::Boolean),
+            (DataValue::Float32(OrderedFloat(1.0)), LogicalType::Float),
+            (DataValue::Float64(OrderedFloat(1.0)), LogicalType::Double),
+            (DataValue::Int8(1), LogicalType::Tinyint),
+            (DataValue::Int16(1), LogicalType::Smallint),
+            (DataValue::Int32(1), LogicalType::Integer),
+            (DataValue::Int64(1), LogicalType::Bigint),
+            (DataValue::UInt8(1), LogicalType::UTinyint),
+            (DataValue::UInt16(1), LogicalType::USmallint),
+            (DataValue::UInt32(1), LogicalType::UInteger),
+            (DataValue::UInt64(1), LogicalType::UBigint),
+            (
+                utf8("a"),
+                LogicalType::Varchar(None, CharLengthUnits::Characters),
+            ),
+            (
+                fixed_utf8("a", 1, CharLengthUnits::Characters),
+                LogicalType::Char(1, CharLengthUnits::Characters),
+            ),
+            (DataValue::Date32(1), LogicalType::Date),
+            (DataValue::Date64(1), LogicalType::DateTime),
+            (DataValue::Time32(1, 2), LogicalType::Time(None)),
+            (
+                DataValue::Time64(1, 2, true),
+                LogicalType::TimeStamp(None, false),
+            ),
+            #[cfg(feature = "decimal")]
+            (
+                DataValue::Decimal(Decimal::new(1, 0)),
+                LogicalType::Decimal(None, None),
+            ),
+            (
+                DataValue::Tuple(vec![DataValue::Int32(1)], false),
+                LogicalType::Tuple(vec![LogicalType::Integer]),
+            ),
+        ];
+        for (value, expected) in logical_type_cases {
+            assert_eq!(value.logical_type(), expected);
+        }
+    }
+
+    #[test]
+    fn test_memcomparable_roundtrips_scalar_variants() {
+        let cases = vec![
+            (DataValue::Boolean(true), LogicalType::Boolean),
+            (DataValue::Boolean(false), LogicalType::Boolean),
+            (DataValue::UInt8(1), LogicalType::UTinyint),
+            (DataValue::UInt16(2), LogicalType::USmallint),
+            (DataValue::UInt32(3), LogicalType::UInteger),
+            (DataValue::UInt64(4), LogicalType::UBigint),
+            (DataValue::Date32(10), LogicalType::Date),
+            (DataValue::Date64(20), LogicalType::DateTime),
+            (DataValue::Time32(30, 3), LogicalType::Time(Some(3))),
+            (
+                DataValue::Time64(40, 6, true),
+                LogicalType::TimeStamp(Some(6), true),
+            ),
+            (
+                fixed_utf8("ab", 2, CharLengthUnits::Characters),
+                LogicalType::Char(2, CharLengthUnits::Characters),
+            ),
+            #[cfg(feature = "decimal")]
+            (
+                DataValue::Decimal(Decimal::new(123, 2)),
+                LogicalType::Decimal(None, None),
+            ),
+        ];
+        for (value, ty) in cases {
+            assert_eq!(roundtrip_memcomparable(&value, &ty), value);
+        }
+
+        let mut nulls_first = Vec::new();
+        DataValue::Null
+            .memcomparable_encode_with_null_order(&mut nulls_first, true)
+            .unwrap();
+        let mut not_null = Vec::new();
+        DataValue::Int32(1)
+            .memcomparable_encode_with_null_order(&mut not_null, true)
+            .unwrap();
+        assert!(nulls_first < not_null);
+        assert_eq!(nulls_first[0], NOTNULL_TAG);
+        assert_eq!(not_null[0], NULL_TAG);
+
+        let mut bytes = Vec::new();
+        DataValue::encode_string(&mut bytes, b"12345678");
+        DataValue::encode_string(&mut bytes, b"9");
+        assert_eq!(
+            DataValue::decode_string(&mut Cursor::new(bytes)).unwrap(),
+            b"12345678".to_vec()
+        );
+
+        assert_eq!(
+            DataValue::memcomparable_decode(
+                &mut Cursor::new(vec![NULL_TAG]),
+                &LogicalType::Integer
+            )
+            .unwrap(),
+            DataValue::Null
+        );
+        assert_eq!(
+            DataValue::memcomparable_decode(
+                &mut Cursor::new(vec![NOTNULL_TAG]),
+                &LogicalType::SqlNull
+            )
+            .unwrap(),
+            DataValue::Null
+        );
+    }
+
+    #[test]
+    fn test_memcomparable_decode_rejects_invalid_strings() {
+        let mut invalid_marker = vec![NOTNULL_TAG];
+        invalid_marker.extend_from_slice(&[0; 8]);
+        invalid_marker.push(0);
+        assert!(DataValue::memcomparable_decode(
+            &mut Cursor::new(invalid_marker),
+            &LogicalType::Varchar(None, CharLengthUnits::Characters)
+        )
+        .is_err());
+
+        let invalid_utf8 = vec![NOTNULL_TAG, 0xff, 0, 0, 0, 0, 0, 0, 0, 248];
+        assert!(DataValue::memcomparable_decode(
+            &mut Cursor::new(invalid_utf8),
+            &LogicalType::Varchar(None, CharLengthUnits::Characters)
+        )
+        .is_err());
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_decimal_memcomparable_roundtrip_and_errors() {
+        let decimals = vec![
+            Decimal::ZERO,
+            Decimal::new(125, 1),
+            Decimal::new(123, 5),
+            Decimal::new(-125, 1),
+            Decimal::new(-123, 5),
+            Decimal::from_i128_with_scale(10_i128.pow(24), 0),
+            Decimal::from_i128_with_scale(-10_i128.pow(24), 0),
+        ];
+        for decimal in decimals {
+            let mut bytes = Vec::new();
+            DataValue::serialize_decimal(decimal, &mut bytes).unwrap();
+            assert_eq!(
+                DataValue::deserialize_decimal(Cursor::new(bytes)).unwrap(),
+                decimal
+            );
+        }
+
+        assert!(matches!(
+            DataValue::deserialize_decimal(Cursor::new(vec![0xff])),
+            Err(DatabaseError::InvalidValue(_))
+        ));
+
+        let mut integer_decimal = Decimal::new(12345, 2);
+        DataValue::decimal_round_i(&Some(1), &mut integer_decimal);
+        assert_eq!(integer_decimal, Decimal::new(1234, 1));
+
+        let mut float_decimal = Decimal::new(126, 2);
+        DataValue::decimal_round_f(&Some(1), &mut float_decimal);
+        assert_eq!(float_decimal, Decimal::new(13, 1));
+
+        // `None` scale is a no-op: the decimal is left unchanged.
+        DataValue::decimal_round_i(&None, &mut integer_decimal);
+        assert_eq!(integer_decimal, Decimal::new(1234, 1));
+        DataValue::decimal_round_f(&None, &mut float_decimal);
+        assert_eq!(float_decimal, Decimal::new(13, 1));
+    }
+
+    #[test]
+    fn test_data_value_truth_cast_prefix_and_formatting() {
+        assert!(!DataValue::Null.is_true().unwrap());
+        assert!(DataValue::Boolean(true).is_true().unwrap());
+        assert!(!DataValue::Boolean(false).is_true().unwrap());
+        assert!(matches!(
+            DataValue::Int32(1).is_true(),
+            Err(DatabaseError::InvalidType)
+        ));
+
+        assert_eq!(
+            DataValue::Int32(1).cast(&LogicalType::Bigint).unwrap(),
+            DataValue::Int64(1)
+        );
+        assert_eq!(
+            utf8("ab")
+                .cast(&LogicalType::Char(2, CharLengthUnits::Characters))
+                .unwrap(),
+            fixed_utf8("ab", 2, CharLengthUnits::Characters)
+        );
+        assert_eq!(
+            DataValue::Null.cast(&LogicalType::Integer).unwrap(),
+            DataValue::Null
+        );
+
+        assert_eq!(
+            DataValue::Null.common_prefix_length(&DataValue::Null),
+            Some(0)
+        );
+        assert_eq!(
+            DataValue::Null.common_prefix_length(&DataValue::Int32(1)),
+            None
+        );
+        assert_eq!(utf8("abc").common_prefix_length(&utf8("abd")), Some(2));
+        assert_eq!(utf8("abc").common_prefix_length(&utf8("abcdef")), Some(3));
+        assert_eq!(
+            DataValue::Int32(1).common_prefix_length(&DataValue::Int64(1)),
+            Some(0)
+        );
+
+        let display_cases = vec![
+            (DataValue::Boolean(true), "true", "Boolean(true)"),
+            (DataValue::Float32(OrderedFloat(1.5)), "1.5", "Float32(1.5)"),
+            (DataValue::Float64(OrderedFloat(2.0)), "2.0", "Float64(2.0)"),
+            (DataValue::Int8(-1), "-1", "Int8(-1)"),
+            (DataValue::Int16(-2), "-2", "Int16(-2)"),
+            (DataValue::Int32(-3), "-3", "Int32(-3)"),
+            (DataValue::Int64(-4), "-4", "Int64(-4)"),
+            (DataValue::UInt8(1), "1", "UInt8(1)"),
+            (DataValue::UInt16(2), "2", "UInt16(2)"),
+            (DataValue::UInt32(3), "3", "UInt32(3)"),
+            (DataValue::UInt64(4), "4", "UInt64(4)"),
+            (utf8("kite"), "kite", "Utf8(\"kite\")"),
+            (DataValue::Null, "null", "null"),
+            #[cfg(feature = "decimal")]
+            (
+                DataValue::Decimal(Decimal::new(123, 2)),
+                "1.23",
+                "Decimal(1.23)",
+            ),
+            (
+                DataValue::Tuple(vec![DataValue::Int32(1), utf8("a")], true),
+                "(1, a)",
+                "Tuple((1, a) [is upper])",
+            ),
+            (
+                DataValue::Time64(0, 0, false),
+                "1970-01-01 00:00:00",
+                "Time64(1970-01-01 00:00:00)",
+            ),
+        ];
+        for (value, display, debug) in display_cases {
+            assert_eq!(value.to_string(), display);
+            assert_eq!(format!("{value:?}"), debug);
+        }
+    }
+
+    #[test]
+    fn test_data_value_hash_distinguishes_variants() {
+        fn hash(value: &DataValue) -> u64 {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            std::hash::Hash::hash(value, &mut hasher);
+            std::hash::Hasher::finish(&hasher)
+        }
+
+        // The whole point of the hand-written `Hash` impl is the per-variant
+        // discriminant byte: values sharing the same inner bits but differing
+        // in type must not collide.
+        let same_bits = [
+            DataValue::Int8(1),
+            DataValue::Int16(1),
+            DataValue::Int32(1),
+            DataValue::Int64(1),
+            DataValue::UInt8(1),
+            DataValue::UInt16(1),
+            DataValue::UInt32(1),
+            DataValue::UInt64(1),
+            DataValue::Date32(1),
+            DataValue::Time32(1, 0),
+        ];
+        for (i, a) in same_bits.iter().enumerate() {
+            assert_eq!(hash(a), hash(&a.clone()), "{a:?} hashed unstably");
+            for b in &same_bits[i + 1..] {
+                assert_ne!(hash(a), hash(b), "{a:?} and {b:?} collided");
+            }
+        }
+    }
+
+    #[test]
+    fn test_data_value_nested_tuple_ordering() {
+        assert_eq!(
+            DataValue::Tuple(
+                vec![DataValue::Tuple(vec![DataValue::Int32(1)], false)],
+                false
+            )
+            .partial_cmp(&DataValue::Tuple(
+                vec![DataValue::Tuple(vec![DataValue::Int32(2)], false)],
+                false,
+            )),
+            Some(Ordering::Less)
+        );
+    }
+
+    #[test]
+    fn test_data_value_from_impls() {
+        assert_eq!(DataValue::from(Some(1_i8)), DataValue::Int8(1));
+        assert_eq!(DataValue::from(None::<i8>), DataValue::Null);
+        assert_eq!(DataValue::from(Some(2_i16)), DataValue::Int16(2));
+        assert_eq!(DataValue::from(None::<i16>), DataValue::Null);
+        assert_eq!(DataValue::from(Some(3_i32)), DataValue::Int32(3));
+        assert_eq!(DataValue::from(None::<i32>), DataValue::Null);
+        assert_eq!(DataValue::from(Some(4_i64)), DataValue::Int64(4));
+        assert_eq!(DataValue::from(None::<i64>), DataValue::Null);
+        assert_eq!(DataValue::from(Some(true)), DataValue::Boolean(true));
+        assert_eq!(DataValue::from(None::<bool>), DataValue::Null);
+        assert_eq!(DataValue::from(Some(5_u8)), DataValue::UInt8(5));
+        assert_eq!(DataValue::from(None::<u8>), DataValue::Null);
+        assert_eq!(DataValue::from(Some(6_u16)), DataValue::UInt16(6));
+        assert_eq!(DataValue::from(None::<u16>), DataValue::Null);
+        assert_eq!(DataValue::from(Some(7_u32)), DataValue::UInt32(7));
+        assert_eq!(DataValue::from(None::<u32>), DataValue::Null);
+        assert_eq!(DataValue::from(Some(8_u64)), DataValue::UInt64(8));
+        assert_eq!(DataValue::from(None::<u64>), DataValue::Null);
+        #[cfg(feature = "decimal")]
+        {
+            assert_eq!(
+                DataValue::from(Some(Decimal::new(9, 0))),
+                DataValue::Decimal(Decimal::new(9, 0))
+            );
+            assert_eq!(DataValue::from(None::<Decimal>), DataValue::Null);
+        }
+        assert_eq!(
+            DataValue::from(1.5_f32),
+            DataValue::Float32(OrderedFloat(1.5))
+        );
+        assert_eq!(
+            DataValue::from(Some(2.5_f32)),
+            DataValue::Float32(OrderedFloat(2.5))
+        );
+        assert_eq!(DataValue::from(None::<f32>), DataValue::Null);
+        assert_eq!(
+            DataValue::from(Some(3.5_f64)),
+            DataValue::Float64(OrderedFloat(3.5))
+        );
+        assert_eq!(DataValue::from(None::<f64>), DataValue::Null);
+        assert_eq!(
+            DataValue::from(Some("abc".to_string())),
+            DataValue::Utf8 {
+                value: "abc".to_string(),
+                ty: Utf8Type::Variable(None),
+                unit: CharLengthUnits::Characters,
+            }
+        );
+        assert_eq!(DataValue::from(None::<String>), DataValue::Null);
+    }
+
+    #[cfg(feature = "time")]
+    #[test]
+    fn test_time_accessors_conversions_and_formatting() {
+        let date = chrono::NaiveDate::from_ymd_opt(2024, 1, 2).unwrap();
+        let datetime = date.and_hms_opt(3, 4, 5).unwrap();
+        let time = chrono::NaiveTime::from_hms_milli_opt(3, 4, 5, 123).unwrap();
+
+        assert_eq!(DataValue::from(&date).date(), Some(date));
+        assert_eq!(DataValue::from(&datetime).datetime(), Some(datetime));
+        assert!(matches!(DataValue::from(&time), DataValue::Time32(_, 6)));
+        assert_eq!(
+            DataValue::from(Some(&date)),
+            DataValue::Date32(date.num_days_from_ce())
+        );
+        assert_eq!(
+            DataValue::from(Some(&datetime)),
+            DataValue::Date64(datetime.and_utc().timestamp())
+        );
+        assert!(matches!(
+            DataValue::from(Some(&time)),
+            DataValue::Time32(_, 0)
+        ));
+        assert_eq!(
+            DataValue::Time32(3 * 3600 + 4 * 60 + 5, 0).time(),
+            Some(chrono::NaiveTime::from_hms_opt(3, 4, 5).unwrap())
+        );
+        assert_eq!(
+            DataValue::from(Option::<&chrono::NaiveDate>::None),
+            DataValue::Null
+        );
+        assert_eq!(
+            DataValue::from(Option::<&chrono::NaiveDateTime>::None),
+            DataValue::Null
+        );
+        assert_eq!(
+            DataValue::from(Option::<&chrono::NaiveTime>::None),
+            DataValue::Null
+        );
+        assert_eq!(DataValue::Int32(1).date(), None);
+        assert_eq!(DataValue::Int32(1).datetime(), None);
+        assert_eq!(DataValue::Int32(1).time(), None);
+
+        let date_value = DataValue::Date32(date.num_days_from_ce());
+        let datetime_value = DataValue::Date64(datetime.and_utc().timestamp());
+        let time_value = DataValue::Time32(
+            DataValue::pack_time(3 * 3600 + 4 * 60 + 5, 123_000_000, 3),
+            3,
+        );
+        let timestamp_value = DataValue::Time64(datetime.and_utc().timestamp(), 0, false);
+        assert_eq!(date_value.to_string(), "2024-01-02");
+        assert_eq!(format!("{date_value:?}"), "Date32(2024-01-02)");
+        assert_eq!(datetime_value.to_string(), "2024-01-02 03:04:05");
+        assert_eq!(format!("{datetime_value:?}"), "Date64(2024-01-02 03:04:05)");
+        assert_eq!(time_value.to_string(), "03:04:05.123");
+        assert_eq!(format!("{time_value:?}"), "Time32(03:04:05.123)");
+        assert_eq!(timestamp_value.to_string(), "2024-01-02 03:04:05");
+        assert_eq!(
+            format!("{timestamp_value:?}"),
+            "Time64(2024-01-02 03:04:05)"
+        );
+
+        let utc = datetime.and_utc();
+        assert_eq!(DataValue::timestamp_precision(utc, 0), utc.timestamp());
+        assert_eq!(
+            DataValue::timestamp_precision(utc, 3),
+            utc.timestamp_millis()
+        );
+        assert_eq!(
+            DataValue::timestamp_precision(utc, 6),
+            utc.timestamp_micros()
+        );
+        assert_eq!(
+            DataValue::from_timestamp_precision(utc.timestamp(), 0),
+            Some(utc)
+        );
+        assert_eq!(
+            DataValue::from_timestamp_precision(utc.timestamp_millis(), 3),
+            Some(utc)
+        );
+        assert_eq!(
+            DataValue::from_timestamp_precision(utc.timestamp_micros(), 6),
+            Some(utc)
+        );
+        let nanos_utc = utc.with_nanosecond(123_456_789).unwrap();
+        let nanos = DataValue::timestamp_precision(nanos_utc, 9);
+        assert_eq!(
+            DataValue::from_timestamp_precision(nanos, 9),
+            Some(nanos_utc)
+        );
+        assert!(matches!(
+            DataValue::init(&LogicalType::TimeStamp(Some(9), true)),
+            DataValue::Time64(_, 9, true)
+        ));
+        assert!(DataValue::from_timestamp_precision(i64::MAX, 0).is_none());
+        assert_panics(|| {
+            let _ = DataValue::timestamp_precision(utc, 5);
+        });
+        assert_panics(|| {
+            let _ = DataValue::from_timestamp_precision(0, 5);
+        });
     }
 
     #[test]
@@ -2509,3 +3168,4 @@ mod test {
         Ok(())
     }
 }
+// GRCOV_EXCL_STOP


### PR DESCRIPTION
## Summary
- add Codecov coverage generation/upload support and non-blocking PR coverage comments
- add focused unit tests for DataValue comparison/accessor behavior
- add cast_create dispatch coverage for boolean, float/double, utf8, chrono, tuple, and decimal casts

## Tests
- cargo test -p kite_sql types::value::test:: --features decimal
- cargo test -p kite_sql types::evaluator::cast::test:: --features decimal
- make test
- make codecov