### PR TITLE
test: improve planner orm and error coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ CODECOV_OUTPUT ?= lcov.info
 COVERAGE_PROFILE_DIR ?= target/grcov/profraw
 COVERAGE_HTML_DIR ?= target/grcov/html
 COVERAGE_RUSTFLAGS ?= -Cinstrument-coverage
+COVERAGE_TEST_FEATURES ?= decimal,orm
 COVERAGE_REPORT_ARGS ?= --llvm --ignore-not-existing --keep-only 'src/**' --ignore 'src/**/tests/**' --ignore 'tests/**' --ignore 'tpcc/**' --excl-start 'GRCOV_EXCL_START' --excl-stop 'GRCOV_EXCL_STOP'
 
 .PHONY: test test-python test-wasm test-slt test-all codecov codecov-html wasm-build check tpcc tpcc-kitesql-rocksdb tpcc-kitesql-lmdb tpcc-lmdb-flamegraph tpcc-lmdb-heaptrack tpcc-sqlite tpcc-sqlite-practical tpcc-sqlite-balanced tpcc-dual cargo-check build wasm-examples native-examples fmt clippy
@@ -55,7 +56,7 @@ codecov:
 		command -v $(GRCOV) >/dev/null || { echo 'grcov is not installed; run: cargo install grcov'; exit 1; }; \
 		rm -rf '$(COVERAGE_PROFILE_DIR)' '$(CODECOV_OUTPUT)'; \
 		mkdir -p '$(COVERAGE_PROFILE_DIR)'; \
-		CARGO_INCREMENTAL=0 RUSTFLAGS=\"$${RUSTFLAGS:-} $(COVERAGE_RUSTFLAGS)\" LLVM_PROFILE_FILE='$(COVERAGE_PROFILE_DIR)/kitesql-%p-%m.profraw' $(CARGO) test --all --features decimal; \
+		CARGO_INCREMENTAL=0 RUSTFLAGS=\"$${RUSTFLAGS:-} $(COVERAGE_RUSTFLAGS)\" LLVM_PROFILE_FILE='$(COVERAGE_PROFILE_DIR)/kitesql-%p-%m.profraw' $(CARGO) test --all --features '$(COVERAGE_TEST_FEATURES)'; \
 		CARGO_INCREMENTAL=0 RUSTFLAGS=\"$${RUSTFLAGS:-} $(COVERAGE_RUSTFLAGS)\" LLVM_PROFILE_FILE='$(COVERAGE_PROFILE_DIR)/kitesql-%p-%m.profraw' $(CARGO) run -p sqllogictest-test -- --path '$(SQLLOGIC_PATH)'; \
 		$(GRCOV) . --binary-path \"$${CARGO_TARGET_DIR:-target}/debug\" -s . -t lcov $(COVERAGE_REPORT_ARGS) -o '$(CODECOV_OUTPUT)'"
 
@@ -65,7 +66,7 @@ codecov-html:
 		command -v $(GRCOV) >/dev/null || { echo 'grcov is not installed; run: cargo install grcov'; exit 1; }; \
 		rm -rf '$(COVERAGE_PROFILE_DIR)' '$(COVERAGE_HTML_DIR)'; \
 		mkdir -p '$(COVERAGE_PROFILE_DIR)' '$(COVERAGE_HTML_DIR)'; \
-		CARGO_INCREMENTAL=0 RUSTFLAGS=\"$${RUSTFLAGS:-} $(COVERAGE_RUSTFLAGS)\" LLVM_PROFILE_FILE='$(COVERAGE_PROFILE_DIR)/kitesql-%p-%m.profraw' $(CARGO) test --all --features decimal; \
+		CARGO_INCREMENTAL=0 RUSTFLAGS=\"$${RUSTFLAGS:-} $(COVERAGE_RUSTFLAGS)\" LLVM_PROFILE_FILE='$(COVERAGE_PROFILE_DIR)/kitesql-%p-%m.profraw' $(CARGO) test --all --features '$(COVERAGE_TEST_FEATURES)'; \
 		CARGO_INCREMENTAL=0 RUSTFLAGS=\"$${RUSTFLAGS:-} $(COVERAGE_RUSTFLAGS)\" LLVM_PROFILE_FILE='$(COVERAGE_PROFILE_DIR)/kitesql-%p-%m.profraw' $(CARGO) run -p sqllogictest-test -- --path '$(SQLLOGIC_PATH)'; \
 		$(GRCOV) . --binary-path \"$${CARGO_TARGET_DIR:-target}/debug\" -s . -t html $(COVERAGE_REPORT_ARGS) -o '$(COVERAGE_HTML_DIR)'"
 	@echo "Coverage report: $(COVERAGE_HTML_DIR)/index.html"

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,7 @@ coverage:
         informational: true
     patch:
       default:
+        target: 90%
         informational: true
 
 comment:

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -518,3 +518,334 @@ fn build_sql_highlight(sql: &str, span: &SqlErrorSpan) -> Option<String> {
 
     Some(out.trim_end().to_string())
 }
+
+// GRCOV_EXCL_START
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::expression::{BinaryOperator, UnaryOperator};
+    use crate::types::value::DataValue;
+    use std::error::Error;
+
+    fn span(line: usize, start: usize, end: usize) -> SqlErrorSpan {
+        SqlErrorSpan {
+            line,
+            start,
+            end,
+            highlight: None,
+        }
+    }
+
+    #[test]
+    fn span_aware_errors_format_location_and_highlight() {
+        let err = DatabaseError::column_not_found("missing").with_span(span(2, 8, 14));
+        assert_eq!(
+            err.to_string(),
+            "column: `missing` not found at line 2, range 8..14"
+        );
+        assert_eq!(err.sql_error_span().unwrap().line, 2);
+
+        let err = err.with_sql_context("select *\nfrom missing\nwhere id = 1");
+        let highlight = err
+            .sql_error_span()
+            .and_then(|span| span.highlight.as_ref())
+            .expect("highlight is added from SQL context");
+        assert!(highlight.contains("--> line 2"));
+        assert!(highlight.contains("2 | from missing"));
+        assert!(highlight.lines().any(|line| line.contains('^')));
+        assert!(err.to_string().contains("\n--> line 2"));
+    }
+
+    #[test]
+    fn sql_context_preserves_existing_highlight_and_ignores_invalid_spans() {
+        let mut existing = span(1, 1, 3);
+        existing.highlight = Some("custom highlight".to_string());
+        let err = DatabaseError::not_null_column("id")
+            .with_span(existing)
+            .with_sql_context("select id");
+        assert_eq!(
+            err.sql_error_span().unwrap().highlight.as_deref(),
+            Some("custom highlight")
+        );
+        assert_eq!(
+            err.to_string(),
+            "column: `id` cannot be null\ncustom highlight"
+        );
+
+        let err = DatabaseError::invalid_table("t")
+            .with_span(span(0, 1, 2))
+            .with_sql_context("select * from t");
+        assert!(err.sql_error_span().unwrap().highlight.is_none());
+        assert_eq!(err.to_string(), "invalid table: `t` at line 0, range 1..2");
+
+        let err = DatabaseError::invalid_table("missing")
+            .with_span(span(3, 1, 4))
+            .with_sql_context("select 1");
+        assert!(err.sql_error_span().unwrap().highlight.is_none());
+        assert_eq!(
+            err.to_string(),
+            "invalid table: `missing` at line 3, range 1..4"
+        );
+    }
+
+    #[test]
+    fn constructors_attach_expected_payloads() {
+        assert_eq!(
+            DatabaseError::invalid_column("c").to_string(),
+            "invalid column: `c`"
+        );
+        assert_eq!(
+            DatabaseError::function_not_found("lower").to_string(),
+            "function: `lower` not found"
+        );
+        assert_eq!(
+            DatabaseError::parameter_not_found("p").to_string(),
+            "parameter: `p` not found"
+        );
+        assert_eq!(DatabaseError::not_null().to_string(), "cannot be null");
+        assert_eq!(
+            DatabaseError::not_null_column("name").to_string(),
+            "column: `name` cannot be null"
+        );
+
+        assert!(DatabaseError::TableNotFound
+            .with_span(span(1, 1, 1))
+            .sql_error_span()
+            .is_none());
+    }
+
+    #[test]
+    fn span_helpers_attach_context_to_remaining_span_aware_variants() {
+        let cast = DatabaseError::CastFail {
+            from: LogicalType::Boolean,
+            to: LogicalType::Integer,
+            span: None,
+        }
+        .with_span(span(1, 8, 11));
+        assert_eq!(
+            cast.to_string(),
+            "cast fail: Boolean -> Integer at line 1, range 8..11"
+        );
+        assert_eq!(cast.sql_error_span().unwrap().start, 8);
+
+        let cast = cast.with_sql_context("select true");
+        assert!(cast.to_string().contains("\n--> line 1"));
+
+        let parameter = DatabaseError::parameter_not_found("tenant_id")
+            .with_span(span(1, 15, 24))
+            .with_sql_context("select :tenant_id");
+        assert_eq!(parameter.sql_error_span().unwrap().line, 1);
+        assert!(parameter
+            .to_string()
+            .contains("parameter: `tenant_id` not found\n--> line 1"));
+    }
+
+    #[test]
+    fn display_formats_common_error_variants() {
+        let cases = [
+            (DatabaseError::AggMiss("sum".into()), "agg miss: sum"),
+            (DatabaseError::CacheSizeOverFlow, "cache size overflow"),
+            (
+                DatabaseError::CastFail {
+                    from: LogicalType::Integer,
+                    to: LogicalType::Varchar(None, crate::types::CharLengthUnits::Characters),
+                    span: None,
+                },
+                "cast fail: Integer -> Varchar(None, CHARACTERS)",
+            ),
+            (
+                DatabaseError::ColumnIdNotFound("7".into()),
+                "column id: `7` not found",
+            ),
+            (
+                DatabaseError::DuplicateColumn("id".into()),
+                "column: `id` already exists",
+            ),
+            (
+                DatabaseError::DuplicateSourceHash("v".into()),
+                "table or view: `v` hash already exists",
+            ),
+            (
+                DatabaseError::DuplicateIndex("idx".into()),
+                "index: `idx` already exists",
+            ),
+            (
+                DatabaseError::Incomparable(LogicalType::Integer, LogicalType::Boolean),
+                "can not compare two types: Integer and Boolean",
+            ),
+            (
+                DatabaseError::InvalidValue("NaN".into()),
+                "invalid value: NaN",
+            ),
+            (
+                DatabaseError::MisMatch("left", "right"),
+                "left and right do not match",
+            ),
+            (
+                DatabaseError::TupleIdNotFound(DataValue::Int32(3)),
+                "tuple id: 3 not found",
+            ),
+            (
+                DatabaseError::TooManyBuckets(8, 3),
+                "there are more buckets: 8 than elements: 3",
+            ),
+            (
+                DatabaseError::UnsupportedUnaryOperator(LogicalType::Integer, UnaryOperator::Not),
+                "unsupported unary operator: Integer cannot support ! for calculations",
+            ),
+            (
+                DatabaseError::UnsupportedBinaryOperator(
+                    LogicalType::Boolean,
+                    BinaryOperator::Plus,
+                ),
+                "unsupported binary operator: Boolean cannot support + for calculations",
+            ),
+            (
+                DatabaseError::ValuesLenMismatch(2, 3),
+                "values length not match, expect 2, got 3",
+            ),
+        ];
+
+        for (err, expected) in cases {
+            assert_eq!(err.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn display_formats_remaining_simple_error_variants() {
+        let cases = [
+            (DatabaseError::ChannelClose, "channel close"),
+            (DatabaseError::ColumnsEmpty, "columns empty"),
+            (
+                DatabaseError::DefaultNotColumnRef,
+                "default cannot be a column related to the table",
+            ),
+            (DatabaseError::DefaultNotExist, "default does not exist"),
+            (DatabaseError::DuplicatePrimaryKey, "duplicate primary key"),
+            (DatabaseError::EmptyPlan, "empty plan"),
+            (DatabaseError::EmptyStatement, "sql statement is empty"),
+            (DatabaseError::EvaluatorNotFound, "evaluator not found"),
+            (DatabaseError::InvalidIndex, "invalid index"),
+            (DatabaseError::InvalidType, "invalid type"),
+            (
+                DatabaseError::NeedNullAbleOrDefault,
+                "add column must be nullable or specify a default value",
+            ),
+            (DatabaseError::NoTransactionBegin, "no transaction begin"),
+            (DatabaseError::OverFlow, "over flow"),
+            (
+                DatabaseError::PrimaryKeyNotFound,
+                "must contain primary key!",
+            ),
+            (
+                DatabaseError::PrimaryKeyTooManyLayers,
+                "primaryKey only allows single or multiple values",
+            ),
+            (
+                DatabaseError::SharedNotAlign,
+                "the number of caches cannot be divisible by the number of shards",
+            ),
+            (DatabaseError::SourceNotFound, "the table or view not found"),
+            (DatabaseError::TableExists, "the table already exists"),
+            (DatabaseError::TableNotFound, "the table not found"),
+            (
+                DatabaseError::TransactionAlreadyExists,
+                "transaction already exists",
+            ),
+            (DatabaseError::TooLong, "too long"),
+            (
+                DatabaseError::UnsupportedStmt("merge".into()),
+                "unsupported statement: merge",
+            ),
+            (DatabaseError::ViewExists, "the view already exists"),
+            (DatabaseError::ViewNotFound, "the view not found"),
+        ];
+
+        for (err, expected) in cases {
+            assert_eq!(err.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn source_returns_inner_errors_for_conversion_variants() {
+        let parse_int: DatabaseError = "not-int".parse::<i32>().unwrap_err().into();
+        let parse_float: DatabaseError = "not-float".parse::<f64>().unwrap_err().into();
+        let parse_bool: DatabaseError = "not-bool".parse::<bool>().unwrap_err().into();
+        let bytes = vec![0xff];
+        let utf8: DatabaseError = std::str::from_utf8(&bytes).unwrap_err().into();
+        let from_utf8: DatabaseError = String::from_utf8(vec![0xff]).unwrap_err().into();
+        let io: DatabaseError = std::io::Error::new(std::io::ErrorKind::Other, "disk").into();
+        let try_from_int: DatabaseError = u8::try_from(300_u16).unwrap_err().into();
+
+        for err in [
+            parse_int,
+            parse_float,
+            parse_bool,
+            utf8,
+            from_utf8,
+            io,
+            try_from_int,
+        ] {
+            assert!(Error::source(&err).is_some(), "{err}");
+        }
+        assert!(Error::source(&DatabaseError::TableNotFound).is_none());
+    }
+
+    #[test]
+    fn display_formats_conversion_error_variants() {
+        let parse_int: DatabaseError = "not-int".parse::<i32>().unwrap_err().into();
+        let parse_float: DatabaseError = "not-float".parse::<f64>().unwrap_err().into();
+        let parse_bool: DatabaseError = "not-bool".parse::<bool>().unwrap_err().into();
+        let bytes = vec![0xff];
+        let utf8: DatabaseError = std::str::from_utf8(&bytes).unwrap_err().into();
+        let from_utf8: DatabaseError = String::from_utf8(vec![0xff]).unwrap_err().into();
+        let io: DatabaseError = std::io::Error::new(std::io::ErrorKind::Other, "disk").into();
+        let try_from_int: DatabaseError = u8::try_from(300_u16).unwrap_err().into();
+
+        assert!(parse_int.to_string().starts_with("parser int:"));
+        assert!(parse_float.to_string().starts_with("parser float:"));
+        assert!(parse_bool.to_string().starts_with("parser bool:"));
+        assert!(utf8.to_string().starts_with("utf8:"));
+        assert!(from_utf8.to_string().starts_with("from utf8:"));
+        assert_eq!(io.to_string(), "io: disk");
+        assert!(try_from_int.to_string().starts_with("try from int:"));
+
+        #[cfg(feature = "copy")]
+        {
+            let mut reader = csv::Reader::from_reader("a\n1,2\n".as_bytes());
+            let csv_err = reader.records().next().unwrap().unwrap_err();
+            let err = DatabaseError::from(csv_err);
+            assert!(err.to_string().starts_with("csv error:"));
+            assert!(Error::source(&err).is_some());
+        }
+
+        #[cfg(feature = "time")]
+        {
+            let err: DatabaseError = chrono::NaiveDate::parse_from_str("not-a-date", "%Y-%m-%d")
+                .unwrap_err()
+                .into();
+            assert!(err.to_string().starts_with("parser date:"));
+            assert!(Error::source(&err).is_some());
+        }
+
+        #[cfg(feature = "parser")]
+        {
+            let dialect = sqlparser::dialect::GenericDialect {};
+            let err: DatabaseError = sqlparser::parser::Parser::parse_sql(&dialect, "select")
+                .unwrap_err()
+                .into();
+            assert!(err.to_string().starts_with("parser sql:"));
+            assert!(Error::source(&err).is_some());
+        }
+
+        #[cfg(feature = "decimal")]
+        {
+            let err: DatabaseError = rust_decimal::Decimal::from_str_exact("not-a-decimal")
+                .unwrap_err()
+                .into();
+            assert!(err.to_string().starts_with("try from decimal:"));
+            assert!(Error::source(&err).is_some());
+        }
+    }
+}
+// GRCOV_EXCL_STOP

--- a/src/orm/mod.rs
+++ b/src/orm/mod.rs
@@ -3117,3 +3117,747 @@ fn orm_list<E: BindSource, M: Model>(executor: E) -> Result<OrmIter<E::Iter, M>,
     })?
     .orm::<M>())
 }
+
+// GRCOV_EXCL_START
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use crate::types::tuple::{Schema, SchemaView};
+    use std::sync::Arc;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct User;
+
+    #[derive(Default, Debug, PartialEq, Eq)]
+    struct OrmUnitUser {
+        id: i32,
+        name: String,
+        age: Option<i32>,
+    }
+
+    const ORM_UNIT_USER_FIELDS: &[OrmField] = &[
+        OrmField {
+            column: "id",
+            column_index: 0,
+            placeholder: "id",
+            primary_key: true,
+            unique: false,
+        },
+        OrmField {
+            column: "name",
+            column_index: 1,
+            placeholder: "name",
+            primary_key: false,
+            unique: false,
+        },
+        OrmField {
+            column: "age",
+            column_index: 2,
+            placeholder: "age",
+            primary_key: false,
+            unique: false,
+        },
+    ];
+
+    impl OrmUnitUser {
+        fn id() -> Field<Self, i32> {
+            Field::new("orm_unit_users", "id")
+        }
+
+        fn name() -> Field<Self, String> {
+            Field::new("orm_unit_users", "name")
+        }
+
+        fn age() -> Field<Self, Option<i32>> {
+            Field::new("orm_unit_users", "age")
+        }
+    }
+
+    impl FromQueryRow for OrmUnitUser {
+        fn from_query_row(
+            schema: &SchemaView<'_, '_>,
+            tuple: &mut Tuple,
+        ) -> Result<Self, DatabaseError> {
+            Ok(Self {
+                id: take_value_at(tuple, schema.position("id"), "id")?,
+                name: take_value_at(tuple, schema.position("name"), "name")?,
+                age: take_value_at(tuple, schema.position("age"), "age")?,
+            })
+        }
+    }
+
+    impl Model for OrmUnitUser {
+        type PrimaryKey = i32;
+
+        fn table_name() -> &'static str {
+            "orm_unit_users"
+        }
+
+        fn fields() -> &'static [OrmField] {
+            ORM_UNIT_USER_FIELDS
+        }
+
+        fn params(&self) -> Vec<(&'static str, DataValue)> {
+            vec![
+                ("id", self.id.to_data_value()),
+                ("name", self.name.to_data_value()),
+                ("age", self.age.to_data_value()),
+            ]
+        }
+
+        fn primary_key(&self) -> &Self::PrimaryKey {
+            &self.id
+        }
+    }
+
+    #[derive(Default, Debug, PartialEq, Eq)]
+    struct OrmUnitOrder {
+        id: i32,
+        user_id: i32,
+        amount: i32,
+    }
+
+    const ORM_UNIT_ORDER_FIELDS: &[OrmField] = &[
+        OrmField {
+            column: "id",
+            column_index: 0,
+            placeholder: "id",
+            primary_key: true,
+            unique: false,
+        },
+        OrmField {
+            column: "user_id",
+            column_index: 1,
+            placeholder: "user_id",
+            primary_key: false,
+            unique: false,
+        },
+        OrmField {
+            column: "amount",
+            column_index: 2,
+            placeholder: "amount",
+            primary_key: false,
+            unique: false,
+        },
+    ];
+
+    impl OrmUnitOrder {
+        fn id() -> Field<Self, i32> {
+            Field::new("orm_unit_orders", "id")
+        }
+
+        fn user_id() -> Field<Self, i32> {
+            Field::new("orm_unit_orders", "user_id")
+        }
+
+        fn amount() -> Field<Self, i32> {
+            Field::new("orm_unit_orders", "amount")
+        }
+    }
+
+    impl FromQueryRow for OrmUnitOrder {
+        fn from_query_row(
+            schema: &SchemaView<'_, '_>,
+            tuple: &mut Tuple,
+        ) -> Result<Self, DatabaseError> {
+            Ok(Self {
+                id: take_value_at(tuple, schema.position("id"), "id")?,
+                user_id: take_value_at(tuple, schema.position("user_id"), "user_id")?,
+                amount: take_value_at(tuple, schema.position("amount"), "amount")?,
+            })
+        }
+    }
+
+    impl Model for OrmUnitOrder {
+        type PrimaryKey = i32;
+
+        fn table_name() -> &'static str {
+            "orm_unit_orders"
+        }
+
+        fn fields() -> &'static [OrmField] {
+            ORM_UNIT_ORDER_FIELDS
+        }
+
+        fn params(&self) -> Vec<(&'static str, DataValue)> {
+            vec![
+                ("id", self.id.to_data_value()),
+                ("user_id", self.user_id.to_data_value()),
+                ("amount", self.amount.to_data_value()),
+            ]
+        }
+
+        fn primary_key(&self) -> &Self::PrimaryKey {
+            &self.id
+        }
+    }
+
+    fn build_orm_unit_database(
+    ) -> Result<crate::db::Database<crate::storage::memory::MemoryStorage>, DatabaseError> {
+        let mut database = crate::db::DataBaseBuilder::path("./orm-unit-test").build_in_memory()?;
+        database
+            .ddl("create table orm_unit_users (id int primary key, name varchar, age int null)")?;
+        database
+            .ddl("create table orm_unit_orders (id int primary key, user_id int, amount int)")?;
+
+        for user in [
+            OrmUnitUser {
+                id: 1,
+                name: "Alice".to_string(),
+                age: Some(18),
+            },
+            OrmUnitUser {
+                id: 2,
+                name: "Bob".to_string(),
+                age: Some(20),
+            },
+            OrmUnitUser {
+                id: 3,
+                name: "Cara".to_string(),
+                age: None,
+            },
+        ] {
+            database.insert(&user)?;
+        }
+
+        for order in [
+            OrmUnitOrder {
+                id: 1,
+                user_id: 1,
+                amount: 100,
+            },
+            OrmUnitOrder {
+                id: 2,
+                user_id: 1,
+                amount: 150,
+            },
+            OrmUnitOrder {
+                id: 3,
+                user_id: 2,
+                amount: 200,
+            },
+        ] {
+            database.insert(&order)?;
+        }
+
+        Ok(database)
+    }
+
+    #[test]
+    fn field_accessors_and_sort_build_expected_metadata() {
+        let field = Field::<User, i32>::new("users", "id");
+        assert_eq!(field.table_name(), "users");
+        assert_eq!(field.column_name(), "id");
+
+        let asc = Field::<User, i32>::new("users", "id").asc();
+        assert_eq!(asc.field.table_name(), "users");
+        assert_eq!(asc.field.column_name(), "id");
+        assert!(asc.asc);
+        assert!(!asc.nulls_first);
+
+        let desc_nulls_first = Field::<User, i32>::new("users", "id").desc().nulls_first();
+        assert!(!desc_nulls_first.asc);
+        assert!(desc_nulls_first.nulls_first);
+
+        let asc_nulls_last = Field::<User, i32>::new("users", "id")
+            .nulls_first()
+            .asc()
+            .nulls_last();
+        assert!(asc_nulls_last.asc);
+        assert!(!asc_nulls_last.nulls_first);
+    }
+
+    #[test]
+    fn describe_column_decodes_projected_tuple_values() -> Result<(), DatabaseError> {
+        let table_arena = crate::planner::TableArenaCell::default();
+        let arena = PlanArena::new(&table_arena);
+        let schema: Schema = Vec::new();
+        let schema_view = SchemaView::new(&schema, &arena);
+        let mut tuple = Tuple::new(
+            None,
+            vec![
+                DataValue::from("id".to_string()),
+                DataValue::from("Integer".to_string()),
+                DataValue::Int32(4),
+                DataValue::from("true".to_string()),
+                DataValue::from("PRI".to_string()),
+                DataValue::Null,
+            ],
+        );
+
+        let column = DescribeColumn::from_query_row(&schema_view, &mut tuple)?;
+        assert_eq!(
+            column,
+            DescribeColumn {
+                field: "id".to_string(),
+                data_type: "Integer".to_string(),
+                len: "4".to_string(),
+                nullable: true,
+                key: "PRI".to_string(),
+                default: "null".to_string(),
+            }
+        );
+        assert!(tuple
+            .values
+            .iter()
+            .all(|value| matches!(value, DataValue::Null)));
+        assert_eq!(describe_text_value(None), "");
+
+        Ok(())
+    }
+
+    #[test]
+    fn data_value_conversion_traits_handle_scalars_options_and_errors() -> Result<(), DatabaseError>
+    {
+        assert_eq!(i32::from_data_value(DataValue::Int32(7))?, 7);
+        assert_eq!(
+            String::from_data_value(DataValue::from("kite".to_string()))?,
+            "kite"
+        );
+        assert_eq!(
+            Arc::<str>::from_data_value(DataValue::from("sql".to_string()))?,
+            Arc::<str>::from("sql")
+        );
+        assert_eq!(Option::<i32>::from_data_value(DataValue::Null)?, None);
+        assert_eq!(
+            Option::<i32>::from_data_value(DataValue::Int32(9))?,
+            Some(9)
+        );
+
+        assert_eq!(true.to_data_value(), DataValue::Boolean(true));
+        assert_eq!("name".to_data_value(), DataValue::from("name".to_string()));
+        assert_eq!(Option::<i32>::None.to_data_value(), DataValue::Null);
+        assert_eq!(Some(3i32).to_data_value(), DataValue::Int32(3));
+
+        assert_eq!(
+            <i32 as ModelColumnType>::logical_type(),
+            LogicalType::Integer
+        );
+        assert!(!<i32 as ModelColumnType>::nullable());
+        assert_eq!(
+            <Option<String> as ModelColumnType>::logical_type(),
+            LogicalType::Varchar(None, CharLengthUnits::Characters)
+        );
+        assert!(<Option<String> as ModelColumnType>::nullable());
+
+        let err = i32::from_data_value(DataValue::from("not-int".to_string())).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("failed to convert Varchar(None, CHARACTERS) value"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn tuple_projection_helpers_cast_extract_and_report_width_mismatch() -> Result<(), DatabaseError>
+    {
+        let mut tuple = Tuple::new(
+            None,
+            vec![DataValue::Int8(7), DataValue::from("seven".to_string())],
+        );
+        assert_eq!(take_value_at::<i32>(&mut tuple, Some(0), "id")?, 7);
+        assert!(matches!(tuple.values[0], DataValue::Null));
+        assert!(matches!(
+            take_value_at::<i32>(&mut tuple, None, "missing"),
+            Err(DatabaseError::ColumnNotFound { .. })
+        ));
+
+        let mut tuple = Tuple::new(
+            None,
+            vec![DataValue::Int32(1), DataValue::from("one".to_string())],
+        );
+        let projected = <(i32, String) as FromQueryTuple>::from_query_tuple(&mut tuple)?;
+        assert_eq!(projected, (1, "one".to_string()));
+        assert!(tuple
+            .values
+            .iter()
+            .all(|value| matches!(value, DataValue::Null)));
+
+        let mut too_wide = Tuple::new(None, vec![DataValue::Int32(1), DataValue::Int32(2)]);
+        assert!(matches!(
+            extract_value_from_tuple::<i32>(&mut too_wide),
+            Err(DatabaseError::MisMatch(
+                "one projected expression",
+                "the query result"
+            ))
+        ));
+
+        let mut too_narrow = Tuple::new(None, vec![DataValue::Int32(1)]);
+        assert!(matches!(
+            <(i32, i32) as FromQueryTuple>::from_query_tuple(&mut too_narrow),
+            Err(DatabaseError::MisMatch(
+                "the expected tuple projection width",
+                "the query result"
+            ))
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn database_and_transaction_orm_helpers_bind_expected_plans() -> Result<(), DatabaseError> {
+        let mut database = crate::db::DataBaseBuilder::path("./orm-unit-test").build_in_memory()?;
+        database
+            .ddl("create table orm_unit_users (id int primary key, name varchar, age int null)")?;
+        database.create_view("orm_unit_user_names", |ctx| {
+            ctx.from::<OrmUnitUser>()?
+                .project_scalars((OrmUnitUser::id(), OrmUnitUser::name()))?
+                .finish()
+        })?;
+
+        database.insert(&OrmUnitUser {
+            id: 1,
+            name: "Alice".to_string(),
+            age: Some(18),
+        })?;
+        database.insert_many([
+            OrmUnitUser {
+                id: 2,
+                name: "Bob".to_string(),
+                age: Some(20),
+            },
+            OrmUnitUser {
+                id: 3,
+                name: "Cara".to_string(),
+                age: None,
+            },
+        ])?;
+        assert!(matches!(
+            database.analyze_model::<OrmUnitUser>(),
+            Err(DatabaseError::TooManyBuckets(100, 3))
+        ));
+
+        assert_eq!(
+            database.get::<OrmUnitUser>(&1)?,
+            Some(OrmUnitUser {
+                id: 1,
+                name: "Alice".to_string(),
+                age: Some(18),
+            })
+        );
+        assert_eq!(
+            database
+                .fetch::<OrmUnitUser>()?
+                .collect::<Result<Vec<_>, _>>()?
+                .len(),
+            3
+        );
+        assert!(database
+            .show_views()?
+            .collect::<Result<Vec<_>, _>>()?
+            .iter()
+            .any(|view| view == "orm_unit_user_names"));
+        assert!(database
+            .describe::<OrmUnitUser>()?
+            .collect::<Result<Vec<_>, _>>()?
+            .iter()
+            .any(|column| column.field == "name"));
+
+        let mut tx = database.new_transaction()?;
+        tx.insert(&OrmUnitUser {
+            id: 4,
+            name: "Dora".to_string(),
+            age: Some(40),
+        })?;
+        tx.insert_many([
+            OrmUnitUser {
+                id: 5,
+                name: "Eve".to_string(),
+                age: None,
+            },
+            OrmUnitUser {
+                id: 6,
+                name: "Finn".to_string(),
+                age: Some(60),
+            },
+        ])?;
+        assert!(matches!(
+            tx.analyze::<OrmUnitUser>(),
+            Err(DatabaseError::TooManyBuckets(100, 6))
+        ));
+
+        assert_eq!(tx.get::<OrmUnitUser>(&4)?.unwrap().name, "Dora");
+        assert_eq!(
+            tx.fetch::<OrmUnitUser>()?
+                .collect::<Result<Vec<_>, _>>()?
+                .len(),
+            6
+        );
+        assert!(tx
+            .show_tables()?
+            .collect::<Result<Vec<_>, _>>()?
+            .iter()
+            .any(|table| table == "orm_unit_users"));
+        assert!(tx
+            .show_views()?
+            .collect::<Result<Vec<_>, _>>()?
+            .iter()
+            .any(|view| view == "orm_unit_user_names"));
+        assert!(tx
+            .describe::<OrmUnitUser>()?
+            .collect::<Result<Vec<_>, _>>()?
+            .iter()
+            .any(|column| column.field == "age"));
+
+        let plan = tx.explain(|ctx| {
+            ctx.from::<OrmUnitUser>()?
+                .filter(|expr| expr.column(OrmUnitUser::id())?.gte(4))?
+                .project_scalar(OrmUnitUser::name())?
+                .finish()
+        })?;
+        assert_eq!(
+            plan,
+            concat!(
+                "Projection [#2] [Project => (Sort Option: Follow)] ",
+                "Filter (#1 >= 4), Is Having: false [Filter => (Sort Option: Follow)] ",
+                "TableScan orm_unit_users -> [#1, #2] [SeqScan => (Sort Option: None)]"
+            ),
+            "{plan}"
+        );
+
+        tx.commit()?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn expression_scope_helpers_build_filter_projection_and_sort_exprs() -> Result<(), DatabaseError>
+    {
+        let database = build_orm_unit_database()?;
+
+        let expression_plan = database.explain(|ctx| {
+            ctx.from::<OrmUnitUser>()?
+                .filter(|e| {
+                    let not_null = e.is_not_null(e.column(OrmUnitUser::age())?);
+                    let in_range = e.between(e.column(OrmUnitUser::age())?, 18, 25);
+                    let not_bob = e.ne(e.column(OrmUnitUser::name())?, "Bob")?;
+                    let not_missing = e.not(e.eq(e.column(OrmUnitUser::name())?, "Missing")?)?;
+                    e.and(e.and(not_null, in_range)?, e.and(not_bob, not_missing)?)
+                })?
+                .project_value(|e| {
+                    e.function("upper", [e.column(OrmUnitUser::name())?])?
+                        .alias("upper_name")
+                        .cast(LogicalType::Varchar(None, CharLengthUnits::Characters))
+                })?
+                .order_by_expr(|e| Ok(e.column(OrmUnitUser::age())?.desc()))?
+                .finish()
+        })?;
+        assert_eq!(
+            expression_plan,
+            concat!(
+                "Projection [upper_name] [Project => (Sort Option: Follow)] ",
+                "Sort By #3 Desc Nulls Last [Sort => (Sort Option: OrderBy: (#3 Desc Nulls Last) ignore_prefix_len: 0)] ",
+                "Filter ((#3 is not null && ((#3 >= 18) && (#3 <= 25))) && (!(#2 != Bob) && (#2 = Missing))), Is Having: false ",
+                "[Filter => (Sort Option: Follow)] TableScan orm_unit_users -> [#2, #3] [SeqScan => (Sort Option: None)]"
+            ),
+            "{expression_plan}"
+        );
+
+        let list_plan = database.explain(|ctx| {
+            ctx.from::<OrmUnitUser>()?
+                .filter(|e| {
+                    let id = e.column(OrmUnitUser::id())?;
+                    let in_list = id.clone().in_list([1, 2, 3])?;
+                    let not_in_list = id.not_in_list([3])?;
+                    in_list.and(not_in_list)
+                })?
+                .project_scalar(OrmUnitUser::id())?
+                .order_by(SortField::from(ScalarExpression::from(1_i32)).asc())?
+                .finish()
+        })?;
+        assert_eq!(
+            list_plan,
+            concat!(
+                "Projection [#1] [Project => (Sort Option: Follow)] ",
+                "Sort By 1 Asc Nulls Last [Sort => (Sort Option: OrderBy: (1 Asc Nulls Last) ignore_prefix_len: 0)] ",
+                "Filter (((#1 = 3) || ((#1 = 2) || (#1 = 1))) && (#1 != 3)), Is Having: false ",
+                "[Filter => (Sort Option: Follow)] TableScan orm_unit_users -> [#1] [SeqScan => (Sort Option: None)]"
+            ),
+            "{list_plan}"
+        );
+
+        let nullable_plan = database.explain(|ctx| {
+            ctx.from::<OrmUnitUser>()?
+                .filter(|e| {
+                    let age = e.column(OrmUnitUser::age())?;
+                    let outside = e.not_between(age.clone(), 10, 30);
+                    let null_age = e.is_null(age);
+                    e.or(outside, null_age)
+                })?
+                .project_scalar(OrmUnitUser::id())?
+                .finish()
+        })?;
+        assert_eq!(
+            nullable_plan,
+            concat!(
+                "Projection [#1] [Project => (Sort Option: Follow)] ",
+                "Filter (((#3 < 10) || (#3 > 30)) || #3 is null), Is Having: false ",
+                "[Filter => (Sort Option: Follow)] TableScan orm_unit_users -> [#1, #3] [SeqScan => (Sort Option: None)]"
+            ),
+            "{nullable_plan}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn query_builder_wrappers_cover_group_having_and_join_variants() -> Result<(), DatabaseError> {
+        let database = build_orm_unit_database()?;
+
+        let grouped_plan = database.explain(|ctx| {
+            ctx.from::<OrmUnitOrder>()?
+                .project_tuple(|e| {
+                    Ok(vec![
+                        e.column(OrmUnitOrder::user_id())?,
+                        e.aggregate("sum", [e.column(OrmUnitOrder::amount())?])?,
+                    ])
+                })?
+                .group_by(|e| e.column(OrmUnitOrder::user_id()))?
+                .having(|e| {
+                    e.aggregate("sum", [e.column(OrmUnitOrder::amount())?])?
+                        .gte(200)
+                })?
+                .order_by_expr(|e| Ok(e.column(OrmUnitOrder::user_id())?.asc()))?
+                .finish()
+        })?;
+        assert_eq!(
+            grouped_plan,
+            concat!(
+                "Projection [#5, #7] [Project => (Sort Option: Follow)] ",
+                "Sort By #5 Asc Nulls Last [Sort => (Sort Option: OrderBy: (#5 Asc Nulls Last) ignore_prefix_len: 0)] ",
+                "Filter (Sum(#6) >= 200), Is Having: true [Filter => (Sort Option: Follow)] ",
+                "Aggregate [Sum(#6)] -> Group By [#5] [HashAggregate => (Sort Option: None)] ",
+                "TableScan orm_unit_orders -> [#5, #6] [SeqScan => (Sort Option: None)]"
+            ),
+            "{grouped_plan}"
+        );
+
+        let right_join_plan = database.explain(|ctx| {
+            ctx.from::<OrmUnitUser>()?
+                .right_join::<OrmUnitOrder, _>(|e| {
+                    e.column(OrmUnitUser::id())?
+                        .eq(e.column(OrmUnitOrder::user_id())?)
+                })?
+                .project_scalar(OrmUnitUser::id())?
+                .finish()
+        })?;
+        assert_eq!(
+            right_join_plan,
+            concat!(
+                "Projection [#1] [Project => (Sort Option: Follow)] ",
+                "RightOuter Join On #1 = #5 [HashJoin => (Sort Option: None)] ",
+                "TableScan orm_unit_users -> [#1] [SeqScan => (Sort Option: None)] ",
+                "TableScan orm_unit_orders -> [#5] [SeqScan => (Sort Option: None)]"
+            ),
+            "{right_join_plan}"
+        );
+
+        let full_join_plan = database.explain(|ctx| {
+            ctx.from::<OrmUnitUser>()?
+                .full_join::<OrmUnitOrder, _>(|e| {
+                    e.column(OrmUnitUser::id())?
+                        .eq(e.column(OrmUnitOrder::user_id())?)
+                })?
+                .project_scalar(OrmUnitUser::id())?
+                .finish()
+        })?;
+        assert_eq!(
+            full_join_plan,
+            concat!(
+                "Projection [#1] [Project => (Sort Option: Follow)] ",
+                "Full Join On #1 = #5 [HashJoin => (Sort Option: None)] ",
+                "TableScan orm_unit_users -> [#1] [SeqScan => (Sort Option: None)] ",
+                "TableScan orm_unit_orders -> [#5] [SeqScan => (Sort Option: None)]"
+            ),
+            "{full_join_plan}"
+        );
+
+        let cross_join_plan = database.explain(|ctx| {
+            ctx.from::<OrmUnitUser>()?
+                .cross_join::<OrmUnitOrder>()?
+                .project_scalars((OrmUnitUser::id(), OrmUnitOrder::id()))?
+                .finish()
+        })?;
+        assert_eq!(
+            cross_join_plan,
+            concat!(
+                "Projection [#1, #4] [Project => (Sort Option: Follow)] ",
+                "Cross Join Nothing [NestLoopJoin => (Sort Option: None)] ",
+                "TableScan orm_unit_users -> [#1] [SeqScan => (Sort Option: None)] ",
+                "TableScan orm_unit_orders -> [#4] [SeqScan => (Sort Option: None)]"
+            ),
+            "{cross_join_plan}"
+        );
+
+        let inner_using_plan = database.explain(|ctx| {
+            ctx.from::<OrmUnitUser>()?
+                .inner_join_using::<OrmUnitOrder>(["id"])?
+                .project_scalar(OrmUnitUser::id())?
+                .finish()
+        })?;
+        assert_eq!(
+            inner_using_plan,
+            concat!(
+                "Projection [#1] [Project => (Sort Option: Follow)] ",
+                "Inner Join On #1 = #4 [HashJoin => (Sort Option: None)] ",
+                "TableScan orm_unit_users -> [#1] [SeqScan => (Sort Option: None)] ",
+                "TableScan orm_unit_orders -> [#4] [SeqScan => (Sort Option: None)]"
+            ),
+            "{inner_using_plan}"
+        );
+
+        let left_using_plan = database.explain(|ctx| {
+            ctx.from::<OrmUnitUser>()?
+                .left_join_using::<OrmUnitOrder>(["id"])?
+                .project_scalar(OrmUnitUser::id())?
+                .finish()
+        })?;
+        assert_eq!(
+            left_using_plan,
+            concat!(
+                "Projection [#1] [Project => (Sort Option: Follow)] ",
+                "LeftOuter Join On #1 = #4 [HashJoin => (Sort Option: None)] ",
+                "TableScan orm_unit_users -> [#1] [SeqScan => (Sort Option: None)] ",
+                "TableScan orm_unit_orders -> [#4] [SeqScan => (Sort Option: None)]"
+            ),
+            "{left_using_plan}"
+        );
+
+        let right_using_plan = database.explain(|ctx| {
+            ctx.from::<OrmUnitUser>()?
+                .right_join_using::<OrmUnitOrder>(["id"])?
+                .project_scalar(OrmUnitUser::id())?
+                .finish()
+        })?;
+        assert_eq!(
+            right_using_plan,
+            concat!(
+                "Projection [#1] [Project => (Sort Option: Follow)] ",
+                "RightOuter Join On #1 = #4 [HashJoin => (Sort Option: None)] ",
+                "TableScan orm_unit_users -> [#1] [SeqScan => (Sort Option: None)] ",
+                "TableScan orm_unit_orders -> [#4] [SeqScan => (Sort Option: None)]"
+            ),
+            "{right_using_plan}"
+        );
+
+        let full_using_plan = database.explain(|ctx| {
+            ctx.from::<OrmUnitUser>()?
+                .full_join_using::<OrmUnitOrder>(["id"])?
+                .project_scalar(OrmUnitUser::id())?
+                .finish()
+        })?;
+        assert_eq!(
+            full_using_plan,
+            concat!(
+                "Projection [#1] [Project => (Sort Option: Follow)] ",
+                "Full Join On #1 = #4 [HashJoin => (Sort Option: None)] ",
+                "TableScan orm_unit_users -> [#1] [SeqScan => (Sort Option: None)] ",
+                "TableScan orm_unit_orders -> [#4] [SeqScan => (Sort Option: None)]"
+            ),
+            "{full_using_plan}"
+        );
+
+        Ok(())
+    }
+}
+// GRCOV_EXCL_STOP

--- a/src/planner/arena.rs
+++ b/src/planner/arena.rs
@@ -524,10 +524,14 @@ impl MetaArena for PlanArena<'_> {
     }
 }
 
+// GRCOV_EXCL_START
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::catalog::{ColumnCatalog, ColumnDesc};
+    use crate::types::index::{IndexMeta, IndexType};
     use crate::types::LogicalType;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
 
     fn column(name: &str) -> ColumnCatalog {
         ColumnCatalog::new(
@@ -541,6 +545,18 @@ mod tests {
         let mut column = column(name);
         column.set_ref_table("t".to_string().into(), if is_temp { 0 } else { 1 }, is_temp);
         column
+    }
+
+    fn index_meta(name: &str) -> IndexMeta {
+        IndexMeta {
+            id: 1,
+            column_ids: vec![1],
+            table_name: "t".into(),
+            pk_ty: LogicalType::Integer,
+            value_ty: LogicalType::Integer,
+            name: name.to_string(),
+            ty: IndexType::Normal,
+        }
     }
 
     #[test]
@@ -597,4 +613,73 @@ mod tests {
         assert_eq!(table_arena.borrow().column(first).name(), "a");
         assert_eq!(second.pos(), 1);
     }
+
+    #[test]
+    fn arena_default_alloc_columns_dummy_debug_and_index_paths() {
+        let table_arena = crate::planner::TableArenaCell::default();
+        let mut plan_arena = crate::planner::PlanArena::new(&table_arena);
+
+        let schema = MetaArena::alloc_columns(&mut plan_arena, [column("a"), column("b")]);
+        assert_eq!(schema.len(), 2);
+        assert_eq!(plan_arena.allocated_columns_len(), 2);
+        assert_eq!(plan_arena.column(schema[0]).name(), "a");
+
+        let dummy = plan_arena.alloc_dummy("TABLE");
+        assert_eq!(plan_arena.column(dummy).name(), "TABLE");
+        assert!(format!("{:?}", table_arena).contains("columns_len"));
+        assert_eq!(plan_arena.temp_table().to_string(), "_temp_table_0_");
+
+        let first_index = plan_arena.alloc_index(index_meta("idx_a"));
+        assert_eq!(plan_arena.alloc_index(index_meta("idx_a")), first_index);
+        assert_eq!(plan_arena.index(first_index).name, "idx_a");
+
+        plan_arena.materialize_into_table_arena();
+        let mut second_plan_arena = crate::planner::PlanArena::new(&table_arena);
+        assert_eq!(
+            second_plan_arena.alloc_index(index_meta("idx_a")),
+            first_index
+        );
+    }
+
+    #[test]
+    fn table_arena_index_reuse_and_recycled_access_guards() {
+        let mut arena = crate::planner::TableArena::default();
+        let first_column = arena.alloc_column(column("a"));
+        let first_index = arena.alloc_index(index_meta("idx_a"));
+
+        arena.columns[first_column.pos()].live = false;
+        arena.indexes[first_index.pos()].live = false;
+
+        let column_panic = catch_unwind(AssertUnwindSafe(|| {
+            let _ = arena.column(first_column);
+        }));
+        assert!(column_panic.is_err());
+
+        let index_panic = catch_unwind(AssertUnwindSafe(|| {
+            let _ = arena.index(first_index);
+        }));
+        assert!(index_panic.is_err());
+
+        assert_eq!(arena.alloc_column(column("b")), first_column);
+        assert_eq!(arena.alloc_index(index_meta("idx_b")), first_index);
+    }
+
+    #[test]
+    fn plan_arena_detects_table_arena_mutation_in_debug_builds() {
+        let table_arena = crate::planner::TableArenaCell::default();
+        let mut plan_arena = crate::planner::PlanArena::new(&table_arena);
+
+        table_arena.borrow_mut().alloc_column(column("late"));
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            plan_arena.alloc_column(column("plan"));
+        }));
+
+        if cfg!(debug_assertions) {
+            assert!(result.is_err());
+        } else {
+            assert!(result.is_ok());
+        }
+    }
 }
+// GRCOV_EXCL_STOP

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -400,3 +400,164 @@ impl crate::serdes::ReferenceSerialization for LogicalPlan {
         })
     }
 }
+
+// GRCOV_EXCL_START
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use crate::catalog::{ColumnCatalog, ColumnDesc, ColumnRef};
+    use crate::planner::operator::describe::DescribeOperator;
+    use crate::planner::operator::limit::LimitOperator;
+    use crate::planner::operator::table_scan::TableScanOperator;
+    use crate::planner::operator::{PlanImpl, SortOption};
+    use crate::types::LogicalType;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    fn column(name: &str, ty: LogicalType, arena: &mut PlanArena) -> ColumnRef {
+        arena.alloc_column(ColumnCatalog::new(
+            name.to_string(),
+            true,
+            ColumnDesc::new(ty, None, false, None).unwrap(),
+        ))
+    }
+
+    fn table_scan(table: &str, columns: Vec<ColumnRef>) -> LogicalPlan {
+        LogicalPlan::new(
+            Operator::TableScan(TableScanOperator {
+                table_name: table.to_string().into(),
+                columns,
+                limit: (None, None),
+                index_infos: Vec::new(),
+                with_pk: false,
+            }),
+            Childrens::None,
+        )
+    }
+
+    fn schema_names(schema: &[ColumnRef], arena: &PlanArena) -> Vec<String> {
+        schema
+            .iter()
+            .map(|column| arena.column(*column).name().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn childrens_iterates_and_pops_expected_plans() {
+        let left = LogicalPlan::new(Operator::ShowTable, Childrens::None);
+        let right = LogicalPlan::new(Operator::ShowView, Childrens::None);
+
+        assert_eq!(Childrens::None.iter().count(), 0);
+
+        let only = Childrens::Only(Box::new(left.clone()));
+        assert_eq!(only.iter().count(), 1);
+        assert!(matches!(only.pop_only().operator, Operator::ShowTable));
+
+        let twins = Childrens::Twins {
+            left: Box::new(left),
+            right: Box::new(right),
+        };
+        let operators = twins
+            .iter()
+            .map(|plan| format!("{}", plan.operator))
+            .collect::<Vec<_>>();
+        assert_eq!(operators, vec!["Show Tables", "Show Views"]);
+
+        let (left, right) = twins.pop_twins();
+        assert!(matches!(left.operator, Operator::ShowTable));
+        assert!(matches!(right.operator, Operator::ShowView));
+    }
+
+    #[test]
+    fn logical_plan_collects_tables_explains_and_hashes_without_schema_cache() {
+        let table_arena = TableArenaCell::default();
+        let mut arena = PlanArena::new(&table_arena);
+        let id = column("id", LogicalType::Integer, &mut arena);
+        let scan = table_scan("users", vec![id]);
+        let mut plan = LimitOperator::build(Some(2), Some(5), scan);
+        plan.physical_option = Some(PhysicalOption::new(PlanImpl::Limit, SortOption::Follow));
+
+        let tables = plan
+            .referenced_table()
+            .into_iter()
+            .map(|table| table.to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(tables, vec!["users"]);
+        assert_eq!(
+            plan.explain(&mut arena, 0),
+            "Limit 5, Offset 2 [Limit => (Sort Option: Follow)] TableScan users -> [#0]"
+        );
+
+        let _ = plan.output_schema(&mut arena);
+        let cloned = plan.clone();
+        assert_eq!(plan, cloned);
+
+        let mut left = DefaultHasher::new();
+        let mut right = DefaultHasher::new();
+        plan.hash(&mut left);
+        cloned.hash(&mut right);
+        assert_eq!(left.finish(), right.finish());
+    }
+
+    #[test]
+    fn output_schema_inherits_from_child_and_can_be_recursively_reset() {
+        let table_arena = TableArenaCell::default();
+        let mut arena = PlanArena::new(&table_arena);
+        let id = column("id", LogicalType::Integer, &mut arena);
+        let name = column(
+            "name",
+            LogicalType::Varchar(None, crate::types::CharLengthUnits::Characters),
+            &mut arena,
+        );
+        let scan = table_scan("users", vec![id]);
+        let mut plan = LimitOperator::build(None, Some(10), scan);
+
+        let schema = plan.output_schema(&mut arena).clone();
+        assert_eq!(schema_names(&schema, &arena), vec!["id"]);
+
+        if let Childrens::Only(child) = plan.childrens.as_mut() {
+            if let Operator::TableScan(scan) = &mut child.operator {
+                scan.columns = vec![name];
+            }
+        }
+
+        let cached = plan.output_schema(&mut arena).clone();
+        assert_eq!(schema_names(&cached, &arena), vec!["id"]);
+
+        plan.reset_output_schema_cache_recursive();
+        let recomputed = plan.output_schema(&mut arena).clone();
+        assert_eq!(schema_names(&recomputed, &arena), vec!["name"]);
+    }
+
+    #[test]
+    fn dummy_operators_produce_expected_output_schema() {
+        let table_arena = TableArenaCell::default();
+        let mut arena = PlanArena::new(&table_arena);
+        let cases = [
+            (Operator::ShowTable, vec!["TABLE"]),
+            (Operator::ShowView, vec!["VIEW"]),
+            (Operator::Explain, vec!["PLAN"]),
+            (
+                Operator::Describe(DescribeOperator {
+                    table_name: "users".into(),
+                }),
+                vec![
+                    "FIELD",
+                    "TYPE",
+                    "LEN",
+                    "NULL",
+                    "Key",
+                    "DEFAULT",
+                    "COLUMN_REF",
+                ],
+            ),
+        ];
+
+        for (operator, expected) in cases {
+            let mut plan = LogicalPlan::new(operator, Childrens::None);
+            let schema = plan.output_schema(&mut arena).clone();
+            assert_eq!(schema_names(&schema, &arena), expected);
+        }
+    }
+}
+// GRCOV_EXCL_STOP

--- a/src/planner/operator/mod.rs
+++ b/src/planner/operator/mod.rs
@@ -430,3 +430,611 @@ impl fmt::Display for PlanImpl {
         }
     }
 }
+
+// GRCOV_EXCL_START
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use crate::catalog::view::View;
+    use crate::catalog::{ColumnCatalog, ColumnDesc, ColumnRef};
+    use crate::expression::function::table::{
+        ArcTableFunctionImpl, TableFunction, TableFunctionCatalog, TableFunctionImpl,
+    };
+    use crate::expression::ScalarExpression;
+    use crate::function::numbers::Numbers;
+    use crate::planner::operator::alter_table::change_column::{DefaultChange, NotNullChange};
+    use crate::planner::operator::delete::DeleteOperator;
+    use crate::planner::operator::mark_apply::MarkApplyQuantifier;
+    use crate::planner::operator::set_membership::SetMembershipKind;
+    use crate::planner::operator::sort::SortField;
+    use crate::planner::operator::values::ValuesOperator;
+    use crate::planner::{Childrens, LogicalPlan, TableArenaCell};
+    use crate::types::index::{IndexInfo, IndexMetaRef, IndexType};
+    use crate::types::value::DataValue;
+    use crate::types::LogicalType;
+
+    fn column_catalog(name: &str) -> ColumnCatalog {
+        ColumnCatalog::new(
+            name.to_string(),
+            true,
+            ColumnDesc::new(LogicalType::Integer, None, false, None).unwrap(),
+        )
+    }
+
+    fn column(name: &str, arena: &mut PlanArena) -> ColumnRef {
+        arena.alloc_column(column_catalog(name))
+    }
+
+    fn index_info() -> IndexInfo {
+        IndexInfo {
+            meta: IndexMetaRef::new(4),
+            sort_option: SortOption::None,
+            lookup: None,
+            residual_predicate: None,
+            covered_deserializers: None,
+            cover_mapping: None,
+            sort_elimination_hint: None,
+            stream_distinct_hint: None,
+        }
+    }
+
+    fn column_expr(column: ColumnRef, position: usize) -> ScalarExpression {
+        ScalarExpression::column_expr(column, position)
+    }
+
+    fn referenced_columns(operator: &Operator, arena: &mut PlanArena) -> Vec<ColumnRef> {
+        let mut columns = Vec::new();
+        operator.visit_referenced_columns(arena, &mut |_, column| {
+            columns.push(*column);
+            true
+        });
+        columns
+    }
+
+    #[test]
+    fn physical_option_and_sort_option_display() {
+        let sort_field = SortField::new(ScalarExpression::from(1i32), false, true);
+        let sort_option = SortOption::OrderBy {
+            fields: vec![sort_field],
+            ignore_prefix_len: 2,
+        };
+        assert_eq!(
+            sort_option.to_string(),
+            "OrderBy: (1 Desc Nulls First) ignore_prefix_len: 2"
+        );
+        assert_eq!(SortOption::Follow.to_string(), "Follow");
+        assert_eq!(SortOption::None.to_string(), "None");
+
+        let physical = PhysicalOption::new(PlanImpl::TopK, sort_option.clone());
+        assert_eq!(
+            physical.to_string(),
+            "TopK => (Sort Option: OrderBy: (1 Desc Nulls First) ignore_prefix_len: 2)"
+        );
+        assert_eq!(physical.sort_option(), &sort_option);
+    }
+
+    #[test]
+    fn plan_impl_display_covers_physical_variants() {
+        let cases = [
+            (PlanImpl::Dummy, "Dummy"),
+            (PlanImpl::SimpleAggregate, "SimpleAggregate"),
+            (PlanImpl::HashAggregate, "HashAggregate"),
+            (PlanImpl::StreamDistinct, "StreamDistinct"),
+            (PlanImpl::ScalarApply, "ScalarApply"),
+            (PlanImpl::MarkApply, "MarkApply"),
+            (PlanImpl::Filter, "Filter"),
+            (PlanImpl::HashJoin, "HashJoin"),
+            (PlanImpl::NestLoopJoin, "NestLoopJoin"),
+            (PlanImpl::Project, "Project"),
+            (PlanImpl::ScalarSubquery, "ScalarSubquery"),
+            (PlanImpl::SeqScan, "SeqScan"),
+            (PlanImpl::FunctionScan, "FunctionScan"),
+            (PlanImpl::Sort, "Sort"),
+            (PlanImpl::Limit, "Limit"),
+            (PlanImpl::TopK, "TopK"),
+            (PlanImpl::Values, "Values"),
+            (PlanImpl::Insert, "Insert"),
+            (PlanImpl::Update, "Update"),
+            (PlanImpl::Delete, "Delete"),
+            (PlanImpl::AddColumn, "AddColumn"),
+            (PlanImpl::ChangeColumn, "ChangeColumn"),
+            (PlanImpl::DropColumn, "DropColumn"),
+            (PlanImpl::CreateTable, "CreateTable"),
+            (PlanImpl::DropTable, "DropTable"),
+            (PlanImpl::Truncate, "Truncate"),
+            (PlanImpl::Show, "Show"),
+            (PlanImpl::Analyze, "Analyze"),
+        ];
+
+        for (plan, expected) in cases {
+            assert_eq!(plan.to_string(), expected);
+        }
+        assert_eq!(
+            PlanImpl::IndexScan(Box::new(index_info())).to_string(),
+            "IndexScan By #4 => EMPTY"
+        );
+    }
+
+    #[test]
+    fn referenced_column_helpers_stop_on_predicate_result() {
+        let table_arena = TableArenaCell::default();
+        let mut arena = PlanArena::new(&table_arena);
+        let left = column("left", &mut arena);
+        let right = column("right", &mut arena);
+        let values = Operator::Values(ValuesOperator {
+            rows: vec![vec![DataValue::Int32(1), DataValue::Int32(2)]],
+            schema_ref: vec![left, right],
+        });
+
+        assert!(values.any_referenced_column(&mut arena, |column| *column == right));
+        assert!(!values
+            .any_referenced_column(&mut arena, |column| { *column != left && *column != right }));
+        assert!(values
+            .all_referenced_columns(&mut arena, |column| { *column == left || *column == right }));
+        assert!(!values.all_referenced_columns(&mut arena, |column| *column == left));
+
+        let delete = Operator::Delete(DeleteOperator {
+            table_name: "users".into(),
+            primary_keys: vec![left],
+        });
+        assert!(delete.any_referenced_column(&mut arena, |column| *column == left));
+        assert!(Operator::Dummy.all_referenced_columns(&mut arena, |_| false));
+        assert!(!Operator::Dummy.any_referenced_column(&mut arena, |_| true));
+    }
+
+    #[test]
+    fn referenced_column_visitor_covers_expression_driven_variants() {
+        let table_arena = TableArenaCell::default();
+        let mut arena = PlanArena::new(&table_arena);
+        let a = column("a", &mut arena);
+        let b = column("b", &mut arena);
+        let c = column("c", &mut arena);
+        let d = column("d", &mut arena);
+
+        let aggregate = Operator::Aggregate(AggregateOperator {
+            agg_calls: vec![column_expr(a, 0)],
+            groupby_exprs: vec![column_expr(b, 1)],
+            is_distinct: false,
+        });
+        assert_eq!(referenced_columns(&aggregate, &mut arena), vec![a, b]);
+
+        let mark_apply =
+            Operator::MarkApply(MarkApplyOperator::new_exists(d, vec![column_expr(c, 2)]));
+        assert_eq!(referenced_columns(&mark_apply, &mut arena), vec![c]);
+
+        let filter = Operator::Filter(FilterOperator {
+            predicate: column_expr(a, 0),
+            is_optimized: false,
+            having: false,
+        });
+        assert_eq!(referenced_columns(&filter, &mut arena), vec![a]);
+
+        let join = Operator::Join(JoinOperator {
+            join_type: join::JoinType::Inner,
+            on: JoinCondition::On {
+                on: vec![(column_expr(a, 0), column_expr(b, 1))],
+                filter: Some(column_expr(c, 2)),
+            },
+        });
+        assert_eq!(referenced_columns(&join, &mut arena), vec![a, b, c]);
+        assert!(!join.all_referenced_columns(&mut arena, |column| *column == a));
+
+        let project = Operator::Project(ProjectOperator {
+            exprs: vec![column_expr(b, 1), column_expr(c, 2)],
+        });
+        assert_eq!(referenced_columns(&project, &mut arena), vec![b, c]);
+
+        let table_scan = Operator::TableScan(TableScanOperator {
+            table_name: "users".into(),
+            columns: vec![a, d],
+            limit: (None, None),
+            index_infos: Vec::new(),
+            with_pk: false,
+        });
+        assert_eq!(referenced_columns(&table_scan, &mut arena), vec![a, d]);
+
+        let function_scan = Operator::FunctionScan(FunctionScanOperator {
+            table_function: TableFunction {
+                args: vec![column_expr(c, 2)],
+                catalog: TableFunctionCatalog {
+                    schema: Vec::new(),
+                    inner: ArcTableFunctionImpl(Numbers::new()),
+                },
+            },
+        });
+        assert_eq!(referenced_columns(&function_scan, &mut arena), vec![c]);
+
+        let sort = Operator::Sort(SortOperator {
+            sort_fields: vec![SortField::from(column_expr(a, 0))],
+            limit: None,
+        });
+        assert_eq!(referenced_columns(&sort, &mut arena), vec![a]);
+
+        let top_k = Operator::TopK(TopKOperator {
+            sort_fields: vec![SortField::from(column_expr(b, 1))],
+            limit: 3,
+            offset: None,
+        });
+        assert_eq!(referenced_columns(&top_k, &mut arena), vec![b]);
+
+        let union = Operator::Union(UnionOperator {
+            left_schema_ref: vec![a],
+            _right_schema_ref: vec![b],
+        });
+        assert_eq!(referenced_columns(&union, &mut arena), vec![a, b]);
+
+        let set_membership = Operator::SetMembership(SetMembershipOperator {
+            kind: SetMembershipKind::Intersect,
+            left_schema_ref: vec![c],
+            _right_schema_ref: vec![d],
+        });
+        assert_eq!(referenced_columns(&set_membership, &mut arena), vec![c, d]);
+
+        let delete = Operator::Delete(DeleteOperator {
+            table_name: "users".into(),
+            primary_keys: vec![a],
+        });
+        assert_eq!(referenced_columns(&delete, &mut arena), vec![a]);
+
+        let no_reference_operators = [
+            Operator::ScalarApply(ScalarApplyOperator),
+            Operator::ScalarSubquery(ScalarSubqueryOperator),
+            Operator::Analyze(AnalyzeOperator {
+                table_name: "users".into(),
+                index_metas: vec![IndexMetaRef::new(1)],
+                histogram_buckets: Some(8),
+            }),
+        ];
+        for operator in no_reference_operators {
+            assert!(referenced_columns(&operator, &mut arena).is_empty());
+        }
+    }
+
+    #[test]
+    fn mark_apply_constructors_and_accessors_cover_quantified_paths() {
+        let left = LogicalPlan::new(Operator::ShowTable, Childrens::None);
+        let right = LogicalPlan::new(Operator::ShowView, Childrens::None);
+        let output = ColumnRef::new(10);
+        let probe = ScalarExpression::from(true);
+
+        let mut any = MarkApplyOperator::new_in(output, vec![ScalarExpression::from(1_i32)]);
+        assert_eq!(any.to_string(), "MarkAnyApply");
+        assert_eq!(any.predicates().len(), 1);
+        any.predicates_mut().push(ScalarExpression::from(2_i32));
+        assert_eq!(any.predicates().len(), 2);
+        assert_eq!(*any.output_column(), output);
+        assert!(any.parameterized_probe().is_none());
+        any.set_parameterized_probe(Some(probe.clone()));
+        assert_eq!(any.parameterized_probe(), Some(&probe));
+        any.set_parameterized_probe(None);
+        assert!(any.parameterized_probe().is_none());
+
+        let all = MarkApplyOperator::new_quantified(
+            MarkApplyQuantifier::All,
+            output,
+            vec![ScalarExpression::from(false)],
+        );
+        assert_eq!(all.to_string(), "MarkAllApply");
+
+        let in_plan = MarkApplyOperator::build_in(
+            left.clone(),
+            right.clone(),
+            output,
+            vec![ScalarExpression::from(1_i32)],
+        );
+        assert_eq!(in_plan.operator.to_string(), "MarkAnyApply");
+        assert!(matches!(*in_plan.childrens, Childrens::Twins { .. }));
+
+        let all_plan = MarkApplyOperator::build_quantified(
+            left,
+            right,
+            MarkApplyQuantifier::All,
+            output,
+            vec![ScalarExpression::from(1_i32)],
+        );
+        assert_eq!(all_plan.operator.to_string(), "MarkAllApply");
+        assert!(matches!(*all_plan.childrens, Childrens::Twins { .. }));
+    }
+
+    #[test]
+    fn ddl_operator_display_formats_table_index_and_column_actions() {
+        let table_arena = TableArenaCell::default();
+        let mut arena = PlanArena::new(&table_arena);
+        let id = column("id", &mut arena);
+        let name = column("name", &mut arena);
+
+        let view = View {
+            name: "active_users".into(),
+            plan: Box::new(LogicalPlan::new(Operator::ShowTable, Childrens::None)),
+            schema: vec![id],
+        };
+
+        let cases = [
+            (
+                Operator::CreateTable(CreateTableOperator {
+                    table_name: "users".into(),
+                    columns: vec![column_catalog("id"), column_catalog("name")],
+                    if_not_exists: true,
+                }),
+                "Create users -> [id, name], If Not Exists: true",
+            ),
+            (
+                Operator::CreateIndex(CreateIndexOperator {
+                    table_name: "users".into(),
+                    columns: vec![id, name],
+                    index_name: "idx_users_name".to_string(),
+                    if_not_exists: false,
+                    ty: IndexType::Normal,
+                }),
+                "Create Index On users -> [#0, #1], If Not Exists: false",
+            ),
+            (
+                Operator::CreateView(CreateViewOperator {
+                    view,
+                    or_replace: true,
+                }),
+                "Create View as View active_users, Or Replace: true",
+            ),
+            (
+                Operator::DropTable(DropTableOperator {
+                    table_name: "users".into(),
+                    if_exists: true,
+                }),
+                "Drop Table users, If Exists: true",
+            ),
+            (
+                Operator::DropView(DropViewOperator {
+                    view_name: "active_users".into(),
+                    if_exists: false,
+                }),
+                "Drop View active_users, If Exists: false",
+            ),
+            (
+                Operator::DropColumn(DropColumnOperator {
+                    table_name: "users".into(),
+                    column_name: "age".to_string(),
+                    if_exists: true,
+                }),
+                "Drop age -> users, If Exists: true",
+            ),
+            (
+                Operator::AddColumn(AddColumnOperator {
+                    table_name: "users".into(),
+                    if_not_exists: true,
+                    column: column_catalog("age"),
+                }),
+                "Add age -> users, If Not Exists: true",
+            ),
+            (
+                Operator::ChangeColumn(ChangeColumnOperator {
+                    table_name: "users".into(),
+                    old_column_name: "age".to_string(),
+                    new_column_name: "age_years".to_string(),
+                    data_type: LogicalType::Integer,
+                    default_change: DefaultChange::Drop,
+                    not_null_change: NotNullChange::Set,
+                }),
+                "Change age -> users.age_years (Integer, Drop, Set)",
+            ),
+            (
+                Operator::Truncate(TruncateOperator {
+                    table_name: "users".into(),
+                }),
+                "Truncate users",
+            ),
+        ];
+
+        for (operator, expected) in cases {
+            assert_eq!(operator.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn dml_values_describe_and_analyze_display_formats_payloads() {
+        let table_arena = TableArenaCell::default();
+        let mut arena = PlanArena::new(&table_arena);
+        let id = column("id", &mut arena);
+
+        let cases = [
+            (
+                Operator::Insert(InsertOperator {
+                    table_name: "users".into(),
+                    is_overwrite: true,
+                    is_mapping_by_name: false,
+                }),
+                "Insert users, Is Overwrite: true, Is Mapping By Name: false",
+            ),
+            (
+                Operator::Update(UpdateOperator {
+                    table_name: "users".into(),
+                    value_exprs: vec![(id, ScalarExpression::from(7_i32))],
+                }),
+                "Update users set #0 -> 7",
+            ),
+            (
+                Operator::Delete(DeleteOperator {
+                    table_name: "users".into(),
+                    primary_keys: vec![id],
+                }),
+                "Delete users",
+            ),
+            (
+                Operator::Describe(DescribeOperator {
+                    table_name: "users".into(),
+                }),
+                "Describe users",
+            ),
+            (
+                Operator::Values(ValuesOperator {
+                    rows: vec![
+                        vec![DataValue::Int32(1), DataValue::Int32(2)],
+                        vec![DataValue::Int32(3)],
+                    ],
+                    schema_ref: vec![id],
+                }),
+                "Values [1, 2], [3], RowsLen: 2",
+            ),
+            (
+                Operator::Analyze(AnalyzeOperator {
+                    table_name: "users".into(),
+                    index_metas: vec![IndexMetaRef::new(3)],
+                    histogram_buckets: Some(128),
+                }),
+                "Analyze users -> [#3]",
+            ),
+        ];
+
+        for (operator, expected) in cases {
+            assert_eq!(operator.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn sort_and_top_k_display_fields_and_build_single_child_plan() {
+        let descending_nulls_first = SortField::from(ScalarExpression::from(9_i32))
+            .desc()
+            .nulls_first();
+        let ascending_nulls_last = SortField::new(ScalarExpression::from(1_i32), false, true)
+            .asc()
+            .nulls_last();
+
+        let sort = Operator::Sort(SortOperator {
+            sort_fields: vec![descending_nulls_first.clone(), ascending_nulls_last.clone()],
+            limit: Some(10),
+        });
+        assert_eq!(
+            sort.to_string(),
+            "Sort By 9 Desc Nulls First, 1 Asc Nulls Last, Limit 10"
+        );
+
+        let child = LogicalPlan::new(Operator::ShowTable, Childrens::None);
+        let top_k = TopKOperator::build(vec![descending_nulls_first], 5, Some(2), child);
+        assert_eq!(
+            top_k.operator.to_string(),
+            "Top 5, Offset 2, Sort By 9 Desc Nulls First"
+        );
+        assert!(matches!(*top_k.childrens, Childrens::Only(_)));
+
+        let top_k_without_offset = Operator::TopK(TopKOperator {
+            sort_fields: vec![ascending_nulls_last],
+            limit: 3,
+            offset: None,
+        });
+        assert_eq!(
+            top_k_without_offset.to_string(),
+            "Top 3, Sort By 1 Asc Nulls Last"
+        );
+    }
+
+    #[test]
+    fn drop_index_build_preserves_operator_payload_and_children() {
+        let plan = DropIndexOperator::build(
+            "users".into(),
+            "idx_users_id".to_string(),
+            true,
+            Childrens::None,
+        );
+
+        assert_eq!(
+            plan.operator.to_string(),
+            "Drop Index idx_users_id On users, If Exists: true"
+        );
+        assert!(matches!(*plan.childrens, Childrens::None));
+    }
+
+    #[test]
+    fn function_scan_display_and_build_preserve_table_function() {
+        let table_arena = TableArenaCell::default();
+        let numbers = Numbers::new();
+        let mut schema = Vec::new();
+        numbers.output_schema_into(table_arena.borrow_mut(), &mut schema);
+        let table_function = TableFunction {
+            args: vec![ScalarExpression::from(3_i32)],
+            catalog: TableFunctionCatalog {
+                schema,
+                inner: ArcTableFunctionImpl(numbers),
+            },
+        };
+
+        let plan = FunctionScanOperator::build(table_function);
+
+        assert_eq!(plan.operator.to_string(), "Function Scan: numbers");
+        assert!(matches!(*plan.childrens, Childrens::None));
+    }
+
+    #[test]
+    fn set_membership_display_and_build_cover_both_kinds() {
+        let table_arena = TableArenaCell::default();
+        let mut arena = PlanArena::new(&table_arena);
+        let left_col = column("left_id", &mut arena);
+        let right_col = column("right_id", &mut arena);
+        let left = LogicalPlan::new(Operator::ShowTable, Childrens::None);
+        let right = LogicalPlan::new(Operator::ShowView, Childrens::None);
+
+        let plan = SetMembershipOperator::build(
+            SetMembershipKind::Intersect,
+            vec![left_col],
+            vec![right_col],
+            left,
+            right,
+        );
+
+        assert_eq!(plan.operator.to_string(), "Intersect: [#0]");
+        assert!(matches!(*plan.childrens, Childrens::Twins { .. }));
+        assert_eq!(
+            Operator::SetMembership(SetMembershipOperator {
+                kind: SetMembershipKind::Except,
+                left_schema_ref: vec![left_col],
+                _right_schema_ref: vec![right_col],
+            })
+            .to_string(),
+            "Except: [#0]"
+        );
+    }
+
+    #[test]
+    fn scalar_apply_and_subquery_build_expected_child_shapes() {
+        let left = LogicalPlan::new(Operator::ShowTable, Childrens::None);
+        let right = LogicalPlan::new(Operator::ShowView, Childrens::None);
+
+        let apply = ScalarApplyOperator::build(left.clone(), right);
+        assert_eq!(apply.operator.to_string(), "ScalarApply");
+        assert!(matches!(*apply.childrens, Childrens::Twins { .. }));
+
+        let subquery = ScalarSubqueryOperator::build(left);
+        assert_eq!(subquery.operator.to_string(), "ScalarSubquery");
+        assert!(matches!(*subquery.childrens, Childrens::Only(_)));
+    }
+
+    #[cfg(feature = "copy")]
+    #[test]
+    fn copy_from_file_display_formats_source_table_and_schema() {
+        use crate::binder::copy::{ExtSource, FileFormat};
+        use std::path::PathBuf;
+
+        let table_arena = TableArenaCell::default();
+        let mut arena = PlanArena::new(&table_arena);
+        let id = column("id", &mut arena);
+        let name = column("name", &mut arena);
+
+        let operator = Operator::CopyFromFile(CopyFromFileOperator {
+            table: "users".into(),
+            source: ExtSource {
+                path: PathBuf::from("/tmp/users.csv"),
+                format: FileFormat::Csv {
+                    delimiter: ',',
+                    quote: '"',
+                    escape: None,
+                    header: true,
+                },
+            },
+            schema_ref: vec![id, name],
+        });
+
+        assert_eq!(
+            operator.to_string(),
+            "Copy /tmp/users.csv -> users [#0, #1]"
+        );
+    }
+}
+// GRCOV_EXCL_STOP


### PR DESCRIPTION
## Summary
- include the orm feature in coverage runs so src/orm is measured by codecov
- add focused unit tests for error formatting, planner schema/operator behavior, and ORM conversion/helper paths
- cover planner DDL/DML/display operator paths and ORM database/transaction helper APIs
