### PR TITLE
test: improve serde optimizer binder coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CODECOV_OUTPUT ?= lcov.info
 COVERAGE_PROFILE_DIR ?= target/grcov/profraw
 COVERAGE_HTML_DIR ?= target/grcov/html
 COVERAGE_RUSTFLAGS ?= -Cinstrument-coverage
-COVERAGE_TEST_FEATURES ?= decimal,orm
+COVERAGE_TEST_FEATURES ?= copy,decimal,orm
 COVERAGE_REPORT_ARGS ?= --llvm --ignore-not-existing --keep-only 'src/**' --ignore 'src/**/tests/**' --ignore 'tests/**' --ignore 'tpcc/**' --excl-start 'GRCOV_EXCL_START' --excl-stop 'GRCOV_EXCL_STOP'
 
 .PHONY: test test-python test-wasm test-slt test-all codecov codecov-html wasm-build check tpcc tpcc-kitesql-rocksdb tpcc-kitesql-lmdb tpcc-lmdb-flamegraph tpcc-lmdb-heaptrack tpcc-sqlite tpcc-sqlite-practical tpcc-sqlite-balanced tpcc-dual cargo-check build wasm-examples native-examples fmt clippy

--- a/src/binder/aggregate.rs
+++ b/src/binder/aggregate.rs
@@ -17,6 +17,7 @@ use std::collections::HashSet;
 use super::{Binder, QueryBindStep};
 use crate::errors::DatabaseError;
 use crate::expression::function::scala::ScalarFunction;
+use crate::expression::visitor::{walk_expr, Visitor};
 use crate::expression::visitor_mut::{walk_mut_expr, VisitorMut};
 use crate::planner::LogicalPlan;
 use crate::storage::Transaction;
@@ -321,148 +322,57 @@ impl<T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<'_, '_, T, A>
             return Ok(());
         }
 
+        HavingOrderByValidator::new(&self.context.group_by_exprs, &self.context.agg_calls)
+            .visit(expr)
+    }
+}
+
+struct HavingOrderByValidator<'a> {
+    group_by_exprs: &'a [ScalarExpression],
+    agg_calls: &'a [ScalarExpression],
+}
+
+impl<'a> HavingOrderByValidator<'a> {
+    fn new(group_by_exprs: &'a [ScalarExpression], agg_calls: &'a [ScalarExpression]) -> Self {
+        Self {
+            group_by_exprs,
+            agg_calls,
+        }
+    }
+
+    fn agg_miss(expr: &ScalarExpression) -> DatabaseError {
+        DatabaseError::AggMiss(format!(
+            "expression '{expr}' must appear in the GROUP BY clause or be used in an aggregate function"
+        ))
+    }
+}
+
+impl<'expr> Visitor<'expr> for HavingOrderByValidator<'_> {
+    fn visit(&mut self, expr: &'expr ScalarExpression) -> Result<(), DatabaseError> {
         match expr {
             ScalarExpression::AggCall { .. } => {
-                if self.context.group_by_exprs.contains(expr)
-                    || self.context.agg_calls.contains(expr)
-                {
-                    return Ok(());
+                if self.group_by_exprs.contains(expr) || self.agg_calls.contains(expr) {
+                    Ok(())
+                } else {
+                    Err(Self::agg_miss(expr))
                 }
-
-                Err(DatabaseError::AggMiss(format!(
-                    "expression '{expr}' must appear in the GROUP BY clause or be used in an aggregate function"
-                )))
             }
-            ScalarExpression::ColumnRef { .. } | ScalarExpression::Alias { .. } => {
-                if self.context.group_by_exprs.contains(expr) {
-                    return Ok(());
+            ScalarExpression::ColumnRef { .. } => {
+                if self.group_by_exprs.contains(expr) {
+                    Ok(())
+                } else {
+                    Err(Self::agg_miss(expr))
                 }
-                if matches!(expr, ScalarExpression::Alias { .. }) {
-                    return self.validate_having_orderby(expr.unpack_alias_ref());
+            }
+            ScalarExpression::Alias { .. } => {
+                if self.group_by_exprs.contains(expr) {
+                    Ok(())
+                } else {
+                    self.visit(expr.unpack_alias_ref())
                 }
-
-                Err(DatabaseError::AggMiss(format!(
-                    "expression '{expr}' must appear in the GROUP BY clause or be used in an aggregate function"
-                )))
             }
-
-            ScalarExpression::TypeCast { expr, .. } => self.validate_having_orderby(expr),
-            ScalarExpression::IsNull { expr, .. } => self.validate_having_orderby(expr),
-            ScalarExpression::Unary { expr, .. } => self.validate_having_orderby(expr),
-            ScalarExpression::In { expr, args, .. } => {
-                self.validate_having_orderby(expr)?;
-                for arg in args {
-                    self.validate_having_orderby(arg)?;
-                }
-                Ok(())
-            }
-            ScalarExpression::Binary {
-                left_expr,
-                right_expr,
-                ..
-            } => {
-                self.validate_having_orderby(left_expr)?;
-                self.validate_having_orderby(right_expr)?;
-                Ok(())
-            }
-            ScalarExpression::Between {
-                expr,
-                left_expr,
-                right_expr,
-                ..
-            } => {
-                self.validate_having_orderby(expr)?;
-                self.validate_having_orderby(left_expr)?;
-                self.validate_having_orderby(right_expr)?;
-                Ok(())
-            }
-            ScalarExpression::SubString {
-                expr,
-                for_expr,
-                from_expr,
-            } => {
-                self.validate_having_orderby(expr)?;
-                if let Some(expr) = for_expr {
-                    self.validate_having_orderby(expr)?;
-                }
-                if let Some(expr) = from_expr {
-                    self.validate_having_orderby(expr)?;
-                }
-                Ok(())
-            }
-            ScalarExpression::Position { expr, in_expr } => {
-                self.validate_having_orderby(expr)?;
-                self.validate_having_orderby(in_expr)?;
-                Ok(())
-            }
-            ScalarExpression::Trim {
-                expr,
-                trim_what_expr,
-                ..
-            } => {
-                self.validate_having_orderby(expr)?;
-                if let Some(trim_what_expr) = trim_what_expr {
-                    self.validate_having_orderby(trim_what_expr)?;
-                }
-                Ok(())
-            }
-            ScalarExpression::Constant(_) => Ok(()),
-            ScalarExpression::Empty => unreachable!(),
-            ScalarExpression::Tuple(args)
-            | ScalarExpression::ScalaFunction(ScalarFunction { args, .. })
-            | ScalarExpression::Coalesce { exprs: args, .. } => {
-                for expr in args {
-                    self.validate_having_orderby(expr)?;
-                }
-                Ok(())
-            }
-            ScalarExpression::If {
-                condition,
-                left_expr,
-                right_expr,
-                ..
-            } => {
-                self.validate_having_orderby(condition)?;
-                self.validate_having_orderby(left_expr)?;
-                self.validate_having_orderby(right_expr)?;
-
-                Ok(())
-            }
-            ScalarExpression::IfNull {
-                left_expr,
-                right_expr,
-                ..
-            }
-            | ScalarExpression::NullIf {
-                left_expr,
-                right_expr,
-                ..
-            } => {
-                self.validate_having_orderby(left_expr)?;
-                self.validate_having_orderby(right_expr)?;
-
-                Ok(())
-            }
-            ScalarExpression::CaseWhen {
-                operand_expr,
-                expr_pairs,
-                else_expr,
-                ..
-            } => {
-                if let Some(expr) = operand_expr {
-                    self.validate_having_orderby(expr)?;
-                }
-                for (expr_1, expr_2) in expr_pairs {
-                    self.validate_having_orderby(expr_1)?;
-                    self.validate_having_orderby(expr_2)?;
-                }
-                if let Some(expr) = else_expr {
-                    self.validate_having_orderby(expr)?;
-                }
-
-                Ok(())
-            }
-            ScalarExpression::TableFunction(_) => unreachable!(),
+            ScalarExpression::Empty | ScalarExpression::TableFunction(_) => unreachable!(),
+            _ => walk_expr(self, expr),
         }
     }
 }
@@ -538,12 +448,16 @@ impl<'a> VisitorMut<'a> for AggregateOutputBinder<'_, '_> {
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::AggregateOutputBinder;
+    use crate::binder::test::build_t1_table;
+    use crate::binder::{Binder, BinderContext};
     use crate::catalog::{ColumnCatalog, ColumnDesc, ColumnRef};
     use crate::errors::DatabaseError;
     use crate::expression::agg::AggKind;
     use crate::expression::visitor_mut::VisitorMut;
-    use crate::expression::{AliasType, ScalarExpression};
+    use crate::expression::{AliasType, BinaryOperator, ScalarExpression};
     use crate::planner::PlanArena;
+    use crate::storage::Storage;
+    use crate::types::value::DataValue;
     use crate::types::LogicalType;
 
     fn test_column(arena: &mut PlanArena, name: &str, ty: LogicalType) -> ColumnRef {
@@ -635,6 +549,67 @@ mod tests {
         }
         let expected = ScalarExpression::column_expr(group_output.output_column_ref(&mut arena), 0);
         assert!(target.eq_ignore_colref_pos(&expected, &arena));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_validate_having_orderby_rejects_missing_group_expr() -> Result<(), DatabaseError> {
+        let tables = build_t1_table()?;
+        let scala_functions = Default::default();
+        let table_functions = Default::default();
+        let transaction = tables.storage.transaction()?;
+        let args: [(&'static str, DataValue); 0] = [];
+        let mut binder = Binder::new(
+            BinderContext::new(
+                &tables.table_cache,
+                &tables.view_cache,
+                &transaction,
+                &scala_functions,
+                &table_functions,
+            ),
+            &args,
+            None,
+        );
+        let table_arena = crate::planner::TableArenaCell::default();
+        let mut arena = PlanArena::new(&table_arena);
+        let group_column = test_column(&mut arena, "c1", LogicalType::Integer);
+        let missing_column = test_column(&mut arena, "c2", LogicalType::Integer);
+        let group_expr = ScalarExpression::column_expr(group_column, 0);
+        let missing_expr = ScalarExpression::column_expr(missing_column, 1);
+        binder.context.group_by_exprs.push(group_expr.clone());
+
+        binder.validate_having_orderby(&group_expr)?;
+        let group_alias = ScalarExpression::Alias {
+            expr: Box::new(group_expr.clone()),
+            alias: AliasType::Name("group_alias".to_string()),
+        };
+        binder.validate_having_orderby(&group_alias)?;
+
+        assert!(matches!(
+            binder.validate_having_orderby(&missing_expr),
+            Err(DatabaseError::AggMiss(_))
+        ));
+
+        let registered_agg = test_count(missing_expr.clone());
+        binder.context.agg_calls.push(registered_agg.clone());
+        binder.validate_having_orderby(&registered_agg)?;
+        assert!(matches!(
+            binder.validate_having_orderby(&test_count(ScalarExpression::Constant(1_i32.into()))),
+            Err(DatabaseError::AggMiss(_))
+        ));
+
+        let invalid_binary = ScalarExpression::Binary {
+            op: BinaryOperator::Eq,
+            left_expr: Box::new(group_expr),
+            right_expr: Box::new(missing_expr),
+            evaluator: None,
+            ty: LogicalType::Boolean,
+        };
+        assert!(matches!(
+            binder.validate_having_orderby(&invalid_binary),
+            Err(DatabaseError::AggMiss(_))
+        ));
 
         Ok(())
     }

--- a/src/binder/parser.rs
+++ b/src/binder/parser.rs
@@ -2840,3 +2840,229 @@ impl<'a, 'parent, T: Transaction, A: AsRef<[(&'static str, DataValue)]>> Binder<
         Ok(self.build_statement(arena).statement(stmt)?.finish())
     }
 }
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use crate::binder::test::build_t1_table;
+    use crate::binder::BinderContext;
+    use crate::db::DataBaseBuilder;
+    use crate::errors::SqlErrorSpan;
+    use crate::storage::Storage;
+    use sqlparser::tokenizer::Location;
+
+    fn assert_unsupported(err: DatabaseError, expected: &str) {
+        let DatabaseError::UnsupportedStmt(message) = err else {
+            panic!("expected unsupported statement, got {err:?}");
+        };
+        assert!(message.contains(expected), "{message}");
+    }
+
+    fn expect_err<T>(result: Result<T, DatabaseError>) -> DatabaseError {
+        match result {
+            Ok(_) => panic!("expected error"),
+            Err(err) => err,
+        }
+    }
+
+    #[test]
+    fn test_prepare_and_command_type_classification() -> Result<(), DatabaseError> {
+        assert!(matches!(
+            prepare_all(""),
+            Err(DatabaseError::EmptyStatement)
+        ));
+        assert_eq!(command_type(&prepare("select 1")?)?, CommandType::DQL);
+        assert_eq!(
+            command_type(&prepare("create table t (id int primary key)")?)?,
+            CommandType::DDL
+        );
+        assert_eq!(
+            command_type(&prepare("analyze table t")?)?,
+            CommandType::Analyze
+        );
+        assert_eq!(
+            command_type(&prepare("insert into t values (1)")?)?,
+            CommandType::DML
+        );
+        assert_eq!(
+            command_type(&prepare("update t set id = 1")?)?,
+            CommandType::DML
+        );
+        assert_eq!(command_type(&prepare("delete from t")?)?, CommandType::DML);
+        assert_eq!(
+            command_type(&prepare("truncate table t")?)?,
+            CommandType::DML
+        );
+
+        let err = command_type(&prepare("start transaction")?).unwrap_err();
+        assert_unsupported(err, "START TRANSACTION");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_database_entrypoints_reject_catalog_mutation() -> Result<(), DatabaseError> {
+        let mut database = DataBaseBuilder::path(".").build_in_memory()?;
+        let params = &[] as &[(&'static str, DataValue)];
+
+        let ddl = prepare("create table t (id int primary key)")?;
+        assert_unsupported(
+            expect_err(database.execute(&ddl, params)),
+            "DDL and ANALYZE",
+        );
+        assert_unsupported(
+            expect_err(database.run("create table t (id int primary key)")),
+            "DDL and ANALYZE",
+        );
+        assert_unsupported(expect_err(database.ddl("select 1")), "`Database::ddl`");
+
+        let analyze = prepare("analyze table t")?;
+        let mut transaction = database.new_transaction()?;
+        assert_unsupported(
+            expect_err(transaction.execute(&analyze, params)),
+            "not allowed to execute within a transaction",
+        );
+        transaction.commit()?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_attach_span_if_absent() {
+        let span = Span::new(Location::new(3, 5), Location::new(3, 5));
+        let err = attach_span_if_absent(DatabaseError::invalid_column("bad"), span);
+        assert_eq!(
+            err.sql_error_span(),
+            Some(&SqlErrorSpan {
+                start: 5,
+                end: 6,
+                line: 3,
+                highlight: None,
+            })
+        );
+
+        let existing = SqlErrorSpan {
+            start: 1,
+            end: 2,
+            line: 1,
+            highlight: None,
+        };
+        let err = attach_span_if_absent(
+            DatabaseError::invalid_column("bad").with_span(existing.clone()),
+            Span::new(Location::new(4, 8), Location::new(4, 9)),
+        );
+        assert_eq!(err.sql_error_span(), Some(&existing));
+
+        let err = attach_span_if_absent(DatabaseError::invalid_column("bad"), Span::empty());
+        assert_eq!(err.sql_error_span(), None);
+    }
+
+    #[test]
+    fn test_alter_table_parser_errors() -> Result<(), DatabaseError> {
+        let tables = build_t1_table()?;
+
+        assert_unsupported(
+            tables
+                .plan("alter table t1 add column c5 int null, add column c6 int null")
+                .unwrap_err(),
+            "only a single ALTER TABLE operation",
+        );
+        assert_unsupported(
+            tables
+                .plan("alter table t1 drop column c1, drop column c2")
+                .unwrap_err(),
+            "only a single ALTER TABLE operation",
+        );
+
+        let mut stmt = prepare("alter table t1 drop column c1")?;
+        let Statement::AlterTable(alter) = &mut stmt else {
+            unreachable!("expected alter table statement")
+        };
+        alter.operations = vec![AlterTableOperation::DropColumn {
+            has_column_keyword: true,
+            column_names: vec![Ident::new("c1"), Ident::new("c2")],
+            if_exists: false,
+            drop_behavior: None,
+        }];
+        let scala_functions = Default::default();
+        let table_functions = Default::default();
+        let transaction = tables.storage.transaction()?;
+        let mut binder = Binder::new(
+            BinderContext::new(
+                &tables.table_cache,
+                &tables.view_cache,
+                &transaction,
+                &scala_functions,
+                &table_functions,
+            ),
+            &[],
+            None,
+        );
+        let mut arena = PlanArena::new(&tables.table_arena);
+        assert_unsupported(
+            binder.bind(&stmt, &mut arena).unwrap_err(),
+            "only dropping a single column",
+        );
+
+        assert!(matches!(
+            tables
+                .plan("alter table t1 rename column c1 to \"bad-name\"")
+                .unwrap_err(),
+            DatabaseError::InvalidColumn { .. }
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_limit_parser_rejects_negative_and_non_constant_values() -> Result<(), DatabaseError> {
+        let tables = build_t1_table()?;
+
+        assert!(matches!(
+            tables.plan("select * from t1 limit -1").unwrap_err(),
+            DatabaseError::InvalidColumn { .. }
+        ));
+        assert!(matches!(
+            tables.plan("select * from t1 limit 1.5").unwrap_err(),
+            DatabaseError::InvalidType
+        ));
+        assert!(matches!(
+            tables.plan("select * from t1 limit c1").unwrap_err(),
+            DatabaseError::InvalidColumn { .. }
+        ));
+
+        Ok(())
+    }
+
+    #[cfg(feature = "copy")]
+    #[test]
+    fn test_copy_file_format_options() -> Result<(), DatabaseError> {
+        let format = copy_file_format(vec![
+            CopyOption::Delimiter('|'),
+            CopyOption::Header(true),
+            CopyOption::Quote('\''),
+            CopyOption::Escape('\\'),
+        ])?;
+        assert_eq!(
+            format,
+            FileFormat::Csv {
+                delimiter: '|',
+                quote: '\'',
+                escape: Some('\\'),
+                header: true,
+            }
+        );
+
+        let source = copy_ext_source(
+            CopyTarget::File {
+                filename: "in.csv".to_string(),
+            },
+            vec![],
+        )?;
+        assert_eq!(source.path, std::path::PathBuf::from("in.csv"));
+        assert!(copy_ext_source(CopyTarget::Stdout, vec![]).is_err());
+        assert!(copy_file_format(vec![CopyOption::Null("NULL".to_string())]).is_err());
+
+        Ok(())
+    }
+}

--- a/src/optimizer/plan_utils.rs
+++ b/src/optimizer/plan_utils.rs
@@ -115,3 +115,105 @@ pub fn wrap_child_with(plan: &mut LogicalPlan, child_idx: usize, operator: Opera
 fn take_childrens(plan: &mut LogicalPlan) -> Childrens {
     mem::replace(&mut *plan.childrens, Childrens::None)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn leaf(operator: Operator) -> LogicalPlan {
+        LogicalPlan::new(operator, Childrens::None)
+    }
+
+    #[test]
+    fn child_accessors_cover_all_child_shapes() {
+        let mut none = leaf(Operator::Dummy);
+        assert_eq!(child_count(&none), 0);
+        assert!(only_child(&none).is_none());
+        assert!(only_child_mut(&mut none).is_none());
+        assert!(left_child_mut(&mut none).is_none());
+        assert!(right_child_mut(&mut none).is_none());
+        assert!(child(&none, 0).is_none());
+        assert!(children(&none).is_empty());
+
+        let mut only = LogicalPlan::new(
+            Operator::Dummy,
+            Childrens::Only(Box::new(leaf(Operator::ShowTable))),
+        );
+        assert_eq!(child_count(&only), 1);
+        assert!(matches!(
+            only_child(&only).unwrap().operator,
+            Operator::ShowTable
+        ));
+        assert!(only_child_mut(&mut only).is_some());
+        assert!(left_child_mut(&mut only).is_some());
+        assert!(right_child_mut(&mut only).is_none());
+        assert!(matches!(
+            child(&only, 0).unwrap().operator,
+            Operator::ShowTable
+        ));
+        assert!(child(&only, 1).is_none());
+        assert_eq!(children(&only).len(), 1);
+
+        let mut twins = LogicalPlan::new(
+            Operator::Dummy,
+            Childrens::Twins {
+                left: Box::new(leaf(Operator::ShowTable)),
+                right: Box::new(leaf(Operator::ShowView)),
+            },
+        );
+        assert_eq!(child_count(&twins), 2);
+        assert!(only_child(&twins).is_none());
+        assert!(left_child_mut(&mut twins).is_some());
+        assert!(right_child_mut(&mut twins).is_some());
+        assert!(matches!(
+            child(&twins, 0).unwrap().operator,
+            Operator::ShowTable
+        ));
+        assert!(matches!(
+            child(&twins, 1).unwrap().operator,
+            Operator::ShowView
+        ));
+        assert!(child(&twins, 2).is_none());
+        assert_eq!(children(&twins).len(), 2);
+    }
+
+    #[test]
+    fn replace_and_wrap_child_helpers_update_expected_slots() {
+        let mut only = LogicalPlan::new(
+            Operator::Dummy,
+            Childrens::Only(Box::new(leaf(Operator::ShowTable))),
+        );
+        assert!(replace_with_only_child(&mut only));
+        assert!(matches!(only.operator, Operator::ShowTable));
+        assert!(matches!(only.childrens.as_ref(), Childrens::None));
+        assert!(!replace_with_only_child(&mut only));
+
+        let mut parent = LogicalPlan::new(
+            Operator::Dummy,
+            Childrens::Twins {
+                left: Box::new(LogicalPlan::new(
+                    Operator::ShowView,
+                    Childrens::Only(Box::new(leaf(Operator::ShowTable))),
+                )),
+                right: Box::new(leaf(Operator::Dummy)),
+            },
+        );
+        assert!(replace_child_with_only_child(&mut parent, 0));
+        assert!(matches!(
+            child(&parent, 0).unwrap().operator,
+            Operator::ShowTable
+        ));
+        assert!(!replace_child_with_only_child(&mut parent, 1));
+        assert!(!replace_child_with_only_child(&mut parent, 2));
+
+        assert!(wrap_child_with(&mut parent, 1, Operator::ShowView));
+        let wrapped = child(&parent, 1).unwrap();
+        assert!(matches!(wrapped.operator, Operator::ShowView));
+        assert!(matches!(wrapped.childrens.as_ref(), Childrens::Only(_)));
+        assert!(matches!(
+            only_child(wrapped).unwrap().operator,
+            Operator::Dummy
+        ));
+        assert!(!wrap_child_with(&mut parent, 2, Operator::ShowView));
+    }
+}

--- a/src/optimizer/rule/implementation/ddl/truncate.rs
+++ b/src/optimizer/rule/implementation/ddl/truncate.rs
@@ -22,7 +22,7 @@ use crate::single_mapping;
 use std::sync::LazyLock;
 
 static TRUNCATE_PATTERN: LazyLock<Pattern> = LazyLock::new(|| Pattern {
-    predicate: |op| matches!(op, Operator::DropTable(_)),
+    predicate: |op| matches!(op, Operator::Truncate(_)),
     children: PatternChildrenPredicate::None,
 });
 

--- a/src/optimizer/rule/implementation/mod.rs
+++ b/src/optimizer/rule/implementation/mod.rs
@@ -256,165 +256,43 @@ impl ImplementationRule for ImplementationRuleImpl {
         loader: &StatisticMetaLoader<'_>,
         best_physical_option: &mut BestPhysicalOption,
     ) -> Result<(), DatabaseError> {
+        macro_rules! update {
+            ($implementation:expr) => {
+                $implementation.update_best_option(operator, arena, loader, best_physical_option)?
+            };
+        }
+
         match self {
-            ImplementationRuleImpl::GroupByAggregate => GroupByAggregateImplementation
-                .update_best_option(operator, arena, loader, best_physical_option)?,
-            ImplementationRuleImpl::SimpleAggregate => SimpleAggregateImplementation
-                .update_best_option(operator, arena, loader, best_physical_option)?,
-            ImplementationRuleImpl::Dummy => DummyImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::Filter => FilterImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::HashJoin => JoinImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::Limit => LimitImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::MarkApply => MarkApplyImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::Projection => ProjectionImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::ScalarApply => ScalarApplyImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::ScalarSubquery => ScalarSubqueryImplementation
-                .update_best_option(operator, arena, loader, best_physical_option)?,
-            ImplementationRuleImpl::SeqScan => SeqScanImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::IndexScan => IndexScanImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::FunctionScan => FunctionScanImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::Sort => SortImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::TopK => TopKImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::Values => ValuesImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
+            ImplementationRuleImpl::GroupByAggregate => update!(GroupByAggregateImplementation),
+            ImplementationRuleImpl::SimpleAggregate => update!(SimpleAggregateImplementation),
+            ImplementationRuleImpl::Dummy => update!(DummyImplementation),
+            ImplementationRuleImpl::Filter => update!(FilterImplementation),
+            ImplementationRuleImpl::HashJoin => update!(JoinImplementation),
+            ImplementationRuleImpl::Limit => update!(LimitImplementation),
+            ImplementationRuleImpl::MarkApply => update!(MarkApplyImplementation),
+            ImplementationRuleImpl::Projection => update!(ProjectionImplementation),
+            ImplementationRuleImpl::ScalarApply => update!(ScalarApplyImplementation),
+            ImplementationRuleImpl::ScalarSubquery => update!(ScalarSubqueryImplementation),
+            ImplementationRuleImpl::SeqScan => update!(SeqScanImplementation),
+            ImplementationRuleImpl::IndexScan => update!(IndexScanImplementation),
+            ImplementationRuleImpl::FunctionScan => update!(FunctionScanImplementation),
+            ImplementationRuleImpl::Sort => update!(SortImplementation),
+            ImplementationRuleImpl::TopK => update!(TopKImplementation),
+            ImplementationRuleImpl::Values => update!(ValuesImplementation),
             #[cfg(feature = "copy")]
-            ImplementationRuleImpl::CopyFromFile => CopyFromFileImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
+            ImplementationRuleImpl::CopyFromFile => update!(CopyFromFileImplementation),
             #[cfg(feature = "copy")]
-            ImplementationRuleImpl::CopyToFile => CopyToFileImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::Delete => DeleteImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::Insert => InsertImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::Update => UpdateImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::AddColumn => AddColumnImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::ChangeColumn => ChangeColumnImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::CreateTable => CreateTableImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::DropColumn => DropColumnImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::DropTable => DropTableImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::Truncate => TruncateImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
-            ImplementationRuleImpl::Analyze => AnalyzeImplementation.update_best_option(
-                operator,
-                arena,
-                loader,
-                best_physical_option,
-            )?,
+            ImplementationRuleImpl::CopyToFile => update!(CopyToFileImplementation),
+            ImplementationRuleImpl::Delete => update!(DeleteImplementation),
+            ImplementationRuleImpl::Insert => update!(InsertImplementation),
+            ImplementationRuleImpl::Update => update!(UpdateImplementation),
+            ImplementationRuleImpl::AddColumn => update!(AddColumnImplementation),
+            ImplementationRuleImpl::ChangeColumn => update!(ChangeColumnImplementation),
+            ImplementationRuleImpl::CreateTable => update!(CreateTableImplementation),
+            ImplementationRuleImpl::DropColumn => update!(DropColumnImplementation),
+            ImplementationRuleImpl::DropTable => update!(DropTableImplementation),
+            ImplementationRuleImpl::Truncate => update!(TruncateImplementation),
+            ImplementationRuleImpl::Analyze => update!(AnalyzeImplementation),
         }
 
         Ok(())
@@ -481,6 +359,10 @@ mod tests {
         arena: &PlanArena,
     ) -> Result<PhysicalOption, DatabaseError> {
         assert!((rule.pattern().predicate)(operator));
+        assert_eq!(
+            ImplementationRuleRootTag::from_operator(operator),
+            Some(rule.root_tag())
+        );
 
         let statistics_cache = StatisticsMetaCache::default();
         let loader = StatisticMetaLoader::new(&statistics_cache);
@@ -567,6 +449,12 @@ mod tests {
             ImplementationRuleImpl::Values,
             |op| matches!(op, Operator::Values(_)),
             PlanImpl::Values,
+        )?;
+        assert_sql_rule(
+            "select * from t1",
+            ImplementationRuleImpl::SeqScan,
+            |op| matches!(op, Operator::TableScan(_)),
+            PlanImpl::SeqScan,
         )?;
 
         Ok(())

--- a/src/optimizer/rule/implementation/mod.rs
+++ b/src/optimizer/rule/implementation/mod.rs
@@ -420,3 +420,337 @@ impl ImplementationRule for ImplementationRuleImpl {
         Ok(())
     }
 }
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use crate::binder::test::build_t1_table;
+    use crate::errors::DatabaseError;
+    use crate::expression::function::table::{
+        ArcTableFunctionImpl, TableFunction, TableFunctionCatalog, TableFunctionImpl,
+    };
+    use crate::function::numbers::Numbers;
+    use crate::optimizer::core::rule::{ImplementationRule, MatchPattern};
+    use crate::optimizer::core::statistics_meta::StatisticMetaLoader;
+    use crate::optimizer::rule::implementation::{
+        ImplementationRuleImpl, ImplementationRuleRootTag,
+    };
+    use crate::planner::operator::function_scan::FunctionScanOperator;
+    use crate::planner::operator::top_k::TopKOperator;
+    use crate::planner::operator::{Operator, PhysicalOption, PlanImpl, SortOption};
+    use crate::planner::{Childrens, LogicalPlan, PlanArena, TableArenaCell};
+    use crate::storage::StatisticsMetaCache;
+    use crate::types::value::DataValue;
+
+    fn find_operator<'a, F>(plan: &'a LogicalPlan, predicate: F) -> Option<&'a Operator>
+    where
+        F: Fn(&Operator) -> bool + Copy,
+    {
+        if predicate(&plan.operator) {
+            return Some(&plan.operator);
+        }
+
+        match plan.childrens.as_ref() {
+            Childrens::Only(child) => find_operator(child, predicate),
+            Childrens::Twins { left, right } => {
+                find_operator(left, predicate).or_else(|| find_operator(right, predicate))
+            }
+            Childrens::None => None,
+        }
+    }
+
+    fn with_operator_from_sql<F, R>(
+        sql: &str,
+        predicate: F,
+        f: impl FnOnce(Operator, &PlanArena) -> Result<R, DatabaseError>,
+    ) -> Result<R, DatabaseError>
+    where
+        F: Fn(&Operator) -> bool + Copy,
+    {
+        let tables = build_t1_table()?;
+        let mut arena = PlanArena::new(&tables.table_arena);
+        let plan = tables.plan_with_arena(sql, &mut arena)?;
+        let operator = find_operator(&plan, predicate).cloned().ok_or_else(|| {
+            DatabaseError::UnsupportedStmt(format!("operator not found for {sql}"))
+        })?;
+        f(operator, &arena)
+    }
+
+    fn best_option(
+        rule: ImplementationRuleImpl,
+        operator: &Operator,
+        arena: &PlanArena,
+    ) -> Result<PhysicalOption, DatabaseError> {
+        assert!((rule.pattern().predicate)(operator));
+
+        let statistics_cache = StatisticsMetaCache::default();
+        let loader = StatisticMetaLoader::new(&statistics_cache);
+        let mut best = None;
+        rule.update_best_option(operator, arena, &loader, &mut best)?;
+
+        Ok(best
+            .expect("implementation rule should produce an option")
+            .0)
+    }
+
+    fn assert_sql_rule(
+        sql: &str,
+        rule: ImplementationRuleImpl,
+        predicate: impl Fn(&Operator) -> bool + Copy,
+        expected_plan: PlanImpl,
+    ) -> Result<(), DatabaseError> {
+        let option = with_operator_from_sql(sql, predicate, |operator, arena| {
+            best_option(rule, &operator, arena)
+        })?;
+
+        assert_eq!(option.plan, expected_plan);
+        Ok(())
+    }
+
+    #[test]
+    fn test_single_mapping_implementations() -> Result<(), DatabaseError> {
+        assert_sql_rule(
+            "select count(c1) from t1",
+            ImplementationRuleImpl::SimpleAggregate,
+            |op| matches!(op, Operator::Aggregate(agg) if agg.groupby_exprs.is_empty()),
+            PlanImpl::SimpleAggregate,
+        )?;
+        assert_sql_rule(
+            "select c1, count(c2) from t1 group by c1",
+            ImplementationRuleImpl::GroupByAggregate,
+            |op| matches!(op, Operator::Aggregate(agg) if !agg.groupby_exprs.is_empty()),
+            PlanImpl::HashAggregate,
+        )?;
+        assert_sql_rule(
+            "select 1",
+            ImplementationRuleImpl::Dummy,
+            |op| matches!(op, Operator::Dummy),
+            PlanImpl::Dummy,
+        )?;
+        assert_sql_rule(
+            "select * from t1 where c1 = 1",
+            ImplementationRuleImpl::Filter,
+            |op| matches!(op, Operator::Filter(_)),
+            PlanImpl::Filter,
+        )?;
+        assert_sql_rule(
+            "select * from t1 limit 1",
+            ImplementationRuleImpl::Limit,
+            |op| matches!(op, Operator::Limit(_)),
+            PlanImpl::Limit,
+        )?;
+        assert_sql_rule(
+            "select * from t1 where exists(select * from t2)",
+            ImplementationRuleImpl::MarkApply,
+            |op| matches!(op, Operator::MarkApply(_)),
+            PlanImpl::MarkApply,
+        )?;
+        assert_sql_rule(
+            "select c1 from t1",
+            ImplementationRuleImpl::Projection,
+            |op| matches!(op, Operator::Project(_)),
+            PlanImpl::Project,
+        )?;
+        assert_sql_rule(
+            "select (select c3 from t2 limit 1) from t1",
+            ImplementationRuleImpl::ScalarApply,
+            |op| matches!(op, Operator::ScalarApply(_)),
+            PlanImpl::ScalarApply,
+        )?;
+        assert_sql_rule(
+            "select (select c3 from t2 limit 1) from t1",
+            ImplementationRuleImpl::ScalarSubquery,
+            |op| matches!(op, Operator::ScalarSubquery(_)),
+            PlanImpl::ScalarSubquery,
+        )?;
+        assert_sql_rule(
+            "values (1, 2)",
+            ImplementationRuleImpl::Values,
+            |op| matches!(op, Operator::Values(_)),
+            PlanImpl::Values,
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_join_sort_topk_and_function_scan_implementations() -> Result<(), DatabaseError> {
+        assert_sql_rule(
+            "select * from t1 join t2 on c1 = c3",
+            ImplementationRuleImpl::HashJoin,
+            |op| matches!(op, Operator::Join(_)),
+            PlanImpl::HashJoin,
+        )?;
+        assert_sql_rule(
+            "select * from t1 cross join t2",
+            ImplementationRuleImpl::HashJoin,
+            |op| matches!(op, Operator::Join(_)),
+            PlanImpl::NestLoopJoin,
+        )?;
+
+        with_operator_from_sql(
+            "select * from t1 order by c1",
+            |op| matches!(op, Operator::Sort(_)),
+            |sort, arena| {
+                let sort_option = best_option(ImplementationRuleImpl::Sort, &sort, arena)?;
+                assert_eq!(sort_option.plan, PlanImpl::Sort);
+                assert!(matches!(
+                    sort_option.sort_option(),
+                    SortOption::OrderBy {
+                        fields,
+                        ignore_prefix_len: 0,
+                    } if fields.len() == 1
+                ));
+
+                let Operator::Sort(sort_op) = sort else {
+                    unreachable!("sort operator expected")
+                };
+                let topk = Operator::TopK(TopKOperator {
+                    sort_fields: sort_op.sort_fields,
+                    limit: 5,
+                    offset: Some(2),
+                });
+                let topk_option = best_option(ImplementationRuleImpl::TopK, &topk, arena)?;
+                assert_eq!(topk_option.plan, PlanImpl::TopK);
+                assert!(matches!(
+                    topk_option.sort_option(),
+                    SortOption::OrderBy {
+                        fields,
+                        ignore_prefix_len: 0,
+                    } if fields.len() == 1
+                ));
+
+                let function_operator = function_scan_operator();
+                let function_option = best_option(
+                    ImplementationRuleImpl::FunctionScan,
+                    &function_operator,
+                    arena,
+                )?;
+                assert_eq!(function_option.plan, PlanImpl::FunctionScan);
+
+                Ok(())
+            },
+        )?;
+
+        Ok(())
+    }
+
+    fn function_scan_operator() -> Operator {
+        let table_arena = TableArenaCell::default();
+        let numbers = Numbers::new();
+        let mut schema = Vec::new();
+        numbers.output_schema_into(table_arena.borrow_mut(), &mut schema);
+        let table_function = TableFunction {
+            args: vec![DataValue::Int32(3).into()],
+            catalog: TableFunctionCatalog {
+                schema,
+                inner: ArcTableFunctionImpl(numbers),
+            },
+        };
+
+        Operator::FunctionScan(FunctionScanOperator { table_function })
+    }
+
+    #[test]
+    fn test_dml_and_ddl_implementations() -> Result<(), DatabaseError> {
+        assert_sql_rule(
+            "analyze table t1",
+            ImplementationRuleImpl::Analyze,
+            |op| matches!(op, Operator::Analyze(_)),
+            PlanImpl::Analyze,
+        )?;
+        assert_sql_rule(
+            "delete from t1 where c1 = 1",
+            ImplementationRuleImpl::Delete,
+            |op| matches!(op, Operator::Delete(_)),
+            PlanImpl::Delete,
+        )?;
+        assert_sql_rule(
+            "insert into t1 values (1, 2)",
+            ImplementationRuleImpl::Insert,
+            |op| matches!(op, Operator::Insert(_)),
+            PlanImpl::Insert,
+        )?;
+        assert_sql_rule(
+            "update t1 set c2 = 3 where c1 = 1",
+            ImplementationRuleImpl::Update,
+            |op| matches!(op, Operator::Update(_)),
+            PlanImpl::Update,
+        )?;
+        #[cfg(feature = "copy")]
+        assert_sql_rule(
+            "copy t1 from 'in.csv'",
+            ImplementationRuleImpl::CopyFromFile,
+            |op| matches!(op, Operator::CopyFromFile(_)),
+            PlanImpl::CopyFromFile,
+        )?;
+        #[cfg(feature = "copy")]
+        assert_sql_rule(
+            "copy t1 to 'out.csv'",
+            ImplementationRuleImpl::CopyToFile,
+            |op| matches!(op, Operator::CopyToFile(_)),
+            PlanImpl::CopyToFile,
+        )?;
+        assert_sql_rule(
+            "alter table t1 add column c5 int null",
+            ImplementationRuleImpl::AddColumn,
+            |op| matches!(op, Operator::AddColumn(_)),
+            PlanImpl::AddColumn,
+        )?;
+        assert_sql_rule(
+            "alter table t1 alter column c2 type bigint",
+            ImplementationRuleImpl::ChangeColumn,
+            |op| matches!(op, Operator::ChangeColumn(_)),
+            PlanImpl::ChangeColumn,
+        )?;
+        assert_sql_rule(
+            "alter table t1 drop column c2",
+            ImplementationRuleImpl::DropColumn,
+            |op| matches!(op, Operator::DropColumn(_)),
+            PlanImpl::DropColumn,
+        )?;
+        assert_sql_rule(
+            "create table t3 (id int primary key)",
+            ImplementationRuleImpl::CreateTable,
+            |op| matches!(op, Operator::CreateTable(_)),
+            PlanImpl::CreateTable,
+        )?;
+        assert_sql_rule(
+            "drop table t1",
+            ImplementationRuleImpl::DropTable,
+            |op| matches!(op, Operator::DropTable(_)),
+            PlanImpl::DropTable,
+        )?;
+        assert_sql_rule(
+            "truncate table t1",
+            ImplementationRuleImpl::Truncate,
+            |op| matches!(op, Operator::Truncate(_)),
+            PlanImpl::Truncate,
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_root_tag_groups_and_unsupported_operator() {
+        assert_eq!(
+            ImplementationRuleImpl::SimpleAggregate.root_tag(),
+            ImplementationRuleRootTag::Aggregate
+        );
+        assert_eq!(
+            ImplementationRuleImpl::GroupByAggregate.root_tag(),
+            ImplementationRuleRootTag::Aggregate
+        );
+        assert_eq!(
+            ImplementationRuleImpl::SeqScan.root_tag(),
+            ImplementationRuleRootTag::TableScan
+        );
+        assert_eq!(
+            ImplementationRuleImpl::IndexScan.root_tag(),
+            ImplementationRuleRootTag::TableScan
+        );
+        assert_eq!(
+            ImplementationRuleRootTag::from_operator(&Operator::ShowTable),
+            None
+        );
+    }
+}

--- a/src/serdes/char.rs
+++ b/src/serdes/char.rs
@@ -25,6 +25,12 @@ impl ReferenceSerialization for char {
         _: &mut ReferenceTables,
         _: &A,
     ) -> Result<(), DatabaseError> {
+        if self.len_utf8() > 2 {
+            return Err(DatabaseError::InvalidValue(format!(
+                "char `{self}` cannot be serialized in two bytes"
+            )));
+        }
+
         let mut buf = [0u8; 2];
         self.encode_utf8(&mut buf);
 
@@ -40,7 +46,6 @@ impl ReferenceSerialization for char {
         let mut buf = [0u8; 2];
         reader.read_exact(&mut buf)?;
 
-        // SAFETY
         Ok(std::str::from_utf8(&buf)?.chars().next().unwrap())
     }
 }

--- a/src/serdes/mod.rs
+++ b/src/serdes/mod.rs
@@ -177,21 +177,75 @@ impl ReferenceTables {
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    use crate::serdes::ReferenceTables;
+    use crate::errors::DatabaseError;
+    use crate::serdes::{ReferenceSerialization, ReferenceTables};
+    use crate::storage::rocksdb::RocksTransaction;
+    use std::collections::BTreeMap;
+    use std::fmt::Debug;
     use std::io;
-    use std::io::{Seek, SeekFrom};
+    use std::io::{Cursor, Seek, SeekFrom};
+    use std::marker::PhantomData;
+    use std::path::PathBuf;
+
+    fn round_trip<S>(source: S) -> Result<S, DatabaseError>
+    where
+        S: ReferenceSerialization + PartialEq + Debug,
+    {
+        let mut reference_tables = ReferenceTables::new();
+        let mut arena = crate::planner::TableArena::default();
+        let mut cursor = Cursor::new(Vec::new());
+
+        source.encode(&mut cursor, false, &mut reference_tables, &arena)?;
+        cursor.seek(SeekFrom::Start(0))?;
+
+        S::decode::<RocksTransaction, _, _>(&mut cursor, None, &reference_tables, &mut arena)
+    }
 
     #[test]
     fn test_to_raw() -> io::Result<()> {
         let mut reference_tables = ReferenceTables::new();
+        assert!(reference_tables.is_empty());
         reference_tables.push_or_replace(&"t1".to_string().into());
         reference_tables.push_or_replace(&"t2".to_string().into());
+        assert_eq!(
+            reference_tables.push_or_replace(&"t1".to_string().into()),
+            0
+        );
+        assert_eq!(reference_tables.len(), 2);
+        assert_eq!(reference_tables.get(1).as_ref(), "t2");
 
         let mut cursor = io::Cursor::new(Vec::new());
         reference_tables.to_raw(&mut cursor)?;
 
         cursor.seek(SeekFrom::Start(0))?;
         assert_eq!(reference_tables, ReferenceTables::from_raw(&mut cursor)?);
+
+        reference_tables.clear();
+        assert!(reference_tables.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_round_trip_basic_containers() -> Result<(), DatabaseError> {
+        assert_eq!(round_trip([3u32, 5u32])?, [3u32, 5u32]);
+        assert_eq!(round_trip(PhantomData::<String>)?, PhantomData::<String>);
+        let path = PathBuf::from("kitesql-serde-path.csv");
+        assert_eq!(round_trip(path.clone())?, path);
+
+        let mut source = BTreeMap::new();
+        source.insert("alpha".to_string(), 11i32);
+        source.insert("beta".to_string(), 29i32);
+        assert_eq!(round_trip(source.clone())?, source);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_round_trip_char_uses_existing_two_byte_encoding() -> Result<(), DatabaseError> {
+        assert_eq!(round_trip('a')?, 'a');
+        assert_eq!(round_trip('é')?, 'é');
+        assert!(round_trip('𐍈').is_err());
 
         Ok(())
     }

--- a/tests/slt/having.slt
+++ b/tests/slt/having.slt
@@ -38,3 +38,25 @@ query II
 select y as b, count(*) as total from test where x > 0 group by b having count(*) > 1 order by b
 ----
 2 2
+
+query I rowsort
+select x from test group by x having substring(cast(x as varchar(10)) from 1 for 1) = '1'
+----
+1
+11
+
+query I
+select x from test group by x having coalesce(x, 0) = 1
+----
+1
+
+query I
+select x from test group by x having case when x = 1 then x else x end = 1
+----
+1
+
+query I rowsort
+select x from test group by x having x between 1 and 10
+----
+1
+2


### PR DESCRIPTION
## Summary
- add focused serde, optimizer implementation, binder parser/aggregate, and plan utility coverage
- move complex HAVING behavior checks into sqllogictest and refactor HAVING validation onto the expression visitor
- fix truncate implementation matching and make char serde reject unsupported multi-byte chars without panicking
- include the copy feature in coverage runs so copy implementation rules are measured

## Testing
- cargo fmt --all -- --check
- cargo test --lib --features decimal,orm binder::aggregate::tests
- cargo run -p sqllogictest-test -- --path 'tests/slt/having.slt'
- cargo test --lib --features decimal,orm
- make codecov